### PR TITLE
Add signing functionality

### DIFF
--- a/packaging/package/helper.py
+++ b/packaging/package/helper.py
@@ -1,0 +1,34 @@
+import os
+import logging
+from pathlib import Path
+from .version import __version__
+
+PATH_ENVIRON = "PATH"
+
+
+def check_jdk_environ_variable(exe_name):
+    """
+    Check if executable needed in jdk is available
+    """
+    path_list = os.environ[PATH_ENVIRON].split(';')
+    for path in path_list:
+        if os.path.isfile(Path(path)/exe_name):
+            return True
+    return False
+
+
+def init_logging(log_path, verbose):
+    # Create logger.
+    logging.basicConfig(filename=log_path, level=logging.DEBUG, filemode='w', format='%(asctime)s | %(message)s')
+    logger = logging.getLogger()
+    ch = logging.StreamHandler()
+    if verbose:
+        # Log to console also.
+        ch.setLevel(logging.DEBUG)
+    else:
+        ch.setLevel(logging.INFO)
+    logger.addHandler(ch)
+
+    logger.debug("Starting Tableau Connector Packaging Version " + __version__)
+
+    return logger

--- a/packaging/package/helper.py
+++ b/packaging/package/helper.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from .version import __version__
 
 PATH_ENVIRON = "PATH"
-
+logger = logging.getLogger(__name__)
 
 def check_jdk_environ_variable(exe_name):
     """
@@ -14,6 +14,9 @@ def check_jdk_environ_variable(exe_name):
     for path in path_list:
         if os.path.isfile(Path(path)/exe_name):
             return True
+
+    logger.error("Java Error: jdk_create_jar: no jdk set up in PATH environment variable, "
+                     "please download JAVA JDK and add it to PATH")
     return False
 
 

--- a/packaging/package/jar_jdk_packager.py
+++ b/packaging/package/jar_jdk_packager.py
@@ -8,7 +8,6 @@ from .connector_file import ConnectorFile
 from .helper import check_jdk_environ_variable
 
 JAR_EXECUTABLE_NAME = "jar.exe"
-PATH_ENVIRON = "PATH"
 logger = logging.getLogger(__name__)
 
 
@@ -32,8 +31,6 @@ def jdk_create_jar(source_dir, files, jar_filename, dest_dir):
     """
 
     if not check_jdk_environ_variable(JAR_EXECUTABLE_NAME):
-        logger.error("Error: jdk_create_jar: no jdk set up in PATH environment variable, "
-                     "please download JAVA JDK and add it to PATH")
         return False
 
     abs_source_path = os.path.abspath(source_dir)

--- a/packaging/package/jar_jdk_packager.py
+++ b/packaging/package/jar_jdk_packager.py
@@ -5,22 +5,11 @@ import shutil
 
 from pathlib import Path
 from .connector_file import ConnectorFile
+from .helper import check_jdk_environ_variable
 
 JAR_EXECUTABLE_NAME = "jar.exe"
 PATH_ENVIRON = "PATH"
 logger = logging.getLogger(__name__)
-
-
-def check_jdk_environ_variable():
-    """
-    Check if jdk is set up in PATH
-    """
-    path_list = os.environ[PATH_ENVIRON].split(';')
-    for path in path_list:
-        if os.path.isfile(Path(path)/JAR_EXECUTABLE_NAME):
-            return True
-
-    return False
 
 
 def jdk_create_jar(source_dir, files, jar_filename, dest_dir):
