### PR TITLE
TFSID: 952729 - [TDVT][Alibaba] Update TDVT to take custom value for timeout

### DIFF
--- a/tdvt/tdvt/config/tdvt/tdvt.ini
+++ b/tdvt/tdvt/config/tdvt/tdvt.ini
@@ -1,3 +1,3 @@
 [DEFAULT]
-TAB_CLI_EXE_X64 = C:/Program Files/Tableau/Tableau 2019.1/bin/tabquerytool.exe
-TAB_CLI_EXE_MAC = /Applications/Tableau 2019.1.app/Contents/MacOs/tabquerytool
+TAB_CLI_EXE_X64 = C:/Program Files/Tableau/Tableau 2019.2/bin/tabquerytool.exe
+TAB_CLI_EXE_MAC = /Applications/Tableau 2019.2.app/Contents/MacOs/tabquerytool

--- a/tdvt/tdvt/config/tdvt/tdvt.ini
+++ b/tdvt/tdvt/config/tdvt/tdvt.ini
@@ -1,3 +1,3 @@
 [DEFAULT]
 TAB_CLI_EXE_X64 = C:/Program Files/Tableau/Tableau 2019.2/bin/tabquerytool.exe
-TAB_CLI_EXE_MAC = /Applications/Tableau 2019.2.app/Contents/MacOs/tabquerytool
+TAB_CLI_EXE_MAC = /Applications/Tableau 2019.2.app/Contents/MacOS/tabquerytool

--- a/tdvt/tdvt/config_gen/datasource_list.py
+++ b/tdvt/tdvt/config_gen/datasource_list.py
@@ -1,5 +1,6 @@
 """
     Register datasources for use with TDVT runner.
+
 """
 
 import configparser
@@ -100,28 +101,38 @@ def load_test(config, test_dir=get_root_dir()):
     Name = bigquery
     LogicalQueryFormat = bool_
     CommandLineOverride =
+
     [StandardTests]
     LogicalExclusions_Calcs =
     LogicalExclusions_Staples = Filter.Trademark
     ExpressionExclusions_Standard = string.char,dateparse
+
     [LODTests]
     LogicalExclusions_Staples =
     ExpressionExclusions_Calcs =
+
     [StaplesDataTest]
+
     [UnionTest]
+
     [MedianTests]
+
     [PercentileTests]
+
     [NewExpressionTest1]
     Name = expression_test_dates.
     TDS = cast_calcs.bigquery_sql_dates.tds
     Exclusions = string.ascii
     TestPath = exprtests/standard/
+
     [NewExpressionTest2]
     SmokeTest = True  # tests are treated as smoke tests if SmokeTest = True
     Enabled = False # If set to False, the test is marked `D`, not run, and counted as a fail.
+    
     [LogicalConfig]
     Name = mydb_config
     key = value
+
     [ConnectionTests]
     CastCalcsTestEnabled = True  # by default these two values are True; set `False` if disabling a test.
     StaplesTestEnabled = False

--- a/tdvt/tdvt/config_gen/datasource_list.py
+++ b/tdvt/tdvt/config_gen/datasource_list.py
@@ -45,7 +45,8 @@ def print_configurations(ds_reg, dsname, verbose):
         elif len(ds_to_run) == 0:
             pass
         else:
-            print("\nDatasource suite " + dsname + " is " + ",".join(ds_to_run))
+            print("\nDatasource suite " + dsname +
+                  " is " + ",".join(ds_to_run))
             if verbose:
                 for ds in ds_to_run:
                     print_ds(ds, ds_reg)
@@ -163,8 +164,9 @@ def load_test(config, test_dir=get_root_dir()):
     dsconfig = config[datasource_section]
     all_ini_sections.remove(datasource_section)
     config_name = dsconfig['Name']
