### PR TITLE
Fix test counts

### DIFF
--- a/tdvt/tdvt/tdvt_core.py
+++ b/tdvt/tdvt/tdvt_core.py
@@ -228,14 +228,12 @@ def do_work(work):
             continue
 
         result = compare_results(t.test_name, base_test_filepath, t.test_file, work)
-        result.test_set = work.test_set
         result.relative_test_file = t.relative_test_file
         result.run_time_ms = total_time_ms
-        result.test_config = work.test_config
         result.cmd_output = work.cmd_output
 
         if result == None:
-            result = TestResult(test_file=t.test_file, relative_test_file=t.relative_test_file)
+            result = TestResult(test_file=t.test_file, relative_test_file=t.relative_test_file, test_set=work.test_set)
             result.error_case = TestErrorStartup()
 
         sys.stdout.write('.' if result.all_passed() else 'F')
@@ -283,6 +281,9 @@ def diff_sql_node(actual_sql, expected_sql, diff_string):
 
 
 def diff_table_node(actual_table, expected_table, diff_string, test_name):
+    if actual_table == None or expected_table == None:
+        return (-1, diff_string)
+
     actual_tuples = actual_table.findall('tuple')
     expected_tuples = expected_table.findall('tuple')
 
@@ -384,7 +385,7 @@ def compare_results(test_name, test_file, full_test_file, work):
     actual_file, actual_diff_file, setup, expected_files, next_path = get_test_file_paths(test_file_root,
                                                                                           base_test_file,
                                                                                           test_config.output_dir)
-    result = TestResult(test_name, test_config, full_test_file)
+    result = TestResult(test_name, test_config, full_test_file, '', work.test_set)
     # There should be an actual file at this point. eg actual.setup.math.txt.
     if not os.path.isfile(actual_file):
         logging.debug(work.get_thread_msg() + "Did not find actual file: " + actual_file)
@@ -393,7 +394,7 @@ def compare_results(test_name, test_file, full_test_file, work):
     try:
         actual_xml = parse(actual_file).getroot()
         result.add_test_results(actual_xml, actual_file)
-    except ElementTree.ParseError as e:
+    except ParseError as e:
         logging.debug(work.get_thread_msg() + "Exception parsing actual file: " + actual_file + " exception: " + str(e))
         return result
 

--- a/tdvt/tdvt/tdvt_core.py
+++ b/tdvt/tdvt/tdvt_core.py
@@ -83,33 +83,28 @@ class BatchQueueWork(object):
 
     def handle_timeout_test_failure(self, test_result_file, output_exists):
         result = TestResult(test_result_file.test_name, self.test_config, test_result_file.test_file,
-                            test_result_file.relative_test_file, self.test_set)
-        result.error_status = TestErrorTimeout()
+                            test_result_file.relative_test_file, self.test_set, TestErrorTimeout())
         self.add_test_result_error(test_result_file.test_file, result, output_exists)
         self.timeout = True
 
     def handle_aborted_test_failure(self, test_result_file, output_exists):
         result = TestResult(test_result_file.test_name, self.test_config, test_result_file.test_file,
-                            test_result_file.relative_test_file, self.test_set)
-        result.error_status = TestErrorAbort()
+                            test_result_file.relative_test_file, self.test_set, TestErrorAbort())
         self.add_test_result_error(test_result_file.test_file, result, output_exists)
 
     def handle_other_test_failure(self, test_result_file, output_exists, test_count):
         result = TestResult(test_result_file.test_name, self.test_config, test_result_file.test_file,
-                            test_result_file.relative_test_file, self.test_set)
-        result.error_status = TestErrorOther()
+                            test_result_file.relative_test_file, self.test_set, TestErrorOther())
         self.add_test_result_error(test_result_file.test_file, result, output_exists, test_count == 0)
 
     def handle_expected_test_failure(self, test_result_file, output_exists):
         result = TestResult(test_result_file.test_name, self.test_config, test_result_file.test_file,
-                            test_result_file.relative_test_file, self.test_set)
-        result.error_status = TestErrorExpected()
+                            test_result_file.relative_test_file, self.test_set, TestErrorExpected())
         self.add_test_result_error(test_result_file.test_file, result, output_exists)
 
     def handle_missing_test_failure(self, test_result_file):
         result = TestResult(test_result_file.test_name, self.test_config, test_result_file.test_file,
-                            test_result_file.relative_test_file, self.test_set)
-        result.error_status = TestErrorMissingActual()
+                            test_result_file.relative_test_file, self.test_set, TestErrorMissingActual())
         self.add_test_result_error(test_result_file.test_file, result, False)
 
     def is_timeout(self):

