### PR TITLE
Packaging tool improvements before shipping

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,0 +1,19 @@
+scanner:
+    linter: flake8
+
+flake8:
+    max-line-length: 120  # Default is 79 in PEP 8
+
+no_blank_comment: False
+descending_issues_order: True
+
+message:  # Customize the comment made by the bot
+    opened:  # Messages when a new PR is submitted
+        header: "Hi, @{name}! Thanks for opening this PR! "
+                # The keyword {name} is converted into the author's username
+        footer: "For reference: [Error Code Reference](https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes), [PEP8](https://pep8.org/), [Python code style](https://docs.python-guide.org/writing/style/)"
+                # The messages can be written as they would over GitHub
+    updated:  # Messages when new commits are added to the PR
+        header: "Thanks for updating the PR. "
+        footer: ""  # Why to comment the link to the style guide everytime? :)
+    no_errors: "No PEP 8 issues detected in this PR! Nice job! "

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -11,6 +11,8 @@ The recommendation is to install `package` within a Python virtual environment. 
 
 ### Run package Module
 
+The `package` tool must be run from the `connector-plugin-sdk/packaging/` directory or it will throw an error message.
+
 To package the connector and sign it:
 ```
 (.venv) PS connector-plugin-sdk\packaging> python -m package.package [path_to_folder] -a [alias_name] -ks [keystore_file_path]

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -64,7 +64,7 @@ Activate the virtual environment.
 PS connector-plugin-sdk\packaging> .\.venv\Scripts\activate
 ```
 
-Verify python version is greater than 3.7.
+Verify Python version is 3.7.3 or higher.
 ```
 (.venv) PS connector-plugin-sdk\packaging> python --version
 Python 3.7.3

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -2,8 +2,8 @@
 
 ## Usage
 
-### Install package Module
-The recommendation is to install package within a Python virtual environment. See section Setup Virtual Environment below to create and activate a virtual environment.
+### Install `package` Module
+The recommendation is to install `package` within a Python virtual environment. See section Setup Virtual Environment below to create and activate a virtual environment.
 
 ```
 (.venv) PS connector-plugin-sdk\packaging> python setup.py install
@@ -44,7 +44,7 @@ optional arguments:
 ## Development
 
 ### Select Python Installation
-If not installed, download and install Python 3.7 or greater: https://www.python.org/downloads/  Add to PATH or in IDE console.
+The `package` tool is developed against Python 3.7.3, which can be downloaded at https://www.python.org/downloads/. After installation, add Python to your PATH or in IDE console.
 
 Example: .vscode\settings.json
 ```javascript
@@ -54,7 +54,7 @@ Example: .vscode\settings.json
 }
 ```
 ### Setup Virtual Environment
