### PR TITLE
Add logging instead of print statements

### DIFF
--- a/packaging/package/jar_packager.py
+++ b/packaging/package/jar_packager.py
@@ -1,10 +1,13 @@
 import os
+import logging
 
 from pathlib import Path
 from zipfile import ZipFile
 
 from .connector_file import ConnectorFile
 from .manifest import Manifest
+
+logger = logging.getLogger(__name__)
 
 
 def create_jar(source_dir, files, jar_filename, dest_dir="..\jar"):
@@ -27,7 +30,7 @@ def create_jar(source_dir, files, jar_filename, dest_dir="..\jar"):
     """
 
     abs_source_path = os.path.abspath(source_dir)
-    print("Start packaging", jar_filename, "from", abs_source_path)
+    logging.debug("Start packaging " + jar_filename + " from " + str(abs_source_path))
 
     # if dest dir doesn't exist, then create it
     if not os.path.exists(dest_dir):
@@ -39,7 +42,7 @@ def create_jar(source_dir, files, jar_filename, dest_dir="..\jar"):
         for file in files:
             jar.write(os.path.join(abs_source_path, file.file_name), file.file_name)
 
-    print(jar_filename, "was created in", os.path.abspath(dest_dir))
+    logging.warning(jar_filename + " was created in " + str(os.path.abspath(dest_dir)))
 
 
 if __name__ == "__main__":

--- a/packaging/package/jar_packager.py
+++ b/packaging/package/jar_packager.py
@@ -42,7 +42,7 @@ def create_jar(source_dir, files, jar_filename, dest_dir="jar/"):
         for file in files:
             jar.write(os.path.join(abs_source_path, file.file_name), file.file_name)
 
-    logging.warning(jar_filename + " was created in " + str(os.path.abspath(dest_dir)))
+    logging.info(jar_filename + " was created in " + str(os.path.abspath(dest_dir)))
 
 
 if __name__ == "__main__":

--- a/packaging/package/package.py
+++ b/packaging/package/package.py
@@ -26,7 +26,7 @@ def main():
         #Log to console also.
         ch.setLevel(logging.DEBUG)
     else:
-        ch.setLevel(logging.WARNING)
+        ch.setLevel(logging.INFO)
     logger.addHandler(ch)
 
     logger.debug("Starting Tableau Connector Packaging Version " + __version__)
@@ -46,7 +46,7 @@ def main():
         jar_name = "postgres_odbc.jar"
         create_jar(path_from_args, files_to_package, jar_name, jar_dest_path)
     else:
-        logger.warning("XML Validation failed, connector not packaged. Check " + LOG_FILE + " for more information.")
+        logger.info("XML Validation failed, connector not packaged. Check " + LOG_FILE + " for more information.")
 
 
 if __name__ == '__main__':

--- a/packaging/package/package.py
+++ b/packaging/package/package.py
@@ -33,8 +33,7 @@ def main():
 
 
     # TODO: Replace all hard coded below input when ready.
-    #path_from_args = Path("..\samples\plugins\postgres_odbc")
-    path_from_args = Path("C:/Users/pvanderknyff/Documents/connector-plugins/postgres_odbc")
+    path_from_args = Path("..\samples\plugins\postgres_odbc")
     files_to_package = [
         ConnectorFile("manifest.xml", "manifest"),
         ConnectorFile("connection-dialog.tcd", "connection-dialog"),

--- a/packaging/package/package.py
+++ b/packaging/package/package.py
@@ -1,18 +1,40 @@
 import sys
+import logging
 from pathlib import Path
 
 from .xsd_validator import validate_xsd
 from .connector_file import ConnectorFile
 from .jar_packager import create_jar
+from .version import __version__
 
+
+LOG_FILE = 'packaging_log.txt'
 
 def create_package_output(path):
     print("create jar package from: " + str(path))
 
 
 def main():
+    # TODO: Handle logger creation in init() function that also handles args like TDVT does
+    verbose = False #TODO: Get from args
+
+    #Create logger.
+    logging.basicConfig(filename=LOG_FILE,level=logging.DEBUG, filemode='w', format='%(asctime)s %(message)s')
+    logger = logging.getLogger()
+    ch = logging.StreamHandler()
+    if verbose:
+        #Log to console also.
+        ch.setLevel(logging.DEBUG)
+    else:
+        ch.setLevel(logging.WARNING)
+    logger.addHandler(ch)
+
+    logger.debug("Starting Tableau Connector Packaging Version " + __version__)
+
+
     # TODO: Replace all hard coded below input when ready.
-    path_from_args = Path("..\samples\plugins\postgres_odbc")
+    #path_from_args = Path("..\samples\plugins\postgres_odbc")
+    path_from_args = Path("C:/Users/pvanderknyff/Documents/connector-plugins/postgres_odbc")
     files_to_package = [
         ConnectorFile("manifest.xml", "manifest"),
         ConnectorFile("connection-dialog.tcd", "connection-dialog"),
@@ -20,11 +42,13 @@ def main():
         ConnectorFile("dialect.tdd", "dialect"),
         ConnectorFile("connectionResolver.tdr", "connection-resolver")]
 
-    validate_xsd(files_to_package, path_from_args)
+    if validate_xsd(files_to_package, path_from_args):
+        jar_dest_path = Path("../jar")
+        jar_name = "postgres_odbc.jar"
+        create_jar(path_from_args, files_to_package, jar_name, jar_dest_path)
 
-    jar_dest_path = Path("../jar")
-    jar_name = "postgres_odbc.jar"
-    create_jar(path_from_args, files_to_package, jar_name, jar_dest_path)
+    else:
+        logger.warning("XML Validation failed, connector not packaged. Check " + LOG_FILE + " for more information.")
 
 
 if __name__ == '__main__':

--- a/packaging/package/xsd_validator.py
+++ b/packaging/package/xsd_validator.py
@@ -1,10 +1,12 @@
 import sys
+import logging
 from pathlib import Path
 from xmlschema import XMLSchema
 from xmlschema.validators.exceptions import XMLSchemaValidationError
 
 from .connector_file import ConnectorFile
 
+logger = logging.getLogger(__name__)
 
 MAX_FILE_SIZE = 1024 * 256  # This is based on the max file size we will load on the Tableau side
 PATH_TO_XSD_FILES = Path("../validation").absolute()
@@ -32,19 +34,19 @@ def validate_xsd(files_list, folder_path):
     Assumes the file_list and folder_path are correct, and do not point to files that don't exist or directories
     """
 
