### PR TITLE
TFS-852745 TDVT: Better error messages when running from unexpected directories

### DIFF
--- a/tdvt/tdvt/config_gen/datasource_list.py
+++ b/tdvt/tdvt/config_gen/datasource_list.py
@@ -14,25 +14,25 @@ from .test_config import TestConfig,TestSet,build_config_name,build_tds_name
 
 
 def print_ds(ds, ds_reg):
-    print ("\n\t" + ds)
+    print("\n\t" + ds)
     test_config = ds_reg.get_datasource_info(ds)
     if not test_config:
         return
-    print ("\tLogical tests:")
+    print("\tLogical tests:")
     for x in test_config.get_logical_tests():
-        print ("\t"*2 + str(x))
+        print("\t"*2 + str(x))
         root_directory = get_root_dir()
         tests = x.generate_test_file_list_from_config()
         for test in tests:
-            print ("\t"*3 + test.test_path)
+            print("\t"*3 + test.test_path)
 
-    print ("\tExpression tests:")
+    print("\tExpression tests:")
     for x in test_config.get_expression_tests():
-        print ("\t"*2 + str(x))
+        print("\t"*2 + str(x))
         root_directory = get_root_dir()
         tests = x.generate_test_file_list_from_config()
         for test in tests:
-            print ("\t"*3 + test.test_path)
+            print("\t"*3 + test.test_path)
 
 
 def print_configurations(ds_reg, dsname, verbose):
@@ -43,21 +43,21 @@ def print_configurations(ds_reg, dsname, verbose):
         elif len(ds_to_run) == 0:
             pass
         else:
-            print ("\nDatasource suite " + dsname + " is "  + ",".join(ds_to_run)) 
+            print("\nDatasource suite " + dsname + " is "  + ",".join(ds_to_run))
             if verbose:
                 for ds in ds_to_run:
                     print_ds(ds, ds_reg)
                     
     else:
-        print ("\nAvailable datasources:")
+        print("\nAvailable datasources:")
         ds_all = ds_reg.get_datasources('all')
         for ds in sorted(ds_all):
-            print (ds)
-        print ("\nAvailable suites:")
+            print(ds)
+        print("\nAvailable suites:")
         for suite in ds_reg.suite_map:
-            print (suite)
-            print ("\t" + ','.join(ds_reg.suite_map[suite]))
-            print ('\n')
+            print(suite)
+            print("\t" + ','.join(ds_reg.suite_map[suite]))
+            print('\n')
 
 
 def print_logical_configurations(ds_registry, config_name=None):
@@ -65,9 +65,9 @@ def print_logical_configurations(ds_registry, config_name=None):
         for config in list_config(ds_registry, config_name):
             print(config)
     else:
-        print ("Available logical query configurations: \n")
+        print("Available logical query configurations: \n")
         for config in list_configs(ds_registry):
-            print (config)
+            print(config)
 
 
 def LoadTest(config, test_dir=get_root_dir()):

--- a/tdvt/tdvt/config_gen/datasource_list.py
+++ b/tdvt/tdvt/config_gen/datasource_list.py
@@ -12,6 +12,7 @@ from .gentests import list_configs, list_config
 from ..resources import *
 from .test_config import TestConfig,TestSet,build_config_name,build_tds_name
 
+
 def print_ds(ds, ds_reg):
     print ("\n\t" + ds)
     test_config = ds_reg.get_datasource_info(ds)
@@ -32,6 +33,7 @@ def print_ds(ds, ds_reg):
         tests = x.generate_test_file_list_from_config()
         for test in tests:
             print ("\t"*3 + test.test_path)
+
 
 def print_configurations(ds_reg, dsname, verbose):
     if dsname:
@@ -57,6 +59,7 @@ def print_configurations(ds_reg, dsname, verbose):
             print ("\t" + ','.join(ds_reg.suite_map[suite]))
             print ('\n')
 
+
 def print_logical_configurations(ds_registry, config_name=None):
     if config_name:
         for config in list_config(ds_registry, config_name):
