### PR TITLE
Fix missing link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This project consists of documentation, example files, and a Python-based test harness that you can use to build and customize a Tableau Connector that uses an ODBC or JDBC driver.
 
-* [Why Connectors?]()
+* [Why Connectors?](#why-connectors)
 * [Get started](#get-started)
 * [Samples](#samples)
 * [Prerequisites](#prerequisites)


### PR DESCRIPTION
The `Why Connectors` link in our README's table of contents doesn't have a target and 404s when clicked.