### PR TITLE
Refactor argparse usage, simplify main

### DIFF
--- a/packaging/package/package.py
+++ b/packaging/package/package.py
@@ -10,29 +10,28 @@ from .xsd_validator import validate_all_xml
 from .xml_parser import XMLParser
 
 
-LOG_FILE = 'packaging_log.txt'
 PACKAGED_EXTENSION = ".taco"
 
-def create_parser():
-    parser = argparse.ArgumentParser(description="Tableau Connector Packaging Tool", usage="Package files into a single Tableau Connector file.")
-    parser.add_argument('--verbose', '-v', dest='verbose', action='store_true', help='Verbose output.', required=False)
-    parser.add_argument('--package', dest='package', help='Packages files in the folder path provided', required=False)
-    parser.add_argument('--validate', dest='validate', help='Validates xml files in the folder path provided', required=False)
-    parser.add_argument('--dest', '-d', dest='dest', help='Destination folder for packaged connector', required=False)
-    parser.add_argument('--name', '-n', dest='name', help='Name of the packaged connector', required=False)
+
+def create_arg_parser():
+    parser = argparse.ArgumentParser(description="Tableau Connector Packaging Tool: package connector files into a singe Tableau Connector (" + PACKAGED_EXTENSION + ") file.")
+    parser.add_argument('input_dir', help='path to directory of connector files to package')
+    parser.add_argument('-v', '--verbose', dest='verbose', action='store_true', help='verbose output', required=False)
+    parser.add_argument('-l', '--log', dest='log_path', help='path of logging output', default='packaging_log.txt')
+    parser.add_argument('--validate_only', dest='validate_only', action='store_true', help='runs package validation steps only', required=False)
+    parser.add_argument('-d', '--dest', dest='dest', help='destination folder for packaged connector', default='packaged-connector')
+    parser.add_argument('-n', '--name', dest='name', help='name of the packaged connector', required=False)
 
     return parser
 
-def init():
-    parser = create_parser()
-    args = parser.parse_args()
 
-    #Create logger.
-    logging.basicConfig(filename=LOG_FILE,level=logging.DEBUG, filemode='w', format='%(asctime)s %(message)s')
+def init_logging(log_path, verbose):
+    # Create logger.
+    logging.basicConfig(filename=log_path, level=logging.DEBUG, filemode='w', format='%(asctime)s %(message)s')
     logger = logging.getLogger()
     ch = logging.StreamHandler()
-    if args.verbose:
-        #Log to console also.
+    if verbose:
+        # Log to console also.
         ch.setLevel(logging.DEBUG)
     else:
         ch.setLevel(logging.INFO)
@@ -40,52 +39,39 @@ def init():
 
     logger.debug("Starting Tableau Connector Packaging Version " + __version__)
 
-    return parser, args, logger
-
+    return logger
 
 
 def main():
-    argparser, args, logger = init()
-    
-    if args.package:
-               
-        path_from_args = Path(args.package)
+    parser = create_arg_parser()
+    args = parser.parse_args()
+    logger = init_logging(args.log_path, args.verbose)
 
-        xmlparser = XMLParser(path_from_args)
+    path_from_args = Path(args.input_dir)
 
-        files_to_package = xmlparser.generate_file_list() # validates XSD's as well
-        package_name = xmlparser.class_name
+    xmlparser = XMLParser(path_from_args)
+    files_to_package = xmlparser.generate_file_list()  # validates XSD's as well
 
-        if files_to_package:
-            
-            if args.name:
-                package_name = args.name
-
-            jar_dest_path = Path("packaged-connector/")
-            jar_name = package_name + PACKAGED_EXTENSION
-
-            if args.dest:
-                jar_dest_path = args.dest
-
-            create_jar(path_from_args, files_to_package, jar_name, jar_dest_path)
-        else:
-            logger.info("Packaging failed. Check " + LOG_FILE + " for more information.")
-
-    elif args.validate:
-        path_from_args = Path(args.validate)  
-
-        xmlparser = XMLParser(path_from_args)
-
-        files_to_package = xmlparser.generate_file_list()
-        
+    if args.validate_only:
         if files_to_package and validate_all_xml(files_to_package, path_from_args):
             logger.info("XML Validation succeeded.")
         else:
-            logger.info("XML Validation failed. Check " + LOG_FILE + " for more information.")
+            logger.info("XML Validation failed. Check " + args.log_path + " for more information.")
+        return
 
-    # if we reach here we didn't get an arg to do stuff, so print help before exiting
-    else:
-        argparser.print_help()
+    if not files_to_package:
+        logger.info("Packaging failed. Check " + args.log_path + " for more information.")
+        return
+
+    package_name = xmlparser.class_name
+    if args.name:
+        package_name = args.name
+
+    jar_dest_path = Path(args.dest)
+    jar_name = package_name + PACKAGED_EXTENSION
+
+    create_jar(path_from_args, files_to_package, jar_name, jar_dest_path)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
(.venv) PS connector-plugin-sdk\packaging> python -m package.package -h
usage: package.py [-h] [-v] [-l LOG_PATH] [--validate_only] [-d DEST]
                  [-n NAME]
                  input_dir

Tableau Connector Packaging Tool: package connector files into a singe Tableau
Connector (.taco) file.

positional arguments:
  input_dir             path to directory of connector files to package

optional arguments:
  -h, --help            show this help message and exit
  -v, --verbose         verbose output
  -l LOG_PATH, --log LOG_PATH
                        path of logging output
  --validate_only       runs package validation steps only
  -d DEST, --dest DEST  destination folder for packaged connector
  -n NAME, --name NAME  name of the packaged connector