@@ -65,6 +68,7 @@ def print_logical_configurations(ds_registry, config_name=None):
         print ("Available logical query configurations: \n")
         for config in list_configs(ds_registry):
             print (config)
+
 
 def LoadTest(config, test_dir=get_root_dir()):
     """ Parse a datasource test suite config into a TestConfig object.
@@ -248,7 +252,8 @@ def LoadTest(config, test_dir=get_root_dir()):
 
     logging.debug(test_config)
     return test_config
-        
+
+
 class TestRegistry(object):
     """Add a new datasource here and then add it to the appropriate registries below."""
     def __init__(self, ini_file):
@@ -319,6 +324,7 @@ class TestRegistry(object):
         seen_ds = set()
         return [x for x in ds_to_run if not (x in seen_ds or seen_ds.add(x))]
 
+
 class WindowsRegistry(TestRegistry):
     """Windows specific test suites."""
     def __init__(self):
@@ -329,6 +335,7 @@ class MacRegistry(TestRegistry):
     """Mac specific test suites."""
     def __init__(self):
         super(MacRegistry, self).__init__('mac')
+
 
 class LinuxRegistry(TestRegistry):
     """Linux specific test suites."""

--- a/tdvt/tdvt/config_gen/datasource_list.py
+++ b/tdvt/tdvt/config_gen/datasource_list.py
@@ -13,7 +13,7 @@ from ..resources import *
 from .test_config import TestConfig,TestSet,build_config_name,build_tds_name
 
 
-RUN_IN_INCORRECT_DIRECTORY_MSG = "No data sources found in this directory. To run tests, the base directory must contain a valid test configuration."
+RUN_IN_INCORRECT_DIRECTORY_MSG = "\nNo data sources found in this directory. To run tests, the base directory must contain a valid test configuration."
 
 def print_ds(ds, ds_reg):
     print("\n\t" + ds)

--- a/tdvt/tdvt/config_gen/datasource_list.py
+++ b/tdvt/tdvt/config_gen/datasource_list.py
@@ -61,7 +61,7 @@ def print_configurations(ds_reg, dsname, verbose):
         print("\nAvailable suites:")
         for suite in ds_reg.suite_map:
             print(suite)
-            print("\t" + ','.join(ds_reg.suite_map[suite]))
+            print("\t" + ', '.join(ds_reg.suite_map[suite]))
             print('\n')
 
 

--- a/tdvt/tdvt/config_gen/datasource_list.py
+++ b/tdvt/tdvt/config_gen/datasource_list.py
@@ -49,8 +49,13 @@ def print_configurations(ds_reg, dsname, verbose):
                     print_ds(ds, ds_reg)
                     
     else:
+        try:
+            ds_all = ds_reg.get_datasources('all')
+        except TypeError:
+            print("""\nNo data sources found in this directory. 
+                     TDVT must be run from a directory that contains data sources.""")
+            return
         print("\nAvailable datasources:")
-        ds_all = ds_reg.get_datasources('all')
         for ds in sorted(ds_all):
             print(ds)
         print("\nAvailable suites:")

--- a/tdvt/tdvt/config_gen/datasource_list.py
+++ b/tdvt/tdvt/config_gen/datasource_list.py
@@ -52,8 +52,7 @@ def print_configurations(ds_reg, dsname, verbose):
         try:
             ds_all = ds_reg.get_datasources('all')
         except TypeError:
-            print("""\nNo data sources found in this directory. 
-                     TDVT must be run from a directory that contains data sources.""")
+            print("\nNo data sources found in this directory. TDVT must be run from a directory that contains data sources.")
             return
         print("\nAvailable datasources:")
         for ds in sorted(ds_all):

--- a/tdvt/tdvt/config_gen/datasource_list.py
+++ b/tdvt/tdvt/config_gen/datasource_list.py
@@ -13,6 +13,8 @@ from ..resources import *
 from .test_config import TestConfig,TestSet,build_config_name,build_tds_name
 
 
+RUN_IN_INCORRECT_DIRECTORY_MSG = "No data sources found in this directory. To run tests, the base directory must contain a valid test configuration."
+
 def print_ds(ds, ds_reg):
     print("\n\t" + ds)
     test_config = ds_reg.get_datasource_info(ds)
@@ -52,7 +54,7 @@ def print_configurations(ds_reg, dsname, verbose):
         try:
             ds_all = ds_reg.get_datasources('all')
         except TypeError:
-            print("\nNo data sources found in this directory. TDVT must be run from a directory that contains data sources.")
+            print(RUN_IN_INCORRECT_DIRECTORY_MSG)
             return
         print("\nAvailable datasources:")
         for ds in sorted(ds_all):

--- a/tdvt/test/tdvt_test.py
+++ b/tdvt/test/tdvt_test.py
@@ -13,13 +13,19 @@
 
 """
 
