### PR TITLE
Remove -n name argument

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -24,7 +24,6 @@ To validate that the xml files are valid:
 All command line usage details:
 ```
 usage: package.py [-h] [-v] [-l LOG_PATH] [--validate_only] [-d DEST]
-                  [-n NAME]
                   input_dir
 
 Tableau Connector Packaging Tool: package connector files into a single Tableau
@@ -40,7 +39,6 @@ optional arguments:
                         path of logging output
   --validate_only       runs package validation steps only
   -d DEST, --dest DEST  destination folder for packaged connector
-  -n NAME, --name NAME  name of the packaged connector
 ```
 
 ## Development

--- a/packaging/package/package.py
+++ b/packaging/package/package.py
@@ -18,7 +18,6 @@ def create_arg_parser():
     parser.add_argument('-l', '--log', dest='log_path', help='path of logging output', default='packaging_log.txt')
     parser.add_argument('--validate_only', dest='validate_only', action='store_true', help='runs package validation steps only', required=False)
     parser.add_argument('-d', '--dest', dest='dest', help='destination folder for packaged connector', default='packaged-connector')
-    parser.add_argument('-n', '--name', dest='name', help='name of the packaged connector', required=False)
 
     return parser
 
@@ -61,14 +60,10 @@ def main():
         logger.info("Packaging failed. Check " + args.log_path + " for more information.")
         return
 
-    package_name = xmlparser.class_name
-    if args.name:
-        package_name = args.name
+    package_dest_path = Path(args.dest)
+    package_name = xmlparser.class_name + PACKAGED_EXTENSION
 
-    jar_dest_path = Path(args.dest)
-    jar_name = package_name + PACKAGED_EXTENSION
-
-    jdk_create_jar(path_from_args, files_to_package, jar_name, jar_dest_path)
+    jdk_create_jar(path_from_args, files_to_package, package_name, package_dest_path)
 
 
 if __name__ == '__main__':

--- a/packaging/tests/test_package.py
+++ b/packaging/tests/test_package.py
@@ -12,7 +12,7 @@ class TestPackage(unittest.TestCase):
 
     def test_package_main(self):
         
-        expected_package_name = "test_package"
+        expected_package_name = "postgres_odbc"
         expected_dest_directory = Path("tests/test_resources/jars")
         files_directory = Path("tests/test_resources/valid_connector")
 
@@ -23,8 +23,7 @@ class TestPackage(unittest.TestCase):
             path_to_test_file.unlink()
 
 
-        os.system("python -m package.package " + str(files_directory) + " --name " + expected_package_name \
-                + " --dest " + str(expected_dest_directory))
+        os.system("python -m package.package " + str(files_directory) + " --dest " + str(expected_dest_directory))
 
         self.assertTrue(path_to_test_file.exists(), "Packaged connector not found in expected directory")
 


### PR DESCRIPTION
Allowing tool to rename at packaging time implies functionality we do not intend to support.  1:1 classAttr:packageFile for now.