### PR TITLE
TFSID952474: Disable Aggregate:MoveGroupBysToMeasures since FuncallRewrite:RewriteConstantFuncall is also disabled

### DIFF
--- a/tdvt/tdvt/tabquery.py
+++ b/tdvt/tdvt/tabquery.py
@@ -3,6 +3,7 @@ import sys
 
 from .resources import *
 tab_cli_exe = ''
+logical_rewrite_appoption = ''
 
 def configure_tabquery_path():
     """Setup the tabquery path from ini settings."""
@@ -71,9 +72,14 @@ class TabqueryCommandLine(object):
             for override in work.test_config.d_override.split(' '):
                 cmdline.extend([override])
 
-        #Disable constant expression folding. This will bypass the VizEngine for certain simple calculations. This way we run a full database query
-        #that tests what you would expect.
-        cmdline.extend(["-DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures"])
+        logical_rewrite_iter = next((i for i in cmdline if i.find("-DLogicalQueryRewriteDisable")), None)
+        if logical_rewrite_iter == None:
+            #Disable constant expression folding. This will bypass the VizEngine for certain simple calculations. This way we run a full database query
+            #that tests what you would expect.
+            cmdline.extend(["-DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall"])
+            logical_rewrite_appoption = '-DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall'
+        else:
+            logical_rewrite_appoption = str(logical_rewrite_iter)
 
         self.extend_command_line(cmdline, work)
         work.test_config.command_line = cmdline

--- a/tdvt/tdvt/tabquery.py
+++ b/tdvt/tdvt/tabquery.py
@@ -71,9 +71,11 @@ class TabqueryCommandLine(object):
             for override in work.test_config.d_override.split(' '):
                 cmdline.extend([override])
 
-        #Disable constant expression folding. This will bypass the VizEngine for certain simple calculations. This way we run a full database query
-        #that tests what you would expect.
-        cmdline.extend(["-DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures"])
+        logical_rewrite_iter = next((i for i in cmdline if i.find("-DLogicalQueryRewriteDisable")), None)
+        if logical_rewrite_iter == None:
+            #Disable constant expression folding. This will bypass the VizEngine for certain simple calculations. This way we run a full database query
+            #that tests what you would expect.
+            cmdline.extend(["-DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall"])
 
         self.extend_command_line(cmdline, work)
         work.test_config.command_line = cmdline

--- a/tdvt/tdvt/tabquery.py
+++ b/tdvt/tdvt/tabquery.py
@@ -3,7 +3,6 @@ import sys
 
 from .resources import *
 tab_cli_exe = ''
-logical_rewrite_appoption = ''
 
 def configure_tabquery_path():
     """Setup the tabquery path from ini settings."""
@@ -72,14 +71,9 @@ class TabqueryCommandLine(object):
             for override in work.test_config.d_override.split(' '):
                 cmdline.extend([override])
 
-        logical_rewrite_iter = next((i for i in cmdline if i.find("-DLogicalQueryRewriteDisable")), None)
-        if logical_rewrite_iter == None:
-            #Disable constant expression folding. This will bypass the VizEngine for certain simple calculations. This way we run a full database query
-            #that tests what you would expect.
-            cmdline.extend(["-DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall"])
-            logical_rewrite_appoption = '-DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall'
-        else:
-            logical_rewrite_appoption = str(logical_rewrite_iter)
+        #Disable constant expression folding. This will bypass the VizEngine for certain simple calculations. This way we run a full database query
+        #that tests what you would expect.
+        cmdline.extend(["-DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures"])
 
         self.extend_command_line(cmdline, work)
         work.test_config.command_line = cmdline

--- a/tdvt/tdvt/tabquery.py
+++ b/tdvt/tdvt/tabquery.py
@@ -71,7 +71,7 @@ class TabqueryCommandLine(object):
             for override in work.test_config.d_override.split(' '):
                 cmdline.extend([override])
 
-        logical_rewrite_iter = next((i for i in cmdline if i.find("-DLogicalQueryRewriteDisable")), None)
+        logical_rewrite_iter = next((i for i in cmdline if i.find('-DLogicalQueryRewriteDisable') != -1), None)
         if logical_rewrite_iter == None:
             #Disable constant expression folding. This will bypass the VizEngine for certain simple calculations. This way we run a full database query
             #that tests what you would expect.

--- a/tdvt/test/tdvt_test.py
+++ b/tdvt/test/tdvt_test.py
@@ -253,9 +253,9 @@ class CommandLineTest(unittest.TestCase):
         cmd_line = build_tabquery_command_line_local(work)
         cmd_line_str = ' '.join(cmd_line)
         if sys.platform in ('win32', 'cygwin'):