+
 import configparser
-from defusedxml.ElementTree import parse,ParseError
+import io
 import logging
 import os
 import pkg_resources
 import shutil
+import sys
 import unittest
+
+from unittest import mock
+
+from defusedxml.ElementTree import parse,ParseError
 
 from tdvt import tdvt_core
 from tdvt.tdvt import enqueue_failed_tests
@@ -29,6 +35,7 @@ from tdvt.config_gen.test_config import ExpressionTestSet, LogicalTestSet, TestF
 from tdvt.resources import get_path, make_temp_dir
 from tdvt.test_results import *
 from tdvt.tabquery import *
+
 
 class DiffTest(unittest.TestCase):
     def test_diff(self):
@@ -535,12 +542,29 @@ class ConfigTest(unittest.TestCase):
         self.assertFalse(test_config.run_as_perf, 'run_as_perf did not match: ' + str(test_config.run_as_perf))
 
 
+class PrintConfigurationsTest(unittest.TestCase):
+    def test_print_configuration_with_no_dsname_and_no_ds_all_returns_explanation(self):
+        with mock.patch('tdvt.config_gen.datasource_list.TestRegistry.get_datasources', side_effect=TypeError):
+            captured_output = io.StringIO()
+            sys.stdout = captured_output  # redirect stdout to a StringIO obj to catch the print statement.
+            datasource_list.print_configurations(datasource_list.TestRegistry('test'), None, None)
+            self.assertIn(datasource_list.RUN_IN_INCORRECT_DIRECTORY_MSG, captured_output.getvalue())
+
+    def test_print_configuration_with_no_dsname(self):
+        with mock.patch('tdvt.config_gen.datasource_list.TestRegistry.get_datasources', return_value=['postgres_odbc', 'postgres_jdbc']):
+            correct_out = "\nAvailable datasources:\npostgres_jdbc\npostgres_odbc\n\nAvailable suites:\nall\n\t\n\n\n"
+            captured_output = io.StringIO()
+            sys.stdout = captured_output
+            datasource_list.print_configurations(datasource_list.TestRegistry('test'), None, None)
+            self.assertEqual(correct_out, captured_output.getvalue())
+
 ROOT_DIRECTORY = pkg_resources.resource_filename(__name__, '') 
 TEST_DIRECTORY = pkg_resources.resource_filename(__name__, 'tool_test')
 print ("Using root dir " + str(ROOT_DIRECTORY))
 print ("Using test dir " + str(TEST_DIRECTORY))
 logging.basicConfig(filename='tdvt_test_log.txt',level=logging.DEBUG, filemode='w', format='%(asctime)s %(message)s')
 configure_tabquery_path()
+
 if __name__ == '__main__':
 
     logging.debug("Starting TDVT tests\n")


### PR DESCRIPTION
This PR gives a detailed error message if there are no data sources found in the directory where `TDVT` is run rather than throwing a `TypeError` as it does now.

![2019-02-05_13-36-33](https://user-images.githubusercontent.com/5643640/52395991-e777e000-2a64-11e9-9970-33af614d6128.png)

Additionally, I made some little edits to the file to get rid of PEP8 warnings and to make the formatting of the "available suites" list a little prettier.