-    print("Starting XSD validation...")
+    logger.debug("Starting XSD validation...")
 
     if type(files_list) != list:
-        print("Error: validate_xsd: input is not a list")
+        logger.debug("Error: validate_xsd: input is not a list")
         return False
 
     if len(files_list) < 1:
-        print("Error: validate_xsd: input list is empty")
+        logger.debug("Error: validate_xsd: input list is empty")
         return False
 
     xml_violations_found = 0
     xml_violations_buffer = ["XML violations found.\n\n"]
-    # If xml violations are found, we save them here and print at end of method
+    # If xml violations are found, we save them here and logger.debug at end of method
 
     for file_to_test in files_list:
         path_to_file = folder_path / file_to_test.file_name
@@ -54,19 +56,19 @@ def validate_xsd(files_list, folder_path):
             continue
 
         if validate_single_file(file_to_test, path_to_file, xml_violations_buffer):
-            print("XML validation successful")
+            logger.debug("XML validation successful")
         else:
             xml_violations_found+=1
 
     if xml_violations_found <= 0:
-        print("No XML violations found")
+        logger.debug("No XML violations found")
     else:        
         for line in xml_violations_buffer:
-            print(line)
+            logger.debug(line)
 
-        print("XML validation failed!\n" + str(xml_violations_found) + " violations found.")
+        logger.debug("XML validation failed!\n" + str(xml_violations_found) + " violations found.")
 
-    print(str(len(files_list)) + " xml files parsed.")
+    logger.debug(str(len(files_list)) + " xml files parsed.")
 
     return xml_violations_found <= 0
 