-            expected = 'tabquerytool.exe --expression-file-list my/output/dir\mytest\\tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir\mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall'  # noqa: E501
+            expected = 'tabquerytool.exe --expression-file-list my/output/dir\mytest\\tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir\mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures'  # noqa: E501
         elif sys.platform in ('darwin', 'linux'):
-            expected = 'tabquerytool --expression-file-list my/output/dir/mytest/tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir/mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall'  # noqa: E501
+            expected = 'tabquerytool --expression-file-list my/output/dir/mytest/tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir/mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures'  # noqa: E501
         else:
             self.skipTest("Unsupported test OS: {}".format(sys.platform))
         self.assertTrue(cmd_line_str == expected, 'Actual: ' + cmd_line_str + ': Expected: ' + expected)
@@ -280,9 +280,9 @@ class CommandLineTest(unittest.TestCase):
         cmd_line = build_tabquery_command_line_local(work)
         cmd_line_str = ' '.join(cmd_line)
         if sys.platform in ('win32', 'cygwin'):
-            expected = 'tabquerytool.exe --expression-file-list my/output/dir\mytest\\tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir\mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall --test_arg my/output/dir'  # noqa: E501
+            expected = 'tabquerytool.exe --expression-file-list my/output/dir\mytest\\tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir\mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures --test_arg my/output/dir'  # noqa: E501
         elif sys.platform in ('darwin', 'linux'):
-            expected = 'tabquerytool --expression-file-list my/output/dir/mytest/tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir/mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall --test_arg my/output/dir'  # noqa: E501
+            expected = 'tabquerytool --expression-file-list my/output/dir/mytest/tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir/mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures --test_arg my/output/dir'  # noqa: E501
         else:
             self.skipTest("Unsupported test OS: {}".format(sys.platform))
         self.assertTrue(cmd_line_str == expected, 'Actual: ' + cmd_line_str + ': Expected: ' + expected)
@@ -292,9 +292,9 @@ class CommandLineTest(unittest.TestCase):
         cmd_line = build_tabquery_command_line_local(work)
         cmd_line_str = ' '.join(cmd_line)
         if sys.platform in ('win32', 'cygwin'):
-            expected = 'tabquerytool.exe --expression-file-list mytest\\tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall'  # noqa: E501
+            expected = 'tabquerytool.exe --expression-file-list mytest\\tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures'  # noqa: E501
         elif sys.platform in ('darwin', 'linux'):
-            expected = 'tabquerytool --expression-file-list mytest/tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall'  # noqa: E501
+            expected = 'tabquerytool --expression-file-list mytest/tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures'  # noqa: E501
         else:
             self.skipTest("Unsupported test OS: {}".format(sys.platform))
         self.assertTrue(cmd_line_str == expected, 'Actual: ' + cmd_line_str + ': Expected: ' + expected)
@@ -306,9 +306,9 @@ class CommandLineTest(unittest.TestCase):
         cmd_line = build_tabquery_command_line_local(work)
         cmd_line_str = ' '.join(cmd_line)
         if sys.platform in ('win32', 'cygwin'):
-            expected = 'tabquerytool.exe --expression-file-list mytest\\tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DUseJDBC -DOverride=MongoDBConnector:on,SomethingElse:off -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall'  # noqa: E501
+            expected = 'tabquerytool.exe --expression-file-list mytest\\tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DUseJDBC -DOverride=MongoDBConnector:on,SomethingElse:off -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures'  # noqa: E501
         elif sys.platform in ('darwin', 'linux'):
-            expected = 'tabquerytool --expression-file-list mytest/tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DUseJDBC -DOverride=MongoDBConnector:on,SomethingElse:off -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall'  # noqa: E501
+            expected = 'tabquerytool --expression-file-list mytest/tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DUseJDBC -DOverride=MongoDBConnector:on,SomethingElse:off -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures'  # noqa: E501
         else:
             self.skipTest(reason="Unsupported test OS: {}".format(sys.platform))
         self.assertTrue(cmd_line_str == expected, 'Actual: ' + cmd_line_str + ': Expected: ' + expected)

--- a/tdvt/test/tdvt_test.py
+++ b/tdvt/test/tdvt_test.py
@@ -253,9 +253,9 @@ class CommandLineTest(unittest.TestCase):
         cmd_line = build_tabquery_command_line_local(work)
         cmd_line_str = ' '.join(cmd_line)
         if sys.platform in ('win32', 'cygwin'):
