### PR TITLE
change logger.debug to logger.error, and judge executable file exist or not

### DIFF
--- a/packaging/package/jar_jdk_packager.py
+++ b/packaging/package/jar_jdk_packager.py
@@ -2,12 +2,12 @@ import os
 import logging
 import subprocess
 import shutil
-import re
 
 from pathlib import Path
 from .connector_file import ConnectorFile
 
-JDK_ENVIRON_VARIABLE_PATTERN = "(jdk\d+\.\d+\.\d+\_\d+)(\\\\)bin"
+JAR_EXECUTABLE_NAME = "jar.exe"
+PATH_ENVIRON = "PATH"
 logger = logging.getLogger(__name__)
 
 
@@ -15,9 +15,9 @@ def check_jdk_environ_variable():
     """
     Check if jdk is set up in PATH
     """
-    path_list = os.environ['PATH'].split(';')
+    path_list = os.environ[PATH_ENVIRON].split(';')
     for path in path_list:
-        if re.search(JDK_ENVIRON_VARIABLE_PATTERN, path):
+        if os.path.isfile(Path(path)/JAR_EXECUTABLE_NAME):
             return True
 
     return False

--- a/packaging/package/jar_jdk_packager.py
+++ b/packaging/package/jar_jdk_packager.py
@@ -43,7 +43,7 @@ def jdk_create_jar(source_dir, files, jar_filename, dest_dir):
     """
 
     if not check_jdk_environ_variable():
-        logger.debug("Error: jdk_create_jar: no jdk set up in PATH environment variable, "
+        logger.error("Error: jdk_create_jar: no jdk set up in PATH environment variable, "
                      "please download JAVA JDK and add it to PATH")
         return False
 
@@ -64,6 +64,7 @@ def jdk_create_jar(source_dir, files, jar_filename, dest_dir):
 
     logging.info(jar_filename + " was created in " + str(os.path.abspath(dest_dir)))
     return True
+
 
 
 


### PR DESCRIPTION
1. change logger.debug to logger.error

2. use executable file existing or not to judge path jdk setup, instead of regular expression pattern match.