@@ -42,7 +31,7 @@ def jdk_create_jar(source_dir, files, jar_filename, dest_dir):
     :return: Boolean
     """
 
-    if not check_jdk_environ_variable():
+    if not check_jdk_environ_variable(JAR_EXECUTABLE_NAME):
         logger.error("Error: jdk_create_jar: no jdk set up in PATH environment variable, "
                      "please download JAVA JDK and add it to PATH")
         return False

--- a/packaging/package/jar_jdk_signer.py
+++ b/packaging/package/jar_jdk_signer.py
@@ -1,0 +1,64 @@
+import os
+import logging
+import subprocess
+from pathlib import Path
+from .helper import check_jdk_environ_variable
+
+JARSIGNER_EXECUTABLE_NAME = "jarsigner.exe"
+logger = logging.getLogger(__name__)
+
+
+def validate_signing_input(input_dir, taco_name, alias, keystore):
+    """
+    Validate signing input
+    """
+
+    if not alias:
+        logger.error("Signing Error: Private key's alias is missing or empty")
+        return False
+
+    if not keystore or not os.path.isfile(Path(keystore)):
+        logger.error("Signing Error: Keystore path is missing or invalid")
+        return False
+
+    if not os.path.isfile(input_dir/taco_name):
+        logger.error("Signing Error: Taco file to be signed has been deleted or doesn't exist")
+        return False
+
+    return True
+
+
+def jdk_sign_jar(input_dir, taco_name, alias, keystore):
+    """
+    Sign a taco using JAVA JDK
+
+    :param input_dir: source dir of taco file to be signed
+    :type input_dir: str
+
+    :param taco_name: taco file name
+    :type taco_name: str
+
+    :param alias: Private key's alias in keystore
+    :type alias: str
+
+    :param keystore: keystore path
+    :type keystore: str
+
+    :return: Boolean
+    """
+
+    if not check_jdk_environ_variable(JARSIGNER_EXECUTABLE_NAME):
+        logger.error("Error: jdk_create_jar: no jdk set up in PATH environment variable, "
+                     "please download JAVA JDK and add it to PATH")
+        return False
+
+    logging.debug("Start signing " + taco_name + " from " + str(os.path.abspath(input_dir)) + " using JDK jarsigner")
+
+    args = ["jarsigner", "-keystore", keystore, "-signedjar", str(input_dir/("signed_" + taco_name)), str(input_dir/taco_name), alias]
+    p = subprocess.Popen(args)
+    p.wait()
+
+    logging.info(taco_name + " was signed as " + "signed_" + taco_name + " at " + str(os.path.abspath(input_dir)))
+
+    return True
+

--- a/packaging/package/jar_jdk_signer.py
+++ b/packaging/package/jar_jdk_signer.py
@@ -52,13 +52,15 @@ def jdk_sign_jar(input_dir, taco_name, alias, keystore):
                      "please download JAVA JDK and add it to PATH")
         return False
 
-    logging.debug("Start signing " + taco_name + " from " + str(os.path.abspath(input_dir)) + " using JDK jarsigner")
+    logger.debug("Start signing " + taco_name + " from " + str(os.path.abspath(input_dir)) + " using JDK jarsigner")
 
     args = ["jarsigner", "-keystore", keystore, "-signedjar", str(input_dir/("signed_" + taco_name)), str(input_dir/taco_name), alias]
     p = subprocess.Popen(args)
     p.wait()
 
-    logging.info(taco_name + " was signed as " + "signed_" + taco_name + " at " + str(os.path.abspath(input_dir)))
-
-    return True
+    if p.returncode == 0:
+        logger.info(taco_name + " was signed as " + "signed_" + taco_name + " at " + str(os.path.abspath(input_dir)))
+        return True
+    else:
+        return False
 

--- a/packaging/package/jar_jdk_signer.py
+++ b/packaging/package/jar_jdk_signer.py
@@ -8,8 +8,8 @@ import getpass
 JARSIGNER_EXECUTABLE_NAME = "jarsigner.exe"
 logger = logging.getLogger(__name__)
 
-KEYSTORE_PWD_PROMPT_LENGTH = 31
-ALIAS_PWD_PROMPT_LENGTH = 33
+KEYSTORE_PWD_PROMPT_LENGTH = len("Enter Passphrase for keystore: ")
+ALIAS_PWD_PROMPT_LENGTH = len("Enter key password for : ")
 
 def validate_signing_input(input_dir, taco_name, alias, keystore):
     """
@@ -88,7 +88,7 @@ def jdk_sign_jar(input_dir, taco_name, alias, keystore):
     if alias_pwd_bytes:
         p.stdin.write(alias_pwd_bytes)
         p.stdin.flush()
-        p.stdout.read(ALIAS_PWD_PROMPT_LENGTH)
+        p.stdout.read(ALIAS_PWD_PROMPT_LENGTH + len(alias))
 
     # log jarsigner output
     while True:

--- a/packaging/package/package.py
+++ b/packaging/package/package.py
@@ -1,42 +1,27 @@
-import logging
 import argparse
 from pathlib import Path
 
+from .helper import init_logging
 from .jar_jdk_packager import jdk_create_jar
-from .version import __version__
+from .jar_jdk_signer import validate_signing_input
+from .jar_jdk_signer import jdk_sign_jar
 from .xsd_validator import validate_all_xml
 from .xml_parser import XMLParser
-
 
 PACKAGED_EXTENSION = ".taco"
 
 
 def create_arg_parser():
-    parser = argparse.ArgumentParser(description="Tableau Connector Packaging Tool: package connector files into a single Tableau Connector (" + PACKAGED_EXTENSION + ") file.")
-    parser.add_argument('input_dir', help='path to directory of connector files to package')
+    parser = argparse.ArgumentParser(description="Tableau Connector Packaging Tool: package and sign connector files into a single Tableau Connector (" + PACKAGED_EXTENSION + ") file.")
+    parser.add_argument('input_dir', help='path to directory of connector files to package and sign')
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true', help='verbose output', required=False)
     parser.add_argument('-l', '--log', dest='log_path', help='path of logging output', default='packaging_log.txt')
     parser.add_argument('--validate_only', dest='validate_only', action='store_true', help='runs package validation steps only', required=False)
     parser.add_argument('-d', '--dest', dest='dest', help='destination folder for packaged connector', default='packaged-connector')