-            expected = 'tabquerytool.exe --expression-file-list my/output/dir\mytest\\tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir\mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures'  # noqa: E501
+            expected = 'tabquerytool.exe --expression-file-list my/output/dir\mytest\\tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir\mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug ' + logical_rewrite_appoption  # noqa: E501
         elif sys.platform in ('darwin', 'linux'):
-            expected = 'tabquerytool --expression-file-list my/output/dir/mytest/tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir/mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures'  # noqa: E501
+            expected = 'tabquerytool --expression-file-list my/output/dir/mytest/tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir/mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug ' + logical_rewrite_appoption  # noqa: E501
         else:
             self.skipTest("Unsupported test OS: {}".format(sys.platform))
         self.assertTrue(cmd_line_str == expected, 'Actual: ' + cmd_line_str + ': Expected: ' + expected)
@@ -280,9 +280,9 @@ class CommandLineTest(unittest.TestCase):
         cmd_line = build_tabquery_command_line_local(work)
         cmd_line_str = ' '.join(cmd_line)
         if sys.platform in ('win32', 'cygwin'):
-            expected = 'tabquerytool.exe --expression-file-list my/output/dir\mytest\\tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir\mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures --test_arg my/output/dir'  # noqa: E501
+            expected = 'tabquerytool.exe --expression-file-list my/output/dir\mytest\\tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir\mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug ' + logical_rewrite_appoption + ' --test_arg my/output/dir'  # noqa: E501
         elif sys.platform in ('darwin', 'linux'):
-            expected = 'tabquerytool --expression-file-list my/output/dir/mytest/tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir/mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures --test_arg my/output/dir'  # noqa: E501
+            expected = 'tabquerytool --expression-file-list my/output/dir/mytest/tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir/mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug ' + logical_rewrite_appoption + ' --test_arg my/output/dir'  # noqa: E501
         else:
             self.skipTest("Unsupported test OS: {}".format(sys.platform))
         self.assertTrue(cmd_line_str == expected, 'Actual: ' + cmd_line_str + ': Expected: ' + expected)
@@ -292,9 +292,9 @@ class CommandLineTest(unittest.TestCase):
         cmd_line = build_tabquery_command_line_local(work)
         cmd_line_str = ' '.join(cmd_line)
         if sys.platform in ('win32', 'cygwin'):
-            expected = 'tabquerytool.exe --expression-file-list mytest\\tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures'  # noqa: E501
+            expected = 'tabquerytool.exe --expression-file-list mytest\\tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog ' + logical_rewrite_appoption  # noqa: E501
         elif sys.platform in ('darwin', 'linux'):
-            expected = 'tabquerytool --expression-file-list mytest/tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures'  # noqa: E501
+            expected = 'tabquerytool --expression-file-list mytest/tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog ' + logical_rewrite_appoption  # noqa: E501
         else:
             self.skipTest("Unsupported test OS: {}".format(sys.platform))
         self.assertTrue(cmd_line_str == expected, 'Actual: ' + cmd_line_str + ': Expected: ' + expected)
@@ -306,9 +306,9 @@ class CommandLineTest(unittest.TestCase):
         cmd_line = build_tabquery_command_line_local(work)
         cmd_line_str = ' '.join(cmd_line)
         if sys.platform in ('win32', 'cygwin'):
-            expected = 'tabquerytool.exe --expression-file-list mytest\\tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DUseJDBC -DOverride=MongoDBConnector:on,SomethingElse:off -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures'  # noqa: E501
+            expected = 'tabquerytool.exe --expression-file-list mytest\\tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DUseJDBC -DOverride=MongoDBConnector:on,SomethingElse:off ' + logical_rewrite_appoption  # noqa: E501
         elif sys.platform in ('darwin', 'linux'):
-            expected = 'tabquerytool --expression-file-list mytest/tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DUseJDBC -DOverride=MongoDBConnector:on,SomethingElse:off -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures'  # noqa: E501
+            expected = 'tabquerytool --expression-file-list mytest/tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DUseJDBC -DOverride=MongoDBConnector:on,SomethingElse:off ' + logical_rewrite_appoption  # noqa: E501
         else:
             self.skipTest(reason="Unsupported test OS: {}".format(sys.platform))
         self.assertTrue(cmd_line_str == expected, 'Actual: ' + cmd_line_str + ': Expected: ' + expected)

--- a/tdvt/test/tdvt_test.py
+++ b/tdvt/test/tdvt_test.py
@@ -253,9 +253,9 @@ class CommandLineTest(unittest.TestCase):
         cmd_line = build_tabquery_command_line_local(work)
         cmd_line_str = ' '.join(cmd_line)
         if sys.platform in ('win32', 'cygwin'):
