### PR TITLE
Fix so that all modules run from same location

### DIFF
--- a/packaging/package/jar_packager.py
+++ b/packaging/package/jar_packager.py
@@ -1,8 +1,8 @@
 import os
 
-from connector_file import ConnectorFile
+from .connector_file import ConnectorFile
 from zipfile import ZipFile
-from manifest import Manifest
+from .manifest import Manifest
 from pathlib import Path
 
 

--- a/packaging/package/package.py
+++ b/packaging/package/package.py
@@ -1,9 +1,9 @@
 import sys
 from pathlib import Path
 
-from xsd_validator import validate_xsd
-from connector_file import ConnectorFile
-from jar_packager import create_jar
+from .xsd_validator import validate_xsd
+from .connector_file import ConnectorFile
+from .jar_packager import create_jar
 
 
 def create_package_output(path):
@@ -12,7 +12,7 @@ def create_package_output(path):
 
 def main():
     # TODO: Replace all hard coded below input when ready.
-    path_from_args = Path("..\..\samples\plugins\postgres_odbc")
+    path_from_args = Path("..\samples\plugins\postgres_odbc")
     files_to_package = [
         ConnectorFile("manifest.xml", "manifest"),
         ConnectorFile("connection-dialog.tcd", "connection-dialog"),


### PR DESCRIPTION
According to the readme, we should be running this from connector-plugin-sdk/packaging, but package.py and jar_packager.py would not find the imports if run from there.