@@ -82,7 +84,7 @@ def validate_single_file(file_to_test, path_to_file, xml_violations_buffer):
         Any xml violation messages will be appended to xml_violations_buffer
     """
     
-    print("Validating " + str(path_to_file))
+    logger.debug("Validating " + str(path_to_file))
 
     xsd_file = get_xsd_file(file_to_test)
 
@@ -104,7 +106,7 @@ def validate_single_file(file_to_test, path_to_file, xml_violations_buffer):
     except XMLSchemaValidationError:
         saved_error = sys.exc_info()[1]
         xml_violations_buffer.append("File: " + file_to_test.file_name + "\n" + str(saved_error))
-        print("Validation failed.")
+        logger.debug("Validation failed.")
         return False
 
     return True
@@ -124,27 +126,3 @@ def get_xsd_file(file_to_test):
         return xsd_file + ".xsd"
     else:
         return None
-
-
-# Pass in a folder to test. Calls the file list generator and validates the xml files against the XSDs.
-if __name__ == "__main__":
-
-    if len(sys.argv) < 2:
-        print("Too few arguments. You must pass in the path to a folder containing the xml files.")
-        sys.exit()
-
-    folder_to_test = Path(sys.argv[1])
-
-    if not folder_to_test.is_dir():
-        print("Error: " + str(folder_to_test) + " does not exist or is not a directory")
-        sys.exit()
-
-    # TODO: Once the plugin files list generator is completed, remove the ugly hardcoded list
-    files_list = [
-        ConnectorFile("manifest.xml", "manifest"),
-        ConnectorFile("connection-dialog.tcd", "connection-dialog"),
-        ConnectorFile("connectionBuilder.js", "script"),
-        ConnectorFile("dialect.tdd", "dialect"),
-        ConnectorFile("connectionResolver.tdr", "connection-resolver")]
-
-    validate_xsd(files_list, folder_to_test)

--- a/packaging/package/xsd_validator.py
+++ b/packaging/package/xsd_validator.py
@@ -45,7 +45,7 @@ def validate_xsd(files_list, folder_path):
         return False
 
     xml_violations_found = 0
-    xml_violations_buffer = ["XML violations found.\n\n"]
+    xml_violations_buffer = ["XML violations found."]
     # If xml violations are found, we save them here and logger.debug at end of method
 
     for file_to_test in files_list:
@@ -66,7 +66,7 @@ def validate_xsd(files_list, folder_path):
         for line in xml_violations_buffer:
             logger.debug(line)
 
-        logger.debug("XML validation failed!\n" + str(xml_violations_found) + " violations found.")
+        logger.debug("XML validation failed. " + str(xml_violations_found) + " violations found.")
 
     logger.debug(str(len(files_list)) + " xml files parsed.")
 

--- a/packaging/tests/__init__.py
+++ b/packaging/tests/__init__.py
@@ -1,0 +1,12 @@
+import logging
+
+LOG_FILE = 'packager_tests_logs.txt'
+
+print("Printing test results to " + LOG_FILE)
+
+#Create logger.
+logging.basicConfig(filename=LOG_FILE,level=logging.DEBUG, filemode='w', format='%(asctime)s %(message)s')
+logger = logging.getLogger()
+ch = logging.StreamHandler()
+ch.setLevel(logging.ERROR)
+logger.addHandler(ch)

--- a/packaging/tests/__init__.py
+++ b/packaging/tests/__init__.py
@@ -2,7 +2,7 @@ import logging
 
 LOG_FILE = 'packager_tests_logs.txt'
 
-print("Printing test results to " + LOG_FILE)
+print("Printing test logs to " + LOG_FILE)
 
 #Create logger.
 logging.basicConfig(filename=LOG_FILE,level=logging.DEBUG, filemode='w', format='%(asctime)s %(message)s')

--- a/packaging/tests/test_xsd_validator.py
+++ b/packaging/tests/test_xsd_validator.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from package.xsd_validator import validate_xsd, validate_single_file, get_xsd_file
 from package.connector_file import ConnectorFile
 
-XSD_TEST_FOLDER = Path("tests/test_xsd_validator")
+XSD_TEST_FOLDER = Path("tests/test_resources")
 
 class TestXSDValidator(unittest.TestCase):
     


### PR DESCRIPTION
Changes most print statements to logging.debug. There are a few I made warnings. This means that, unless verbose is set to true via a command line argument, we do not print it to the console. (It's hardcoded right now since we haven't set that up yet.) We will, however, always save it all log messages to packaging_log.txt. 

Let me know if there are some messages that should be shown to the console that I have labeled as debug.