### PR TITLE
Improve TDVT log organization

### DIFF
--- a/tdvt/tdvt/tdvt.py
+++ b/tdvt/tdvt/tdvt.py
@@ -140,7 +140,8 @@ class TestRunner():
     def copy_files_and_cleanup(self):
         left_temp_dir = False
         try:
-            self.copy_files_to_zip(TestOutputFiles.output_actuals, self.temp_dir, 'actual.*', self.test_config.config_file)
+            self.copy_files_to_zip(TestOutputFiles.output_actuals, self.temp_dir, 'actual.*',
+                                   self.test_config.config_file)
             self.copy_files_to_zip(TestOutputFiles.output_tabquery_log, self.temp_dir, '*/all_logs.zip')
             self.copy_output_files()
             self.copy_test_result_file()

--- a/tdvt/tdvt/tdvt.py
+++ b/tdvt/tdvt/tdvt.py
@@ -14,6 +14,7 @@ import glob
 import json
 import logging
 import os
+import pathlib
 import queue
 import shutil
 import subprocess
@@ -99,7 +100,11 @@ class TestRunner():
         actual_files = glob.glob( glob_path )
         with ZipFile(dst, mode) as myzip:
             for actual in actual_files:
-                myzip.write( actual )
+                path = pathlib.PurePath(actual)
+                parent_folder = path.parent.name
+                file_to_be_zipped = path.name
+                inner_output = os.path.join(parent_folder, file_to_be_zipped)
+                myzip.write(actual, inner_output)
 
     def copy_output_files(self):
         TestOutputFiles.copy_output_file("test_results.csv", self.temp_dir, TestOutputFiles.output_csv, True)

--- a/tdvt/tdvt/tdvt.py
+++ b/tdvt/tdvt/tdvt.py
@@ -93,7 +93,7 @@ class TestRunner():
         self.temp_dir = make_temp_dir([self.test_config.suite_name, str(thread_id)])
         self.test_config.output_dir = self.temp_dir
 
-    def copy_files_to_zip(self, dst_file_name, src_dir, src_pattern):
+    def copy_files_to_zip(self, dst_file_name, src_dir, src_pattern, optional_dir_name=''):
         dst = os.path.join(os.getcwd(), dst_file_name)
         mode = 'w' if not os.path.isfile(dst) else 'a'
         glob_path = os.path.join(src_dir, src_pattern)
@@ -101,9 +101,12 @@ class TestRunner():
         with ZipFile(dst, mode) as myzip:
             for actual in actual_files:
                 path = pathlib.PurePath(actual)
-                parent_folder = path.parent.name
                 file_to_be_zipped = path.name
-                inner_output = os.path.join(parent_folder, file_to_be_zipped)
+                if optional_dir_name:
+                    inner_output = os.path.join(optional_dir_name, file_to_be_zipped)
+                else:
+                    parent_folder = path.parent.name
+                    inner_output = os.path.join(parent_folder, file_to_be_zipped)
                 myzip.write(actual, inner_output)
 
     def copy_output_files(self):
@@ -137,7 +140,7 @@ class TestRunner():
     def copy_files_and_cleanup(self):
         left_temp_dir = False
         try:
-            self.copy_files_to_zip(TestOutputFiles.output_actuals, self.temp_dir, 'actual.*')
+            self.copy_files_to_zip(TestOutputFiles.output_actuals, self.temp_dir, 'actual.*', self.test_config.config_file)
             self.copy_files_to_zip(TestOutputFiles.output_tabquery_log, self.temp_dir, '*/all_logs.zip')
             self.copy_output_files()
             self.copy_test_result_file()

--- a/tdvt/tdvt/tdvt_core.py
+++ b/tdvt/tdvt/tdvt_core.py
@@ -171,17 +171,6 @@ class BatchQueueWork(object):
 
         total_time_ms = (time.perf_counter() - start_time) * 1000
 
-        # Copy log files to a zip file for later optional use.
-        self.log_zip_file = os.path.join(self.test_config.log_dir, 'all_logs.zip')
-        logging.debug(self.get_thread_msg() + "Creating log zip file: {0}".format(self.log_zip_file))
-        mode = 'w' if not os.path.isfile(self.log_zip_file) else 'a'
-        with zipfile.ZipFile(self.log_zip_file, mode, zipfile.ZIP_DEFLATED) as myzip:
-            log_files = glob.glob(os.path.join(self.test_config.log_dir, 'log*.txt'))
-            log_files.extend(glob.glob(os.path.join(self.test_config.log_dir, 'tabprotosrv*.txt')))
-            log_files.extend(glob.glob(os.path.join(self.test_config.log_dir, 'crashdumps/*')))
-            for log in log_files:
-                myzip.write(log, os.path.basename(log))
-
         logging.debug(self.get_thread_msg() + "Command line output:" + str(self.cmd_output))
         return total_time_ms
 


### PR DESCRIPTION
Make changes to the log zip file organization so it will be as follows:

`tabquery_logs.zip/test_type_suite_name/<'log*.txt'/'tabprotosrv*.txt'/'crashdumps/*'>`
`tdvt_actuals_combined.zip/test_type_suite_name/*actuals`

(click to enlarge)
![8FAFBB2A-F9E1-44BD-AF09-262BF6509D21](https://user-images.githubusercontent.com/5643640/61257202-db373380-a724-11e9-9836-518c2bbbe7ff.GIF)
