### PR TITLE
Stamp min support tableau version while packaging

### DIFF
--- a/connector-packager/connector_packager/jar_jdk_packager.py
+++ b/connector-packager/connector_packager/jar_jdk_packager.py
@@ -2,13 +2,74 @@ import os
 import logging
 import subprocess
 import shutil
+import xml.etree.ElementTree as ET
 
 from pathlib import Path
 from .connector_file import ConnectorFile
 from .helper import check_jdk_environ_variable
+from .version import __min_version_tableau__
 
 JAR_EXECUTABLE_NAME = "jar.exe"
 logger = logging.getLogger(__name__)
+MANIFEST_FILE_TYPE = "manifest"
+MANIFEST_FILE_NAME = "manifest.xml"
+MANIFEST_FILE_COPY_NAME = "manifest_copy.xml"
+MANIFEST_ROOT_ELEM = "connector-plugin"
+MIN_TABLEAU_VERSION_ATTR = "min-version-tableau"
+
+
+def stamp_min_support_version(input_dir, file_list, jar_filename):
+    """
+    Stamp of minimum support version to the connector manifest in packaged jar file
+
+    :param input_dir: source dir of files to be packaged
+    :type input_dir: Path
+
+    :param file_list: files need to be packaged
+    :type file_list: list of ConnectorFile
+
+    :param jar_filename: filename of the created JAR
+    :type jar_filename: str
+
+    :return: Boolean
+    """
+
+    # find manifest in connector file list
+    manifest_file = None
+    for file in file_list:
+        if file.file_type == MANIFEST_FILE_TYPE and file.file_name == MANIFEST_FILE_NAME:
+            manifest_file = file
+            break
+    if not manifest_file:
+        logger.info("Can not find manifest.xml in input directory while packaging")
+        return False
+
+    # make a copy of manifest file
+    shutil.copyfile(input_dir / manifest_file.file_name, input_dir / MANIFEST_FILE_COPY_NAME)
+
+    # stamp the original manifest file
+    manifest = ET.parse(input_dir / manifest_file.file_name)
+    plugin_elem = manifest.getroot()
+    if plugin_elem.tag != MANIFEST_ROOT_ELEM:
+        logger.info("Manifest's root element has been modified after xml validation")
+        return False
+    plugin_elem.set(MIN_TABLEAU_VERSION_ATTR, __min_version_tableau__)
+    manifest.write(input_dir / manifest_file.file_name, encoding="utf-8", xml_declaration=True)
+
+    # update the connector manifest inside taco
+    args = ["jar", "uf", jar_filename, manifest_file.file_name]
+    p = subprocess.Popen(args, cwd=os.path.abspath(input_dir))
+    return_code = p.wait()
+
+    # Recover manifest file from its copy
+    os.remove(input_dir / MANIFEST_FILE_NAME)
+    os.rename(input_dir / MANIFEST_FILE_COPY_NAME, input_dir / MANIFEST_FILE_NAME)
+
+    # Check Subprocess result
+    if return_code != 0:
+        logger.info("Unable to stamp minimum support version while packaging")
+        return False
+    return True
 
 
 def jdk_create_jar(source_dir, files, jar_filename, dest_dir):
@@ -46,8 +107,10 @@ def jdk_create_jar(source_dir, files, jar_filename, dest_dir):
     p = subprocess.Popen(args, cwd=abs_source_path)
     p.wait()
 
+    if not stamp_min_support_version(source_dir, files, jar_filename):
+        return False
+
     shutil.move(abs_source_path/Path(jar_filename), dest_dir/jar_filename)
 
     logging.info(jar_filename + " was created in " + str(os.path.abspath(dest_dir)))
     return True
-

--- a/connector-packager/connector_packager/jar_jdk_packager.py
+++ b/connector-packager/connector_packager/jar_jdk_packager.py
@@ -12,8 +12,8 @@ from .version import __min_version_tableau__
 JAR_EXECUTABLE_NAME = "jar.exe"
 logger = logging.getLogger(__name__)
 MANIFEST_FILE_TYPE = "manifest"