-            expected = 'tabquerytool.exe --expression-file-list my/output/dir\mytest\\tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir\mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug ' + logical_rewrite_appoption  # noqa: E501
+            expected = 'tabquerytool.exe --expression-file-list my/output/dir\mytest\\tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir\mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures'  # noqa: E501
         elif sys.platform in ('darwin', 'linux'):
-            expected = 'tabquerytool --expression-file-list my/output/dir/mytest/tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir/mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug ' + logical_rewrite_appoption  # noqa: E501
+            expected = 'tabquerytool --expression-file-list my/output/dir/mytest/tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir/mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures'  # noqa: E501
         else:
             self.skipTest("Unsupported test OS: {}".format(sys.platform))
         self.assertTrue(cmd_line_str == expected, 'Actual: ' + cmd_line_str + ': Expected: ' + expected)
@@ -280,9 +280,9 @@ class CommandLineTest(unittest.TestCase):
         cmd_line = build_tabquery_command_line_local(work)
         cmd_line_str = ' '.join(cmd_line)
         if sys.platform in ('win32', 'cygwin'):
-            expected = 'tabquerytool.exe --expression-file-list my/output/dir\mytest\\tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir\mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug ' + logical_rewrite_appoption + ' --test_arg my/output/dir'  # noqa: E501
+            expected = 'tabquerytool.exe --expression-file-list my/output/dir\mytest\\tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir\mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures --test_arg my/output/dir'  # noqa: E501
         elif sys.platform in ('darwin', 'linux'):
-            expected = 'tabquerytool --expression-file-list my/output/dir/mytest/tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir/mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug ' + logical_rewrite_appoption + ' --test_arg my/output/dir'  # noqa: E501
+            expected = 'tabquerytool --expression-file-list my/output/dir/mytest/tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir/mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures --test_arg my/output/dir'  # noqa: E501
         else:
             self.skipTest("Unsupported test OS: {}".format(sys.platform))
         self.assertTrue(cmd_line_str == expected, 'Actual: ' + cmd_line_str + ': Expected: ' + expected)
@@ -292,9 +292,9 @@ class CommandLineTest(unittest.TestCase):
         cmd_line = build_tabquery_command_line_local(work)
         cmd_line_str = ' '.join(cmd_line)
         if sys.platform in ('win32', 'cygwin'):
-            expected = 'tabquerytool.exe --expression-file-list mytest\\tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog ' + logical_rewrite_appoption  # noqa: E501
+            expected = 'tabquerytool.exe --expression-file-list mytest\\tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures'  # noqa: E501
         elif sys.platform in ('darwin', 'linux'):
-            expected = 'tabquerytool --expression-file-list mytest/tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog ' + logical_rewrite_appoption  # noqa: E501
+            expected = 'tabquerytool --expression-file-list mytest/tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures'  # noqa: E501
         else:
             self.skipTest("Unsupported test OS: {}".format(sys.platform))
         self.assertTrue(cmd_line_str == expected, 'Actual: ' + cmd_line_str + ': Expected: ' + expected)
@@ -306,9 +306,9 @@ class CommandLineTest(unittest.TestCase):
         cmd_line = build_tabquery_command_line_local(work)
         cmd_line_str = ' '.join(cmd_line)
         if sys.platform in ('win32', 'cygwin'):
-            expected = 'tabquerytool.exe --expression-file-list mytest\\tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DUseJDBC -DOverride=MongoDBConnector:on,SomethingElse:off ' + logical_rewrite_appoption  # noqa: E501
+            expected = 'tabquerytool.exe --expression-file-list mytest\\tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DUseJDBC -DOverride=MongoDBConnector:on,SomethingElse:off -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures'  # noqa: E501
         elif sys.platform in ('darwin', 'linux'):
-            expected = 'tabquerytool --expression-file-list mytest/tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DUseJDBC -DOverride=MongoDBConnector:on,SomethingElse:off ' + logical_rewrite_appoption  # noqa: E501
+            expected = 'tabquerytool --expression-file-list mytest/tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DUseJDBC -DOverride=MongoDBConnector:on,SomethingElse:off -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures'  # noqa: E501
         else:
             self.skipTest(reason="Unsupported test OS: {}".format(sys.platform))
         self.assertTrue(cmd_line_str == expected, 'Actual: ' + cmd_line_str + ': Expected: ' + expected)

--- a/tdvt/test/tdvt_test.py
+++ b/tdvt/test/tdvt_test.py
@@ -253,9 +253,9 @@ class CommandLineTest(unittest.TestCase):
         cmd_line = build_tabquery_command_line_local(work)
         cmd_line_str = ' '.join(cmd_line)
         if sys.platform in ('win32', 'cygwin'):
