### PR TITLE
[Security] Fix docs XSS vulnerability in search

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -23,7 +23,7 @@
 
     function displaySearchHeading(query) {
         var heading = document.getElementById("searchHeading");
-        heading.innerHTML = "Search results for: " + query;
+        heading.textContent = "Search results for: " + query;
     }
 
     // Get the raw search results


### PR DESCRIPTION
When displaying a user's search query on the search results page, we should use `textContent` instead of `innerHTML` to prevent XSS per [this OWASP cheatsheet](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/DOM_based_XSS_Prevention_Cheat_Sheet.md#rule-6---populate-the-dom-using-safe-javascript-functions-or-properties).

Note: This change is already in `gh-pages-dev`.