-MANIFEST_FILE_NAME = "manifest.xml"
-MANIFEST_FILE_COPY_NAME = "manifest_copy.xml"
+MANIFEST_FILE_NAME = MANIFEST_FILE_TYPE + ".xml"
+MANIFEST_FILE_COPY_NAME = MANIFEST_FILE_TYPE + "_copy.xml"
 MANIFEST_ROOT_ELEM = "connector-plugin"
 MIN_TABLEAU_VERSION_ATTR = "min-version-tableau"
 

--- a/connector-packager/connector_packager/version.py
+++ b/connector-packager/connector_packager/version.py
@@ -1,1 +1,2 @@
 __version__ = '0.0.1'
+__min_version_tableau__ = '2019.4'

--- a/connector-packager/tests/test_jar_packager.py
+++ b/connector-packager/tests/test_jar_packager.py
@@ -7,7 +7,6 @@ import xml.etree.ElementTree as ET
 
 from .jar_packager import create_jar
 from connector_packager.jar_jdk_packager import jdk_create_jar
-from connector_packager.jar_jdk_packager import stamp_min_support_version
 from connector_packager.connector_file import ConnectorFile
 from connector_packager.version import __min_version_tableau__
 
@@ -63,7 +62,7 @@ class TestJarPackager(unittest.TestCase):
 
         manifest = ET.parse(path_to_extracted_manifest)
         self.assertEqual(manifest.getroot().get("min-version-tableau"),
-                         __min_version_tableau__,  "wrong min-version-tableau attr or doesn't exist")
+                         __min_version_tableau__, "wrong min-version-tableau attr or doesn't exist")
 
         if dest_dir.exists():
             shutil.rmtree(dest_dir)

--- a/connector-packager/tests/test_jar_packager.py
+++ b/connector-packager/tests/test_jar_packager.py
@@ -1,12 +1,18 @@
 import unittest
 import os.path
 from pathlib import Path
+import subprocess
+import shutil
+import xml.etree.ElementTree as ET
 
 from .jar_packager import create_jar
 from connector_packager.jar_jdk_packager import jdk_create_jar
+from connector_packager.jar_jdk_packager import stamp_min_support_version
 from connector_packager.connector_file import ConnectorFile
+from connector_packager.version import __min_version_tableau__
 
 TEST_FOLDER = Path("tests/test_resources")
+MANIFEST_FILE_NAME = "manifest.xml"
 
 
 class TestJarPackager(unittest.TestCase):
@@ -28,9 +34,8 @@ class TestJarPackager(unittest.TestCase):
         path_to_test_file = dest_dir / Path(package_name)
         self.assertTrue(os.path.isfile(path_to_test_file), "taco file doesn't exist")
 
-        if path_to_test_file.exists():
-            path_to_test_file.unlink()
-
+        if dest_dir.exists():
+            shutil.rmtree(dest_dir)
 
     def test_jdk_create_jar(self):
         files_list = [
@@ -49,5 +54,16 @@ class TestJarPackager(unittest.TestCase):
         path_to_test_file = dest_dir / Path(package_name)
         self.assertTrue(os.path.isfile(path_to_test_file), "taco file doesn't exist")
 
-        if path_to_test_file.exists():
-            path_to_test_file.unlink()
+        # test min support tableau version is stamped
+        args = ["jar", "xf", package_name, MANIFEST_FILE_NAME]
+        p = subprocess.Popen(args, cwd=os.path.abspath(dest_dir))
+        self.assertEqual(p.wait(), 0, "can not extract manfifest file from taco")
+        path_to_extracted_manifest = dest_dir / MANIFEST_FILE_NAME
+        self.assertTrue(os.path.isfile(path_to_extracted_manifest), "extracted manifest file doesn't exist")
+
+        manifest = ET.parse(path_to_extracted_manifest)
+        self.assertEqual(manifest.getroot().get("min-version-tableau"),
+                         __min_version_tableau__,  "wrong min-version-tableau attr or doesn't exist")
+
+        if dest_dir.exists():
+            shutil.rmtree(dest_dir)


### PR DESCRIPTION
Stamp min support tableau version while packaging(updated)
- Do the stamping after packaging
- Make a copy of the original manifest file, after packaging, recover it to keep original manifest unchanged 

Test it: 
py -3 -m connector_packager.package tests\test_resources\valid_connector --package-only