-    test_config = TestConfig(config_name, dsconfig['LogicalQueryFormat'], dsconfig.get('MaxThread', '0'),
-                             dsconfig.get('MaxSubThread', '0'), dsconfig.get('CommandLineOverride', ''),
+    test_config = TestConfig(config_name, dsconfig.getint('TimeoutSeconds', 60 * 60), dsconfig['LogicalQueryFormat'], dsconfig.get('MaxThread', '0'),
+                             dsconfig.get('MaxSubThread', '0'), dsconfig.get(
+                                 'CommandLineOverride', ''),
                              dsconfig.getboolean('RunAsPerf', False))
 
     # Add the standard test suites.
@@ -174,17 +176,23 @@ def load_test(config, test_dir=get_root_dir()):
             all_ini_sections.remove(standard_tests)
 
             test_config.add_logical_test('logical.calcs.', CALCS_TDS, standard.get('LogicalExclusions_Calcs', ''),
-                                         test_config.get_logical_test_path('logicaltests/setup/calcs/setup.*.'),
-                                         test_dir, get_password_file(standard), get_expected_message(standard),
+                                         test_config.get_logical_test_path(
+                                             'logicaltests/setup/calcs/setup.*.'),
+                                         test_dir, get_password_file(
+                                             standard), get_expected_message(standard),
                                          get_is_smoke_test(standard), get_is_test_enabled(standard), False)
             test_config.add_logical_test('logical.staples.', STAPLES_TDS, standard.get('LogicalExclusions_Staples', ''),
-                                         test_config.get_logical_test_path('logicaltests/setup/staples/setup.*.'),
-                                         test_dir, get_password_file(standard), get_expected_message(standard),
+                                         test_config.get_logical_test_path(
+                                             'logicaltests/setup/staples/setup.*.'),
+                                         test_dir, get_password_file(
+                                             standard), get_expected_message(standard),
                                          get_is_smoke_test(standard), get_is_test_enabled(standard), False)
             test_config.add_expression_test('expression.standard.', CALCS_TDS,
-                                            standard.get('ExpressionExclusions_Standard', ''),
+                                            standard.get(
+                                                'ExpressionExclusions_Standard', ''),
                                             'exprtests/standard/setup.*.txt',
-                                            test_dir, get_password_file(standard), get_expected_message(standard),
+                                            test_dir, get_password_file(
+                                                standard), get_expected_message(standard),
                                             get_is_smoke_test(standard), get_is_test_enabled(standard), False)
         except KeyError as e:
             logging.debug(e)
@@ -196,12 +204,16 @@ def load_test(config, test_dir=get_root_dir()):
             lod = config[lod_tests]
             all_ini_sections.remove(lod_tests)
             test_config.add_logical_test('logical.lod.', STAPLES_TDS, lod.get('LogicalExclusions_Staples', ''),
-                                         test_config.get_logical_test_path('logicaltests/setup/lod/setup.*.'), test_dir,
-                                         get_password_file(lod), get_expected_message(lod), get_is_smoke_test(lod),
+                                         test_config.get_logical_test_path(
+                                             'logicaltests/setup/lod/setup.*.'), test_dir,
+                                         get_password_file(lod), get_expected_message(
+                                             lod), get_is_smoke_test(lod),
                                          get_is_test_enabled(lod), False)
             test_config.add_expression_test('expression.lod.', CALCS_TDS, lod.get('ExpressionExclusions_Calcs', ''),
-                                            'exprtests/lodcalcs/setup.*.txt', test_dir, get_password_file(lod),
-                                            get_expected_message(lod), get_is_smoke_test(lod), get_is_test_enabled(lod),
+                                            'exprtests/lodcalcs/setup.*.txt', test_dir, get_password_file(
+                                                lod),
+                                            get_expected_message(lod), get_is_smoke_test(
+                                                lod), get_is_test_enabled(lod),
                                             False)
         except KeyError as e:
             logging.debug(e)
@@ -213,8 +225,10 @@ def load_test(config, test_dir=get_root_dir()):
             staples_data = config[staples_data_test]
             all_ini_sections.remove(staples_data_test)
             test_config.add_expression_test('expression.staples.', STAPLES_TDS, '', 'exprtests/staples/setup.*.txt',
-                                            test_dir, get_password_file(staples_data),
-                                            get_expected_message(staples_data), get_is_smoke_test(staples_data),
+                                            test_dir, get_password_file(
+                                                staples_data),
+                                            get_expected_message(
+                                                staples_data), get_is_smoke_test(staples_data),
                                             get_is_test_enabled(staples_data), False)
         except KeyError as e:
             logging.debug(e)
@@ -226,8 +240,10 @@ def load_test(config, test_dir=get_root_dir()):
             union = config[union_test]
             all_ini_sections.remove(union_test)
             test_config.add_logical_test('logical.union.', CALCS_TDS, '',
-                                         test_config.get_logical_test_path('logicaltests/setup/union/setup.*.'),
-                                         test_dir, get_password_file(union), get_expected_message(union),
+                                         test_config.get_logical_test_path(
+                                             'logicaltests/setup/union/setup.*.'),
+                                         test_dir, get_password_file(
+                                             union), get_expected_message(union),
                                          get_is_smoke_test(union), get_is_test_enabled(union), False)
         except KeyError as e:
             logging.debug(e)
@@ -239,8 +255,10 @@ def load_test(config, test_dir=get_root_dir()):
             regex = config[regex_test]
             all_ini_sections.remove(regex_test)
             test_config.add_expression_test('expression.regex.', CALCS_TDS, regex.get(KEY_EXCLUSIONS, ''),
-                                            'exprtests/regexcalcs', test_dir, get_password_file(regex),
-                                            get_expected_message(regex), get_is_smoke_test(regex),
+                                            'exprtests/regexcalcs', test_dir, get_password_file(
+                                                regex),
+                                            get_expected_message(
+                                                regex), get_is_smoke_test(regex),
                                             get_is_test_enabled(regex), False)
         except KeyError as e:
             logging.debug(e)
@@ -252,8 +270,10 @@ def load_test(config, test_dir=get_root_dir()):
             median = config[median_test]
             all_ini_sections.remove(median_test)
             test_config.add_expression_test('expression.median.', CALCS_TDS, median.get(KEY_EXCLUSIONS, ''),
-                                            'exprtests/median', test_dir, get_password_file(median),
-                                            get_expected_message(median), get_is_smoke_test(median),
+                                            'exprtests/median', test_dir, get_password_file(
+                                                median),
+                                            get_expected_message(
+                                                median), get_is_smoke_test(median),
                                             get_is_test_enabled(median), False)
         except KeyError as e:
             logging.debug(e)
@@ -265,8 +285,10 @@ def load_test(config, test_dir=get_root_dir()):
             percentile = config[percentile_test]
             all_ini_sections.remove(percentile_test)
             test_config.add_expression_test('expression.percentile.', CALCS_TDS, percentile.get(KEY_EXCLUSIONS, ''),
-                                            'exprtests/percentile', test_dir, get_password_file(percentile),
-                                            get_expected_message(percentile), get_is_smoke_test(percentile),
+                                            'exprtests/percentile', test_dir, get_password_file(
+                                                percentile),
+                                            get_expected_message(
+                                                percentile), get_is_smoke_test(percentile),
                                             get_is_test_enabled(percentile), False)
         except KeyError as e:
             logging.debug(e)
@@ -299,8 +321,10 @@ def load_test(config, test_dir=get_root_dir()):
             try:
                 all_ini_sections.remove(section)
                 test_config.add_expression_test(sect.get('Name', ''), tds_name, sect.get(KEY_EXCLUSIONS, ''),
-                                                sect.get('TestPath', ''), test_dir, get_password_file(sect),
-                                                get_expected_message(sect), get_is_smoke_test(sect),
+                                                sect.get('TestPath', ''), test_dir, get_password_file(
+                                                    sect),
+                                                get_expected_message(
+                                                    sect), get_is_smoke_test(sect),
                                                 get_is_test_enabled(sect), False)
             except KeyError as e:
                 logging.debug(e)
@@ -311,8 +335,10 @@ def load_test(config, test_dir=get_root_dir()):
             try:
                 all_ini_sections.remove(section)
                 test_config.add_logical_test(sect.get('Name', ''), tds_name, sect.get(KEY_EXCLUSIONS, ''),
-                                             sect.get('TestPath', ''), test_dir, get_password_file(sect),
-                                             get_expected_message(sect), get_is_smoke_test(sect),
+                                             sect.get('TestPath', ''), test_dir, get_password_file(
+                                                 sect),
+                                             get_expected_message(
+                                                 sect), get_is_smoke_test(sect),
                                              get_is_test_enabled(sect), False)
             except KeyError as e:
                 logging.debug(e)
@@ -325,11 +351,15 @@ def load_test(config, test_dir=get_root_dir()):
                 all_ini_sections.remove(section)
                 test_config.add_expression_test('StaplesConnectionTest', STAPLES_TDS, sect.get(KEY_EXCLUSIONS, ''),
                                                 test_path + 'staples/setup.staples_connection.txt', test_dir,
-                                                get_password_file(sect), get_expected_message(sect),  True,
+                                                get_password_file(
+                                                    sect), get_expected_message(sect),  True,
                                                 get_is_test_enabled(sect, 'StaplesTestEnabled'), False)
                 test_config.add_expression_test('CastCalcsConnectionTest', CALCS_TDS, sect.get(KEY_EXCLUSIONS, ''),
-                                                test_path + 'setup.calcs_key.txt', test_dir, get_password_file(sect),
-                                                get_expected_message(sect), True,
+                                                test_path +
+                                                'setup.calcs_key.txt', test_dir, get_password_file(
+                                                    sect),
+                                                get_expected_message(
+                                                    sect), True,
                                                 get_is_test_enabled(sect, 'CastCalcsTestEnabled'), False)
             except KeyError as e:
                 logging.debug(e)
@@ -370,8 +400,10 @@ class TestRegistry(object):
 
     def load_ini_file(self, ini_file):
         # Create the test suites (groups of datasources to test)
-        registry_ini_file = get_ini_path_local_first('config/registry', ini_file)
-        logging.debug("Reading registry ini file [{}]".format(registry_ini_file))
+        registry_ini_file = get_ini_path_local_first(
+            'config/registry', ini_file)
+        logging.debug(
+            "Reading registry ini file [{}]".format(registry_ini_file))
         self.load_registry(registry_ini_file)
 
     def load_registry(self, registry_ini_file):
@@ -381,7 +413,8 @@ class TestRegistry(object):
             ds = config['DatasourceRegistry']
 
             for suite_name in ds:
-                self.suite_map[suite_name] = self.interpret_ds_list(ds[suite_name], False).split(',')
+                self.suite_map[suite_name] = self.interpret_ds_list(
+                    ds[suite_name], False).split(',')
 
         except KeyError:
             # Create a simple default.
@@ -407,7 +440,8 @@ class TestRegistry(object):
         for ds in suite.split(','):
             ds = ds.strip()
             if ds in self.suite_map:
-                ds_to_run.extend(self.get_datasources(','.join(self.suite_map[ds])))
+                ds_to_run.extend(self.get_datasources(
+                    ','.join(self.suite_map[ds])))
             elif ds:
                 ds_to_run.append(ds)
 

--- a/tdvt/tdvt/config_gen/datasource_list.py
+++ b/tdvt/tdvt/config_gen/datasource_list.py
@@ -128,7 +128,7 @@ def load_test(config, test_dir=get_root_dir()):
     [NewExpressionTest2]
     SmokeTest = True  # tests are treated as smoke tests if SmokeTest = True
     Enabled = False # If set to False, the test is marked `D`, not run, and counted as a fail.
-    
+
     [LogicalConfig]
     Name = mydb_config
     key = value
@@ -136,6 +136,7 @@ def load_test(config, test_dir=get_root_dir()):
     [ConnectionTests]
     CastCalcsTestEnabled = True  # by default these two values are True; set `False` if disabling a test.
     StaplesTestEnabled = False
+
     """
     CALCS_TDS = 'cast_calcs.'
     STAPLES_TDS = 'Staples.'

--- a/tdvt/tdvt/config_gen/datasource_list.py
+++ b/tdvt/tdvt/config_gen/datasource_list.py
@@ -434,4 +434,3 @@ class LinuxRegistry(TestRegistry):
 
     def __init__(self):
         super(LinuxRegistry, self).__init__('linux')
-        

--- a/tdvt/tdvt/config_gen/datasource_list.py
+++ b/tdvt/tdvt/config_gen/datasource_list.py
@@ -163,9 +163,8 @@ def load_test(config, test_dir=get_root_dir()):
     dsconfig = config[datasource_section]
     all_ini_sections.remove(datasource_section)
     config_name = dsconfig['Name']
-    test_config = TestConfig(config_name, dsconfig.getint('TimeoutSeconds', 60 * 60) , dsconfig['LogicalQueryFormat'], dsconfig.get('MaxThread', '0'),
-                             dsconfig.get('MaxSubThread', '0'), dsconfig.get('CommandLineOverride', ''),
-                             dsconfig.getboolean('RunAsPerf', False))
+    test_config = TestConfig(config_name, dsconfig.getint('TimeoutSeconds', 60 * 60), dsconfig['LogicalQueryFormat'], dsconfig.get('MaxThread', '0'),
+                             dsconfig.get('MaxSubThread', '0'), dsconfig.get('CommandLineOverride', ''), dsconfig.getboolean('RunAsPerf', False))
 
     # Add the standard test suites.
     if standard_tests in config.sections():
@@ -435,3 +434,4 @@ class LinuxRegistry(TestRegistry):
 
     def __init__(self):
         super(LinuxRegistry, self).__init__('linux')
+        

--- a/tdvt/tdvt/config_gen/datasource_list.py
+++ b/tdvt/tdvt/config_gen/datasource_list.py
@@ -1,6 +1,5 @@
 """
     Register datasources for use with TDVT runner.
-
 """
 
 import configparser
@@ -45,8 +44,7 @@ def print_configurations(ds_reg, dsname, verbose):
         elif len(ds_to_run) == 0:
             pass
         else:
-            print("\nDatasource suite " + dsname +
-                  " is " + ",".join(ds_to_run))
+            print("\nDatasource suite " + dsname + " is " + ",".join(ds_to_run))
             if verbose:
                 for ds in ds_to_run:
                     print_ds(ds, ds_reg)
@@ -102,42 +100,31 @@ def load_test(config, test_dir=get_root_dir()):
     Name = bigquery
     LogicalQueryFormat = bool_
     CommandLineOverride =
-
     [StandardTests]
     LogicalExclusions_Calcs =
     LogicalExclusions_Staples = Filter.Trademark
     ExpressionExclusions_Standard = string.char,dateparse
-
     [LODTests]
     LogicalExclusions_Staples =
     ExpressionExclusions_Calcs =
-
     [StaplesDataTest]
-
     [UnionTest]
-
     [MedianTests]
-
     [PercentileTests]
-
     [NewExpressionTest1]
     Name = expression_test_dates.
     TDS = cast_calcs.bigquery_sql_dates.tds
     Exclusions = string.ascii
     TestPath = exprtests/standard/
-
     [NewExpressionTest2]
     SmokeTest = True  # tests are treated as smoke tests if SmokeTest = True
     Enabled = False # If set to False, the test is marked `D`, not run, and counted as a fail.
-
     [LogicalConfig]
     Name = mydb_config
     key = value
-
     [ConnectionTests]
     CastCalcsTestEnabled = True  # by default these two values are True; set `False` if disabling a test.
     StaplesTestEnabled = False
-
     """
     CALCS_TDS = 'cast_calcs.'
     STAPLES_TDS = 'Staples.'
@@ -164,9 +151,8 @@ def load_test(config, test_dir=get_root_dir()):
     dsconfig = config[datasource_section]
     all_ini_sections.remove(datasource_section)
     config_name = dsconfig['Name']
-    test_config = TestConfig(config_name, dsconfig.getint('TimeoutSeconds', 60 * 60), dsconfig['LogicalQueryFormat'], dsconfig.get('MaxThread', '0'),
-                             dsconfig.get('MaxSubThread', '0'), dsconfig.get(
-                                 'CommandLineOverride', ''),
+    test_config = TestConfig(config_name, dsconfig.getint('TimeoutSeconds', 60 * 60) , dsconfig['LogicalQueryFormat'], dsconfig.get('MaxThread', '0'),
+                             dsconfig.get('MaxSubThread', '0'), dsconfig.get('CommandLineOverride', ''),
                              dsconfig.getboolean('RunAsPerf', False))
 
     # Add the standard test suites.
@@ -176,23 +162,17 @@ def load_test(config, test_dir=get_root_dir()):
             all_ini_sections.remove(standard_tests)
 
             test_config.add_logical_test('logical.calcs.', CALCS_TDS, standard.get('LogicalExclusions_Calcs', ''),
-                                         test_config.get_logical_test_path(
-                                             'logicaltests/setup/calcs/setup.*.'),
-                                         test_dir, get_password_file(
-                                             standard), get_expected_message(standard),
+                                         test_config.get_logical_test_path('logicaltests/setup/calcs/setup.*.'),
+                                         test_dir, get_password_file(standard), get_expected_message(standard),
                                          get_is_smoke_test(standard), get_is_test_enabled(standard), False)
             test_config.add_logical_test('logical.staples.', STAPLES_TDS, standard.get('LogicalExclusions_Staples', ''),
-                                         test_config.get_logical_test_path(
-                                             'logicaltests/setup/staples/setup.*.'),
-                                         test_dir, get_password_file(
-                                             standard), get_expected_message(standard),
+                                         test_config.get_logical_test_path('logicaltests/setup/staples/setup.*.'),
+                                         test_dir, get_password_file(standard), get_expected_message(standard),
                                          get_is_smoke_test(standard), get_is_test_enabled(standard), False)
             test_config.add_expression_test('expression.standard.', CALCS_TDS,
-                                            standard.get(
-                                                'ExpressionExclusions_Standard', ''),
+                                            standard.get('ExpressionExclusions_Standard', ''),
                                             'exprtests/standard/setup.*.txt',
-                                            test_dir, get_password_file(
-                                                standard), get_expected_message(standard),
+                                            test_dir, get_password_file(standard), get_expected_message(standard),
                                             get_is_smoke_test(standard), get_is_test_enabled(standard), False)
         except KeyError as e:
             logging.debug(e)
@@ -204,16 +184,12 @@ def load_test(config, test_dir=get_root_dir()):
             lod = config[lod_tests]
             all_ini_sections.remove(lod_tests)
             test_config.add_logical_test('logical.lod.', STAPLES_TDS, lod.get('LogicalExclusions_Staples', ''),
-                                         test_config.get_logical_test_path(
-                                             'logicaltests/setup/lod/setup.*.'), test_dir,
-                                         get_password_file(lod), get_expected_message(
-                                             lod), get_is_smoke_test(lod),
+                                         test_config.get_logical_test_path('logicaltests/setup/lod/setup.*.'), test_dir,
+                                         get_password_file(lod), get_expected_message(lod), get_is_smoke_test(lod),
                                          get_is_test_enabled(lod), False)
             test_config.add_expression_test('expression.lod.', CALCS_TDS, lod.get('ExpressionExclusions_Calcs', ''),
-                                            'exprtests/lodcalcs/setup.*.txt', test_dir, get_password_file(
-                                                lod),
-                                            get_expected_message(lod), get_is_smoke_test(
-                                                lod), get_is_test_enabled(lod),
+                                            'exprtests/lodcalcs/setup.*.txt', test_dir, get_password_file(lod),
+                                            get_expected_message(lod), get_is_smoke_test(lod), get_is_test_enabled(lod),
                                             False)
         except KeyError as e:
             logging.debug(e)
@@ -225,10 +201,8 @@ def load_test(config, test_dir=get_root_dir()):
             staples_data = config[staples_data_test]
             all_ini_sections.remove(staples_data_test)
             test_config.add_expression_test('expression.staples.', STAPLES_TDS, '', 'exprtests/staples/setup.*.txt',
-                                            test_dir, get_password_file(
-                                                staples_data),
-                                            get_expected_message(
-                                                staples_data), get_is_smoke_test(staples_data),
+                                            test_dir, get_password_file(staples_data),
+                                            get_expected_message(staples_data), get_is_smoke_test(staples_data),
                                             get_is_test_enabled(staples_data), False)
         except KeyError as e:
             logging.debug(e)
@@ -240,10 +214,8 @@ def load_test(config, test_dir=get_root_dir()):
             union = config[union_test]
             all_ini_sections.remove(union_test)
             test_config.add_logical_test('logical.union.', CALCS_TDS, '',
-                                         test_config.get_logical_test_path(
-                                             'logicaltests/setup/union/setup.*.'),
-                                         test_dir, get_password_file(
-                                             union), get_expected_message(union),
+                                         test_config.get_logical_test_path('logicaltests/setup/union/setup.*.'),
+                                         test_dir, get_password_file(union), get_expected_message(union),
                                          get_is_smoke_test(union), get_is_test_enabled(union), False)
         except KeyError as e:
             logging.debug(e)
@@ -255,10 +227,8 @@ def load_test(config, test_dir=get_root_dir()):
             regex = config[regex_test]
             all_ini_sections.remove(regex_test)
             test_config.add_expression_test('expression.regex.', CALCS_TDS, regex.get(KEY_EXCLUSIONS, ''),
-                                            'exprtests/regexcalcs', test_dir, get_password_file(
-                                                regex),
-                                            get_expected_message(
-                                                regex), get_is_smoke_test(regex),
+                                            'exprtests/regexcalcs', test_dir, get_password_file(regex),
+                                            get_expected_message(regex), get_is_smoke_test(regex),
                                             get_is_test_enabled(regex), False)
         except KeyError as e:
             logging.debug(e)
@@ -270,10 +240,8 @@ def load_test(config, test_dir=get_root_dir()):
             median = config[median_test]
             all_ini_sections.remove(median_test)
             test_config.add_expression_test('expression.median.', CALCS_TDS, median.get(KEY_EXCLUSIONS, ''),
-                                            'exprtests/median', test_dir, get_password_file(
-                                                median),
-                                            get_expected_message(
-                                                median), get_is_smoke_test(median),
+                                            'exprtests/median', test_dir, get_password_file(median),
+                                            get_expected_message(median), get_is_smoke_test(median),
                                             get_is_test_enabled(median), False)
         except KeyError as e:
             logging.debug(e)
@@ -285,10 +253,8 @@ def load_test(config, test_dir=get_root_dir()):
             percentile = config[percentile_test]
             all_ini_sections.remove(percentile_test)
             test_config.add_expression_test('expression.percentile.', CALCS_TDS, percentile.get(KEY_EXCLUSIONS, ''),
-                                            'exprtests/percentile', test_dir, get_password_file(
-                                                percentile),
-                                            get_expected_message(
-                                                percentile), get_is_smoke_test(percentile),
+                                            'exprtests/percentile', test_dir, get_password_file(percentile),
+                                            get_expected_message(percentile), get_is_smoke_test(percentile),
                                             get_is_test_enabled(percentile), False)
         except KeyError as e:
             logging.debug(e)
@@ -321,10 +287,8 @@ def load_test(config, test_dir=get_root_dir()):
             try:
                 all_ini_sections.remove(section)
                 test_config.add_expression_test(sect.get('Name', ''), tds_name, sect.get(KEY_EXCLUSIONS, ''),
-                                                sect.get('TestPath', ''), test_dir, get_password_file(
-                                                    sect),
-                                                get_expected_message(
-                                                    sect), get_is_smoke_test(sect),
+                                                sect.get('TestPath', ''), test_dir, get_password_file(sect),
+                                                get_expected_message(sect), get_is_smoke_test(sect),
                                                 get_is_test_enabled(sect), False)
             except KeyError as e:
                 logging.debug(e)
@@ -335,10 +299,8 @@ def load_test(config, test_dir=get_root_dir()):
             try:
                 all_ini_sections.remove(section)
                 test_config.add_logical_test(sect.get('Name', ''), tds_name, sect.get(KEY_EXCLUSIONS, ''),
-                                             sect.get('TestPath', ''), test_dir, get_password_file(
-                                                 sect),
-                                             get_expected_message(
-                                                 sect), get_is_smoke_test(sect),
+                                             sect.get('TestPath', ''), test_dir, get_password_file(sect),
+                                             get_expected_message(sect), get_is_smoke_test(sect),
                                              get_is_test_enabled(sect), False)
             except KeyError as e:
                 logging.debug(e)
@@ -351,15 +313,11 @@ def load_test(config, test_dir=get_root_dir()):
                 all_ini_sections.remove(section)
                 test_config.add_expression_test('StaplesConnectionTest', STAPLES_TDS, sect.get(KEY_EXCLUSIONS, ''),
                                                 test_path + 'staples/setup.staples_connection.txt', test_dir,
-                                                get_password_file(
-                                                    sect), get_expected_message(sect),  True,
+                                                get_password_file(sect), get_expected_message(sect),  True,
                                                 get_is_test_enabled(sect, 'StaplesTestEnabled'), False)
                 test_config.add_expression_test('CastCalcsConnectionTest', CALCS_TDS, sect.get(KEY_EXCLUSIONS, ''),
-                                                test_path +
-                                                'setup.calcs_key.txt', test_dir, get_password_file(
-                                                    sect),
-                                                get_expected_message(
-                                                    sect), True,
+                                                test_path + 'setup.calcs_key.txt', test_dir, get_password_file(sect),
+                                                get_expected_message(sect), True,
                                                 get_is_test_enabled(sect, 'CastCalcsTestEnabled'), False)
             except KeyError as e:
                 logging.debug(e)
@@ -400,10 +358,8 @@ class TestRegistry(object):
 
     def load_ini_file(self, ini_file):
         # Create the test suites (groups of datasources to test)
-        registry_ini_file = get_ini_path_local_first(
-            'config/registry', ini_file)
-        logging.debug(
-            "Reading registry ini file [{}]".format(registry_ini_file))
+        registry_ini_file = get_ini_path_local_first('config/registry', ini_file)
+        logging.debug("Reading registry ini file [{}]".format(registry_ini_file))
         self.load_registry(registry_ini_file)
 
     def load_registry(self, registry_ini_file):
@@ -413,8 +369,7 @@ class TestRegistry(object):
             ds = config['DatasourceRegistry']
 
             for suite_name in ds:
-                self.suite_map[suite_name] = self.interpret_ds_list(
-                    ds[suite_name], False).split(',')
+                self.suite_map[suite_name] = self.interpret_ds_list(ds[suite_name], False).split(',')
 
         except KeyError:
             # Create a simple default.
@@ -440,8 +395,7 @@ class TestRegistry(object):
         for ds in suite.split(','):
             ds = ds.strip()
             if ds in self.suite_map:
-                ds_to_run.extend(self.get_datasources(
-                    ','.join(self.suite_map[ds])))
+                ds_to_run.extend(self.get_datasources(','.join(self.suite_map[ds])))
             elif ds:
                 ds_to_run.append(ds)
 

--- a/tdvt/tdvt/config_gen/tdvtconfig.py
+++ b/tdvt/tdvt/config_gen/tdvtconfig.py
@@ -7,11 +7,12 @@ from ..resources import *
 
 class TdvtTestConfig(object):
     """Track how items were tested. This captures how tdvt was invoked."""
-    def __init__(self, tested_sql = False, tested_tuples = True, tds = '', config = '', output_dir = '', logical = False, verbose = False, override = '', suite_name = '', from_args = None, thread_count = 6, from_json = None, run_as_perf = False):
+    def __init__(self, tested_sql = False, timeout_seconds = 60 * 60,tested_tuples = True, tds = '', config = '', output_dir = '', logical = False, verbose = False, override = '', suite_name = '', from_args = None, thread_count = 6, from_json = None, run_as_perf = False):
         self.tested_sql = tested_sql
         self.tested_tuples = tested_tuples
         self.log_dir = ''
         self.output_dir = output_dir
+        self.timeout_seconds = timeout_seconds
         self.logical = logical
         self.config_file = config
         self.suite_name = suite_name

--- a/tdvt/tdvt/config_gen/tdvtconfig.py
+++ b/tdvt/tdvt/config_gen/tdvtconfig.py
@@ -7,7 +7,7 @@ from ..resources import *
 
 class TdvtTestConfig(object):
     """Track how items were tested. This captures how tdvt was invoked."""
-    def __init__(self, tested_sql = False, timeout_seconds = 60 * 60,tested_tuples = True, tds = '', config = '', output_dir = '', logical = False, verbose = False, override = '', suite_name = '', from_args = None, thread_count = 6, from_json = None, run_as_perf = False):
+    def __init__(self, tested_sql = False,tested_tuples = True, tds = '', config = '', output_dir = '', logical = False, verbose = False, override = '', suite_name = '', from_args = None, thread_count = 6, from_json = None, run_as_perf = False, timeout_seconds = 60 * 60):
         self.tested_sql = tested_sql
         self.tested_tuples = tested_tuples
         self.log_dir = ''

--- a/tdvt/tdvt/config_gen/tdvtconfig.py
+++ b/tdvt/tdvt/config_gen/tdvtconfig.py
@@ -7,7 +7,7 @@ from ..resources import *
 
 class TdvtTestConfig(object):
     """Track how items were tested. This captures how tdvt was invoked."""
-    def __init__(self, tested_sql = False,tested_tuples = True, tds = '', config = '', output_dir = '', logical = False, verbose = False, override = '', suite_name = '', from_args = None, thread_count = 6, from_json = None, run_as_perf = False, timeout_seconds = 60 * 60):
+    def __init__(self, tested_sql=False, tested_tuples=True, tds='', config='', output_dir='', logical=False, verbose=False, override='', suite_name='', from_args=None, thread_count=6, from_json=None, run_as_perf=False, timeout_seconds=60 * 60):
         self.tested_sql = tested_sql
         self.tested_tuples = tested_tuples
         self.log_dir = ''

--- a/tdvt/tdvt/config_gen/test_config.py
+++ b/tdvt/tdvt/config_gen/test_config.py
@@ -276,9 +276,6 @@ class TestConfig(object):
     def get_config_name(self, prefix):
         return prefix + self.dsname
 
-    def get_time_out_seconds(self):
-        return self.timeout_seconds
-
     def get_logical_test_path(self, prefix):
         return prefix + self.logical_config_name + '.xml'
 

--- a/tdvt/tdvt/config_gen/test_config.py
+++ b/tdvt/tdvt/config_gen/test_config.py
@@ -254,8 +254,9 @@ class TestConfig(object):
     """
         Defines all the tests that can be run for a single data source. An organized collection of TestSet objects.
     """
-    def __init__(self, dsname, logical_config_name, maxthread, maxsubthread, d_override='', run_as_perf=False):
+    def __init__(self,dsname, timeout_seconds, logical_config_name, maxthread, maxsubthread, d_override='', run_as_perf=False):
         self.dsname = dsname
+        self.timeout_seconds = timeout_seconds
         self.logical_config_name = logical_config_name
         self.calcs_tds = self.get_tds_name('cast_calcs.')
         self.staples_tds = self.get_tds_name('Staples.')
@@ -274,6 +275,9 @@ class TestConfig(object):
 
     def get_config_name(self, prefix):
         return prefix + self.dsname
+
+    def get_time_out_seconds(self):
+        return self.timeout_seconds
 
     def get_logical_test_path(self, prefix):
         return prefix + self.logical_config_name + '.xml'

--- a/tdvt/tdvt/config_gen/test_config.py
+++ b/tdvt/tdvt/config_gen/test_config.py
@@ -254,7 +254,7 @@ class TestConfig(object):
     """
         Defines all the tests that can be run for a single data source. An organized collection of TestSet objects.
     """
-    def __init__(self,dsname, timeout_seconds, logical_config_name, maxthread, maxsubthread, d_override='', run_as_perf=False):
+    def __init__(self, dsname, timeout_seconds, logical_config_name, maxthread, maxsubthread, d_override='', run_as_perf=False):
         self.dsname = dsname
         self.timeout_seconds = timeout_seconds
         self.logical_config_name = logical_config_name

--- a/tdvt/tdvt/config_gen/test_config.py
+++ b/tdvt/tdvt/config_gen/test_config.py
@@ -254,7 +254,8 @@ class TestConfig(object):
     """
         Defines all the tests that can be run for a single data source. An organized collection of TestSet objects.
     """
-    def __init__(self, dsname, timeout_seconds, logical_config_name, maxthread, maxsubthread, d_override='', run_as_perf=False):
+    def __init__(self, dsname, timeout_seconds, logical_config_name, maxthread, maxsubthread, d_override='', 
+                 run_as_perf=False):
         self.dsname = dsname
         self.timeout_seconds = timeout_seconds
         self.logical_config_name = logical_config_name

--- a/tdvt/tdvt/tdvt.py
+++ b/tdvt/tdvt/tdvt.py
@@ -218,6 +218,7 @@ def enqueue_single_test(args, ds_info, suite):
 
     test_config = TdvtTestConfig(from_args=args)
     test_config.suite_name = suite
+    test_config.timeout_seconds = ds_info.timeout_seconds
     test_config.logical = test_set.is_logical_test()
     test_config.d_override = ds_info.d_override
     test_config.run_as_perf = ds_info.run_as_perf
@@ -324,6 +325,7 @@ def enqueue_tests(ds_info, args, suite):
 
     for test_set in tests:
         test_config = TdvtTestConfig(from_args=args)
+        test_config.timeout_seconds = ds_info.timeout_seconds
         test_config.suite_name = suite
         test_config.logical = test_set.is_logical_test()
         test_config.d_override = ds_info.d_override

--- a/tdvt/tdvt/tdvt_core.py
+++ b/tdvt/tdvt/tdvt_core.py
@@ -50,7 +50,7 @@ class BatchQueueWork(object):
         self.test_set = test_set
         self.results = {}
         self.thread_id = -1
-        self.timeout_seconds = 60 * 60
+        self.timeout_seconds = test_config.timeout_seconds
         self.cmd_output = None
         self.saved_error_message = None
         self.log_zip_file = ''


### PR DESCRIPTION
Added custom timeout seconds feature in tdvt by updating the config file(ini) for a particular plugin.
To set the custom time out in seconds, you will need to add TimeoutSeconds attribute in [Datasource Section]
For example:
[Datasource]
Name = vertica
LogicalQueryFormat = prefix
CommandLineOverride = -DOverride=ISO8601DateAddDiffYearQtr
TimeoutSeconds = 7200