-[Create]((https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments)) a virtual environment using Python [venv](https://docs.python.org/3/library/venv.html) command. Note: example commands are Windows specific.
+[Create](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments) a virtual environment using Python's [venv](https://docs.python.org/3/library/venv.html) command. Note: example commands are Windows specific.
 ```
 PS connector-plugin-sdk\packaging> py -3 -m venv .venv
 ```

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -37,7 +37,7 @@ optional arguments:
   -v, --verbose         verbose output
   -l LOG_PATH, --log LOG_PATH
                         path of logging output
-  --validate_only       runs package validation steps only
+  --validate-only       runs package validation steps only
   -d DEST, --dest DEST  destination folder for packaged connector
 ```
 
@@ -91,6 +91,3 @@ For reference, to deactivate the virtual environment in the future.
 ```
 (.venv) PS connector-plugin-sdk\packaging> python -m package.package
 ```
-
-#### Notes
-- https://stackoverflow.com/a/47559925

--- a/packaging/package/jar_jdk_packager.py
+++ b/packaging/package/jar_jdk_packager.py
@@ -51,8 +51,3 @@ def jdk_create_jar(source_dir, files, jar_filename, dest_dir):
     logging.info(jar_filename + " was created in " + str(os.path.abspath(dest_dir)))
     return True
 
-
-
-
-
-

--- a/packaging/package/jar_jdk_signer.py
+++ b/packaging/package/jar_jdk_signer.py
@@ -82,7 +82,7 @@ def jdk_sign_jar(input_dir, taco_name, alias, keystore):
         alias_pwd_bytes = pwd_input[1]
 
     # Start jarsigner subprocess
-    args = ["jarsigner", "-keystore", keystore, str(input_dir/taco_name), alias]
+    args = ["jarsigner", "-keystore", keystore, str(input_dir/taco_name), alias]  # noqa: E226
     p = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
     # Pass keystore and alias password to jarsigner subprocess

--- a/packaging/package/jar_jdk_signer.py
+++ b/packaging/package/jar_jdk_signer.py
@@ -15,6 +15,8 @@ ALIAS_PWD_PROMPT_LENGTH = len("Enter key password for : ")
 def validate_signing_input(input_dir, taco_name, alias, keystore):
     """
     Validate signing input
+
+    :return: Boolean
     """
 
     if not alias:
@@ -26,8 +28,7 @@ def validate_signing_input(input_dir, taco_name, alias, keystore):
         return False
 
     if not os.path.isfile(input_dir/taco_name):
-        logger.error(
-            "Signing Error: Taco file to be signed has been deleted or doesn't exist")
+        logger.error("Signing Error: Taco file to be signed has been deleted or doesn't exist")
         return False
 
     return True
@@ -81,10 +82,8 @@ def jdk_sign_jar(input_dir, taco_name, alias, keystore):
         alias_pwd_bytes = pwd_input[1]
 
     # Start jarsigner subprocess
-    args = ["jarsigner", "-keystore", keystore,
-            str(input_dir/taco_name), alias]
-    p = subprocess.Popen(args, stdin=subprocess.PIPE,
-                         stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    args = ["jarsigner", "-keystore", keystore, str(input_dir/taco_name), alias]
+    p = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
     # Pass keystore and alias password to jarsigner subprocess
     p.stdin.write(ks_pwd_bytes)
@@ -110,8 +109,7 @@ def jdk_sign_jar(input_dir, taco_name, alias, keystore):
     p.wait()
 
     if p.returncode == 0:
-        logger.info("taco was signed as " + taco_name +
-                    " at " + str(os.path.abspath(input_dir)))
+        logger.info("taco was signed as " + taco_name + " at " + str(os.path.abspath(input_dir)))
         return True
     else:
         return False

--- a/packaging/package/package.py
+++ b/packaging/package/package.py
@@ -34,7 +34,7 @@ def create_arg_parser():
 def main():
     parser = create_arg_parser()
     args = parser.parse_args()
-    log_file = args.log_path + 'packaging_log.txt'
+    log_file = args.log_path + '/packaging_log.txt'
     logger = init_logging(log_file, args.verbose)
 
     path_from_args = Path(args.input_dir)
@@ -43,21 +43,23 @@ def main():
     files_to_package = xmlparser.generate_file_list()  # validates XSD's as well
 
     if args.validate_only:
+        if args.package_only:
+            logger.warning("Because the validate-only flag was used, files will not be packaged.")
         if files_to_package and validate_all_xml(files_to_package, path_from_args):
             logger.info("XML Validation succeeded.")
         else:
-            logger.info("XML Validation failed. Check " + args.log_path + " for more information.")
+            logger.info("XML Validation failed. Check " + log_file + " for more information.")
         return
 
     if not files_to_package:
-        logger.info("Packaging failed. Check " + args.log_path + " for more information.")
+        logger.info("Packaging failed. Check " + log_file + " for more information.")
         return
 
     package_dest_path = Path(args.dest)
     package_name = xmlparser.class_name + PACKAGED_EXTENSION
 
     if not jdk_create_jar(path_from_args, files_to_package, package_name, package_dest_path):
-        logger.info("Taco packaging failed. Check " + args.log_path + " for more information.")
+        logger.info("Taco packaging failed. Check " + log_file + " for more information.")
         return
 
     if args.package_only:
@@ -68,11 +70,11 @@ def main():
     keystore_from_args = args.keystore
 
     if not validate_signing_input(package_dest_path, package_name, alias_from_args, keystore_from_args):
-        logger.debug("Signing input validation failed. check " + args.log_path + " for more information.")
+        logger.debug("Signing input validation failed. check " + log_file + " for more information.")
         return
 
     if not jdk_sign_jar(package_dest_path, package_name, alias_from_args, keystore_from_args):
-        logger.info("Signing failed. check console output and " + args.log_path + " for more information.")
+        logger.info("Signing failed. check console output and " + log_file + " for more information.")
         return
 
 

--- a/packaging/package/package.py
+++ b/packaging/package/package.py
@@ -34,7 +34,8 @@ def create_arg_parser():
 def main():
     parser = create_arg_parser()
     args = parser.parse_args()
-    logger = init_logging(args.log_path, args.verbose)
+    log_file = args.log_path + 'packaging_log.txt'
+    logger = init_logging(log_file, args.verbose)
 
     path_from_args = Path(args.input_dir)
 

--- a/packaging/package/package.py
+++ b/packaging/package/package.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 from pathlib import Path
 
 from .helper import init_logging
@@ -12,15 +13,21 @@ PACKAGED_EXTENSION = ".taco"
 
 
 def create_arg_parser():
-    parser = argparse.ArgumentParser(description="Tableau Connector Packaging Tool: package and sign connector files into a single Tableau Connector (" + PACKAGED_EXTENSION + ") file.")
+    parser = argparse.ArgumentParser(description="Tableau Connector Packaging Tool: package and sign connector files into a single Tableau Connector (" + PACKAGED_EXTENSION + ") file.")  # noqa: E501
     parser.add_argument('input_dir', help='path to directory of connector files to package and sign')
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true', help='verbose output', required=False)
-    parser.add_argument('-l', '--log', dest='log_path', help='path of logging output', default='packaging_log.txt')
-    parser.add_argument('--validate-only', dest='validate_only', action='store_true', help='runs package validation steps only', required=False)
-    parser.add_argument('-d', '--dest', dest='dest', help='destination folder for packaged connector', default='packaged-connector')
-    parser.add_argument('--package-only', dest='package_only', action='store_true',  help='package a taco only, skip signing', required=False)
-    parser.add_argument('-a', '--alias', dest='alias', help='alias identifying the private key to be used to sign taco file', required=False)
-    parser.add_argument('-ks', '--keystore', dest='keystore', help='keystore location, default is the jks file in user home directory', required=False)
+    parser.add_argument('-l', '--log', dest='log_path', help='path to directory for logging output',
+                        default=os.getcwd())
+    parser.add_argument('--validate-only', dest='validate_only', action='store_true',
+                        help='runs package validation steps only', required=False)
+    parser.add_argument('-d', '--dest', dest='dest', help='destination folder for packaged connector',
+                        default='packaged-connector')
+    parser.add_argument('--package-only', dest='package_only', action='store_true',
+                        help='package a taco only, skip signing', required=False)
+    parser.add_argument('-a', '--alias', dest='alias',
+                        help='alias identifying the private key to be used to sign taco file', required=False)
+    parser.add_argument('-ks', '--keystore', dest='keystore',
+                        help='keystore location, default is the jks file in user home directory', required=False)
     return parser
 
 

--- a/packaging/package/xml_parser.py
+++ b/packaging/package/xml_parser.py
@@ -39,7 +39,7 @@ class XMLParser:
             -- Returns none if any of the files are invalid, or the files do not agree on the name
         """
 
-        logging.debug("Generating list of for validation and/or packaging...")
+        logging.debug("Generating list of files for validation and/or packaging...")
 
         if not self.path_to_folder.is_dir():
             logger.error("Error: " + str(self.path_to_folder) + " does not exist or is not a directory.")

--- a/packaging/package/xml_parser.py
+++ b/packaging/package/xml_parser.py
@@ -38,20 +38,20 @@ class XMLParser:
             list[ConnectorFile] -- list of files to package
             -- Returns none if any of the files are invalid, or the files do not agree on the name
         """
-        
-        logging.debug("Generating list of files to package...")
-        
+
+        logging.debug("Generating list of for validation and/or packaging...")
+
         if not self.path_to_folder.is_dir():
-            logger.error("Error: " + str(self.path_to_folder) + " does not exist or is not a directory.")   
+            logger.error("Error: " + str(self.path_to_folder) + " does not exist or is not a directory.")
             return None
-        
+
         # Make sure manifest exists
         path_to_manifest = self.path_to_folder / Path("manifest.xml")
         if not path_to_manifest.is_file():
-            logger.error("Error: " + str(self.path_to_folder) + " does not contain a file called manifest.xml.")   
+            logger.error("Error: " + str(self.path_to_folder) + " does not contain a file called manifest.xml.")
             return None
-        
-        self.file_list.append(ConnectorFile("manifest.xml", "manifest"))   
+
+        self.file_list.append(ConnectorFile("manifest.xml", "manifest"))
 
         # Call parse_file on manifest, when it finds links to other files it will recursiveley call it again
         files_valid = self.parse_file(self.file_list[0])
@@ -83,19 +83,19 @@ class XMLParser:
                         for error in xml_violations_buffer:
                             logging.debug(error)
                         return None
-                    
+
                     self.file_list.append(ConnectorFile(resource_file_name, "resource"))
                     logging.debug("Adding file to list (name = " + resource_file_name + ", type = resource)")
 
-            
+
 
         else:
             logger.debug("No loc files.")
 
-        # Print generated files to log for debugging        
+        # Print generated files to log for debugging
         logger.debug("Generated file list:")
         for f in self.file_list:
-            logger.debug("-- " + f.file_name)        
+            logger.debug("-- " + f.file_name)
 
         return self.file_list
 
@@ -111,7 +111,7 @@ class XMLParser:
         """
         path_to_file = self.path_to_folder / str(file_to_parse.file_name)
         xml_violation_buffer = []
-        
+
         # if the file is not valid, return false
         if not validate_single_file(file_to_parse, path_to_file, xml_violation_buffer):
             for v in xml_violation_buffer:
@@ -131,7 +131,7 @@ class XMLParser:
         for child in root.iter():
 
             # If xml element has file attribute, add it to the file list. If it's not a script, parse that file too.
-            
+
             if 'file' in child.attrib:
 
                 # Make new connector file object
@@ -152,7 +152,7 @@ class XMLParser:
 
             # If an element has the 'class' attribute, and the class name is not set, set the class name. If it is set, make sure it is the same name
             if 'class' in child.attrib:
-                
+
                 # Name not yet found
                 if not self.class_name:
                     logging.debug("Found class name: " + child.attrib['class'])
@@ -171,4 +171,3 @@ class XMLParser:
 
         # If we've reached here, all the children are valid
         return True
-        


### PR DESCRIPTION
This PR does the following:
* Change the `--log` arg. Previously it took a path to a specific file. Now, it does what the label says, and accepts a path to where the file is saved.
* Raises a warning at the command line and in the logs when `--validate-only` and `--package-only` are run together.
* Minor changes to README
* Brings in pep8speaks so it'll stop nagging us about 120 char lines

There are whitespace changes in this PR; you can have GitHub ignore them by selecting the following:
![Snag_b3a764](https://user-images.githubusercontent.com/5643640/62400762-49596400-b535-11e9-937e-bccc9ed5a5b8.png)