--- a/tdvt/tdvt/test_results.py
+++ b/tdvt/tdvt/test_results.py
@@ -35,7 +35,7 @@ class TestCaseResult(object):
 
     def get_tuples(self):
         tuple_list = []
-        tuples = self.table.findall('tuple')
+        tuples = self.table.findall('tuple') if self.table else None
         for t in tuples:
             for v in t.findall('value'):
                 tuple_list.append(v.text)
@@ -78,7 +78,7 @@ class TestCaseResult(object):
     def table_to_json(self):
         json_str = 'tuple'
         tuple_list = []
-        tuples = self.table.findall('tuple')
+        tuples = self.table.findall('tuple') if self.table else None
         for t in tuples:
             for v in t.findall('value'):
                 tuple_list.append(v.text)
@@ -190,8 +190,28 @@ class TestResult(object):
             node = test_child.find('sql')
             sq = node.text if node is not None else ''
 
-            test_result = TestCaseResult(test_child.get('name'), str(i), sq, query_time, error_msg, error_type, test_child.find('table'), self.test_config)
+            test_child_name = test_child.get('name')
+            if not test_child_name:
+                continue
+            test_result = TestCaseResult(test_child_name, str(i), sq, query_time, error_msg, error_type, test_child.find('table'), self.test_config)
             self.test_case_map.append(test_result)
+        #If it is an expression test with no results, it probably means the test failed and the individual test cases weren't run. Count them here.
+        #Expression tests that didn't run would have some number of test cases that aren't accounted for. Parse the setup file to get the count.
+        if not self.test_case_map:
+            if self.test_set.is_logical:
+                test_result = TestCaseResult("Not run", 0, "", 0, "Not run", "", None, self.test_config)
+                self.test_case_map.append(test_result)
+            else:
+                reg_blank = re.compile('^\s*$')
+                reg_comment = re.compile('^\s*//.*')
+                with open(self.test_file, 'r') as test_file:
+                    test_case_count = 0
+                    for line in test_file.readlines():
+                        if not re.match(reg_blank, line) and not re.match(reg_comment, line):
+                            test_result = TestCaseResult("Not run", str(test_case_count), "", 0, "Not run", "", None, self.test_config)
+                            self.test_case_map.append(test_result)
+                            test_case_count += 1
+
 
     def get_failure_message_or_all_exceptions(self):
         msg = ''

--- a/tdvt/tdvt/test_results.py
+++ b/tdvt/tdvt/test_results.py
@@ -67,12 +67,13 @@ class TestCaseResult(object):
 
     def all_passed(self):
         """Return true if all aspects of the test passed."""
+        if self.test_error_expected() and self.error_type:
+            return True
+
         passed = True
         if self.tested_config.tested_sql and not self.passed_sql:
             passed = False
         if self.tested_config.tested_tuples and not self.passed_tuples:
-            passed = False
-        if not self.test_error_expected() and self.error_type:
             passed = False
 
         return passed
@@ -133,11 +134,11 @@ class TestErrorMissingActual(TestErrorState):
 
 class TestResult(object):
     """Information about a test run. A test can contain one or more test cases."""
-    def __init__(self, base_name = '', test_config = TdvtTestConfig(), test_file = '', relative_test_file = '', test_set = None):
+    def __init__(self, base_name = '', test_config = TdvtTestConfig(), test_file = '', relative_test_file = '', test_set = None, error_status=None):
         self.name = base_name
         self.test_config = test_config
         self.matched_expected_version = 0
-        self.error_status = None
+        self.error_status = error_status
         self.saved_error_message = None
         self.diff_count = 0
         self.best_matching_expected_results = None
@@ -158,7 +159,7 @@ class TestResult(object):
         #Parse the setup file to get the count.
         if not self.test_case_map and self.test_set:
             if self.test_set.is_logical:
-                test_result = TestCaseResult("Not run", 0, "", 0, "Not run", "", None, self.test_config)
+                test_result = TestCaseResult("Not run", 0, "", 0, "Not run", self.error_status, None, self.test_config)
                 self.test_case_map.append(test_result)
             else:
                 reg_blank = re.compile('^\s*$')
@@ -168,7 +169,7 @@ class TestResult(object):
                         test_case_count = 0
                         for line in test_file.readlines():
                             if not re.match(reg_blank, line) and not re.match(reg_comment, line):