-            expected = 'tabquerytool.exe --expression-file-list my/output/dir\mytest\\tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir\mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures'  # noqa: E501
+            expected = 'tabquerytool.exe --expression-file-list my/output/dir\mytest\\tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir\mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall'  # noqa: E501
         elif sys.platform in ('darwin', 'linux'):
-            expected = 'tabquerytool --expression-file-list my/output/dir/mytest/tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir/mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures'  # noqa: E501
+            expected = 'tabquerytool --expression-file-list my/output/dir/mytest/tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir/mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall'  # noqa: E501
         else:
             self.skipTest("Unsupported test OS: {}".format(sys.platform))
         self.assertTrue(cmd_line_str == expected, 'Actual: ' + cmd_line_str + ': Expected: ' + expected)
@@ -280,9 +280,9 @@ class CommandLineTest(unittest.TestCase):
         cmd_line = build_tabquery_command_line_local(work)
         cmd_line_str = ' '.join(cmd_line)
         if sys.platform in ('win32', 'cygwin'):
-            expected = 'tabquerytool.exe --expression-file-list my/output/dir\mytest\\tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir\mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures --test_arg my/output/dir'  # noqa: E501
+            expected = 'tabquerytool.exe --expression-file-list my/output/dir\mytest\\tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir\mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall --test_arg my/output/dir'  # noqa: E501
         elif sys.platform in ('darwin', 'linux'):
-            expected = 'tabquerytool --expression-file-list my/output/dir/mytest/tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir/mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures --test_arg my/output/dir'  # noqa: E501
+            expected = 'tabquerytool --expression-file-list my/output/dir/mytest/tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir/mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall --test_arg my/output/dir'  # noqa: E501
         else:
             self.skipTest("Unsupported test OS: {}".format(sys.platform))
         self.assertTrue(cmd_line_str == expected, 'Actual: ' + cmd_line_str + ': Expected: ' + expected)
@@ -292,9 +292,9 @@ class CommandLineTest(unittest.TestCase):
         cmd_line = build_tabquery_command_line_local(work)
         cmd_line_str = ' '.join(cmd_line)
         if sys.platform in ('win32', 'cygwin'):
-            expected = 'tabquerytool.exe --expression-file-list mytest\\tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures'  # noqa: E501
+            expected = 'tabquerytool.exe --expression-file-list mytest\\tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall'  # noqa: E501
         elif sys.platform in ('darwin', 'linux'):
-            expected = 'tabquerytool --expression-file-list mytest/tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures'  # noqa: E501
+            expected = 'tabquerytool --expression-file-list mytest/tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall'  # noqa: E501
         else:
             self.skipTest("Unsupported test OS: {}".format(sys.platform))
         self.assertTrue(cmd_line_str == expected, 'Actual: ' + cmd_line_str + ': Expected: ' + expected)
@@ -306,9 +306,9 @@ class CommandLineTest(unittest.TestCase):
         cmd_line = build_tabquery_command_line_local(work)
         cmd_line_str = ' '.join(cmd_line)
         if sys.platform in ('win32', 'cygwin'):
-            expected = 'tabquerytool.exe --expression-file-list mytest\\tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DUseJDBC -DOverride=MongoDBConnector:on,SomethingElse:off -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures'  # noqa: E501
+            expected = 'tabquerytool.exe --expression-file-list mytest\\tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DUseJDBC -DOverride=MongoDBConnector:on,SomethingElse:off -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall'  # noqa: E501
         elif sys.platform in ('darwin', 'linux'):
-            expected = 'tabquerytool --expression-file-list mytest/tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DUseJDBC -DOverride=MongoDBConnector:on,SomethingElse:off -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall,Aggregate:MoveGroupBysToMeasures'  # noqa: E501
+            expected = 'tabquerytool --expression-file-list mytest/tests.txt -d mytds.tds --combined -DLogDir=mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DUseJDBC -DOverride=MongoDBConnector:on,SomethingElse:off -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall'  # noqa: E501
         else:
             self.skipTest(reason="Unsupported test OS: {}".format(sys.platform))
         self.assertTrue(cmd_line_str == expected, 'Actual: ' + cmd_line_str + ': Expected: ' + expected)


### PR DESCRIPTION
We have completed a new feature planned to turn on for 19.4. There is a rewrite rule added which has to work with RewriteConstantFuncall which is disabled in TDVT tests, so we also need to disable this one since it would cause some SQL text unable to be executed in DB2.