### PR TITLE
Add initial sql + impersonate attributes to samples

### DIFF
--- a/samples/plugins/mysql_odbc/connectionResolver.tdr
+++ b/samples/plugins/mysql_odbc/connectionResolver.tdr
@@ -6,6 +6,7 @@
     </connection-builder>
     <connection-normalizer>
       <required-attributes>
+        <setImpersonateAttributes/>
         <attribute-list>
           <attr>server</attr>
           <attr>dbname</attr>
@@ -14,6 +15,7 @@
           <attr>port</attr>
           <attr>odbc-connect-string-extras</attr>
           <attr>source-charset</attr>
+          <attr>one-time-sql</attr>
         </attribute-list>
       </required-attributes>
     </connection-normalizer>

--- a/samples/plugins/postgres_jdbc/connectionResolver.tdr
+++ b/samples/plugins/postgres_jdbc/connectionResolver.tdr
@@ -6,12 +6,14 @@
     </connection-builder>
     <connection-normalizer>
       <required-attributes>
+        <setImpersonateAttributes/>
         <attribute-list>
           <attr>server</attr>
           <attr>port</attr>
           <attr>dbname</attr>
           <attr>username</attr>
           <attr>password</attr>
+          <attr>one-time-sql</attr>
         </attribute-list>
       </required-attributes>
     </connection-normalizer>

--- a/samples/plugins/postgres_odbc/connectionResolver.tdr
+++ b/samples/plugins/postgres_odbc/connectionResolver.tdr
@@ -6,12 +6,14 @@
     </connection-builder>
     <connection-normalizer>
       <required-attributes>
+        <setImpersonateAttributes/>
         <attribute-list>
           <attr>server</attr>
           <attr>port</attr>
           <attr>dbname</attr>
           <attr>username</attr>
           <attr>password</attr>
+          <attr>one-time-sql</attr>
         </attribute-list>
       </required-attributes>
     </connection-normalizer>


### PR DESCRIPTION
For the 2019.4 partner-built plugins, this was something I had to add to all of them.