-                                test_result = TestCaseResult("Not run", str(test_case_count), "", test_case_count, "Not run", "", None, self.test_config)
+                                test_result = TestCaseResult("Not run", str(test_case_count), "", test_case_count, "Not run", self.error_status, None, self.test_config)
                                 self.test_case_map.append(test_result)
                                 test_case_count += 1
                 except IOError:

--- a/tdvt/tdvt/test_results.py
+++ b/tdvt/tdvt/test_results.py
@@ -36,6 +36,8 @@ class TestCaseResult(object):
     def get_tuples(self):
         tuple_list = []
         tuples = self.table.findall('tuple') if self.table else None
+        if not tuples:
+            return tuple_list
         for t in tuples:
             for v in t.findall('value'):
                 tuple_list.append(v.text)
@@ -79,9 +81,10 @@ class TestCaseResult(object):
         json_str = 'tuple'
         tuple_list = []
         tuples = self.table.findall('tuple') if self.table else None
-        for t in tuples:
-            for v in t.findall('value'):
-                tuple_list.append(v.text)
+        if tuples:
+            for t in tuples:
+                for v in t.findall('value'):
+                    tuple_list.append(v.text)
 
         return {'tuples' : tuple_list}
 
@@ -148,6 +151,29 @@ class TestResult(object):
         self.relative_test_file = relative_test_file
         self.test_set = test_set
 
+        self.parse_default_test_cases()
+
+    def parse_default_test_cases(self):
+        #If it is an expression test with no results, it probably means the test failed and the individual test cases weren't run. Count them here.
+        #Parse the setup file to get the count.
+        if not self.test_case_map and self.test_set:
+            if self.test_set.is_logical:
+                test_result = TestCaseResult("Not run", 0, "", 0, "Not run", "", None, self.test_config)
+                self.test_case_map.append(test_result)
+            else:
+                reg_blank = re.compile('^\s*$')
+                reg_comment = re.compile('^\s*//.*')
+                try:
+                    with open(self.test_file, 'r') as test_file:
+                        test_case_count = 0
+                        for line in test_file.readlines():
+                            if not re.match(reg_blank, line) and not re.match(reg_comment, line):
+                                test_result = TestCaseResult("Not run", str(test_case_count), "", test_case_count, "Not run", "", None, self.test_config)
+                                self.test_case_map.append(test_result)
+                                test_case_count += 1
+                except IOError:
+                    pass
+
     def __json__(self):
         return {'all_passed' : self.all_passed(), 'name' : self.name,
                 'matched_expected' : self.matched_expected_version, 'expected_diffs' : self.diff_count,
@@ -172,9 +198,12 @@ class TestResult(object):
             </results>
 
         """
-        self.test_case_map = []
         self.path_to_actual = actual_path
         #Go through all the test nodes under 'results'.
+        if not test_xml:
+            return
+
+        temp_test_cases = []
         for i in range(0, len(list(test_xml))):
             test_child = test_xml[i]
 
@@ -194,24 +223,11 @@ class TestResult(object):
             if not test_child_name:
                 continue
             test_result = TestCaseResult(test_child_name, str(i), sq, query_time, error_msg, error_type, test_child.find('table'), self.test_config)
-            self.test_case_map.append(test_result)
-        #If it is an expression test with no results, it probably means the test failed and the individual test cases weren't run. Count them here.
-        #Expression tests that didn't run would have some number of test cases that aren't accounted for. Parse the setup file to get the count.
-        if not self.test_case_map:
-            if self.test_set.is_logical:
-                test_result = TestCaseResult("Not run", 0, "", 0, "Not run", "", None, self.test_config)
-                self.test_case_map.append(test_result)
-            else:
-                reg_blank = re.compile('^\s*$')
-                reg_comment = re.compile('^\s*//.*')
-                with open(self.test_file, 'r') as test_file:
-                    test_case_count = 0
-                    for line in test_file.readlines():
-                        if not re.match(reg_blank, line) and not re.match(reg_comment, line):
-                            test_result = TestCaseResult("Not run", str(test_case_count), "", 0, "Not run", "", None, self.test_config)
-                            self.test_case_map.append(test_result)
-                            test_case_count += 1
+            temp_test_cases.append(test_result)
 
+        if temp_test_cases:
+            #Clear any dummy place holders.
+            self.test_case_map = temp_test_cases
 
     def get_failure_message_or_all_exceptions(self):
         msg = ''


### PR DESCRIPTION
Create dummy test cases when creating a TestResult. There is only one test case per logical test, but expression tests can have multiples, so parse the setup file and count them.

Verified that tests counts don't change if they pass, fail, or are aborted.