-
+    parser.add_argument('--package-only', dest='package_only', action='store_true',  help='package a taco only, skip signing', required=False)
+    parser.add_argument('-a', '--alias', dest='alias', help='alias identifying the private key to be used to sign taco file', required=False)
+    parser.add_argument('-ks', '--keystore', dest='keystore', help='keystore location, default is the jks file in user home directory' , required=False)
     return parser
-
-
-def init_logging(log_path, verbose):
-    # Create logger.
-    logging.basicConfig(filename=log_path, level=logging.DEBUG, filemode='w', format='%(asctime)s | %(message)s')
-    logger = logging.getLogger()
-    ch = logging.StreamHandler()
-    if verbose:
-        # Log to console also.
-        ch.setLevel(logging.DEBUG)
-    else:
-        ch.setLevel(logging.INFO)
-    logger.addHandler(ch)
-
-    logger.debug("Starting Tableau Connector Packaging Version " + __version__)
-
-    return logger
 
 
 def main():
@@ -57,13 +42,30 @@ def main():
         return
 
     if not files_to_package:
-        logger.info("Packaging failed. Check " + args.log_path + " for more information.")
+        logger.info("Packaging failed due to Connector Files not valid. Check " + args.log_path + " for more information.")
         return
 
     package_dest_path = Path(args.dest)
     package_name = xmlparser.class_name + PACKAGED_EXTENSION
 
-    jdk_create_jar(path_from_args, files_to_package, package_name, package_dest_path)
+    if not jdk_create_jar(path_from_args, files_to_package, package_name, package_dest_path):
+        logger.info("Taco packaging failed. Check " + args.log_path + " for more information.")
+        return
+
+    if args.package_only:
+        logger.info("Taco packaging finished completely, signing skipped")
+        return
+
+    alias_from_args = args.alias
+    keystore_from_args = args.keystore
+
+    if not validate_signing_input(package_dest_path, package_name, alias_from_args, keystore_from_args):
+        logger.debug("Signing input validation failed. check " + args.log_path + " for more information.")
+        return
+
+    if not jdk_sign_jar(package_dest_path, package_name, alias_from_args, keystore_from_args):
+        logger.debug("Signing failed. check " + args.log_path + + " for more information.")
+        return
 
 
 if __name__ == '__main__':

--- a/packaging/package/package.py
+++ b/packaging/package/package.py
@@ -20,7 +20,7 @@ def create_arg_parser():
     parser.add_argument('-d', '--dest', dest='dest', help='destination folder for packaged connector', default='packaged-connector')
     parser.add_argument('--package-only', dest='package_only', action='store_true',  help='package a taco only, skip signing', required=False)
     parser.add_argument('-a', '--alias', dest='alias', help='alias identifying the private key to be used to sign taco file', required=False)
-    parser.add_argument('-ks', '--keystore', dest='keystore', help='keystore location, default is the jks file in user home directory' , required=False)
+    parser.add_argument('-ks', '--keystore', dest='keystore', help='keystore location, default is the jks file in user home directory', required=False)
     return parser
 
 
@@ -42,7 +42,7 @@ def main():
         return
 
     if not files_to_package:
-        logger.info("Packaging failed due to Connector Files not valid. Check " + args.log_path + " for more information.")
+        logger.info("Packaging failed. Check " + args.log_path + " for more information.")
         return
 
     package_dest_path = Path(args.dest)
@@ -64,7 +64,7 @@ def main():
         return
 
     if not jdk_sign_jar(package_dest_path, package_name, alias_from_args, keystore_from_args):
-        logger.debug("Signing failed. check " + args.log_path + + " for more information.")
+        logger.info("Signing failed. check console output and " + args.log_path + " for more information.")
         return
 
 


### PR DESCRIPTION
Changes:
1. Add jar_jdk_signer package, and call it from package.py
2. Add a helper package, move package.init_logging function and jar_jdk_packager.check_jdk_environ_variable function to helper.
3. Add a few command arguments for signing use 

Command to do packaging and signing:
py -3 -m package.package E:\Github\testdir\postgres_odbc -a jsun -ks "C:\Program Files\Java\jdk1.8.0_201\jre\lib\security\testdir\jsun.jks"
Command to do packaging only:
py -3 -m package.package E:\Github\testdir\postgres_odbc --package-only