### PR TITLE
Remove failed tests if they succeed on retry

### DIFF
--- a/tdvt/tdvt/tdvt.py
+++ b/tdvt/tdvt/tdvt.py
@@ -135,10 +135,10 @@ class TestRunner():
                 existing_results['successful_tests'].extend(results['successful_tests'])
 
                 # Check the newly succeeding tests, and if they are in the existing failed
-                # test list, remove them from the failed test llist since they now succeed
-                for element in results['successful_tests']:                    
+                # test list, remove them from the failed test list since they now succeed
+                for element in results['successful_tests']:
                     for failed in existing_results['failed_tests']:
-                        if element['test_name'] == failed['test_name']:        
+                        if element['test_name'] == failed['test_name']:
                             existing_results['failed_tests'].remove(failed)
 
                 dst_file = open(dst, 'w', encoding='utf8')

--- a/tdvt/tdvt/tdvt.py
+++ b/tdvt/tdvt/tdvt.py
@@ -134,6 +134,13 @@ class TestRunner():
 
                 existing_results['successful_tests'].extend(results['successful_tests'])
 
+                # Check the newly succeeding tests, and if they are in the existing failed
+                # test list, remove them from the failed test llist since they now succeed
+                for element in results['successful_tests']:                    
+                    for failed in existing_results['failed_tests']:
+                        if element['test_name'] == failed['test_name']:        
+                            existing_results['failed_tests'].remove(failed)
+
                 dst_file = open(dst, 'w', encoding='utf8')
                 json.dump(existing_results, dst_file)
                 dst_file.close()


### PR DESCRIPTION
If the test fails in teamcity and succeeds on retry, we will add the test to the successful tests, but not remove it from the failed test list in tdvt_ouput_combined.json. I think this is why teamcity counts the test cases that succeed on retry as failed. This commit will strip out the failed test if it is in the newly succeeding tests.