### PR TITLE
Create stub for XSD Validation

### DIFF
--- a/packaging/package.py
+++ b/packaging/package.py
@@ -1,5 +1,7 @@
 import sys
 
+from packaging import xsd_validator
+
 if sys.version_info[0] < 3:
     raise EnvironmentError("package requires Python 3 or greater.")
 
@@ -15,8 +17,10 @@ def create_package_output(path):
 
 def main():
     path_from_args = "D:/dev/tableau/connector-plugin-sdk/samples/plugins/postgres_odbc"
-    validate_package_contents(path_from_args)
+    files_to_package = ["manifest.xml", "connectionBuilder.js", "connection-dialog.tcd", "connectionResolver.tdr", "dialect.tdd"]
+
+    xsd_validator.validate_xsd(files_to_package, folder_path=path_from_args)
     create_package_output(path_from_args)
 
-
-main()
+if __name__ == "__main__":
+    main()

--- a/packaging/packaging/xsd_validator.py
+++ b/packaging/packaging/xsd_validator.py
@@ -1,0 +1,20 @@
+
+# files_list: List of files to validate
+# folder_path: path to folder that contains the files.
+# Return value: True if all xml files pass validation, false if they do not or there is an error
+def validate_xsd(files_list, folder_path = ""):
+    print("===Start XSD Validation===")
+    
+    if type(files_list) != list:
+        print("Error: validate_xsd input is not a list")
+        return False
+
+    print("No XSD Violations Found")
+    return True
+
+#For testing, will remove and add unit tests once initial version is done
+if __name__ == "__main__":
+    files_list = ["manifest.xml"]
+    validate_xsd(files_list)
+    files_list = 2
+    validate_xsd(files_list)


### PR DESCRIPTION
Initial stub. I added the XSD validator as a separate file, and used TDVT as a guide for setting that up to put that in a module we can import from.