### PR TITLE
Documentation tweaks

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -32,10 +32,6 @@ If your connection is very similar to an existing database such as PostgreSQL or
 
 You might find other super class values in the workbook XML from an existing Tableau connection, but we don't recommend using them; they haven't been tested.
 
-### Features based on superclass
-
-Web Authoring (creating a new connection from the web) is not currently available for all connector superclasses. If your connector is based on 'odbc' or 'jdbc,' then you can publish your workbook or datasource from desktop to server, but you can't create a new connection directly on server. Connectors based on 'mysql_odbc' do support web authoring because this ability is inherited from the mysql code they are based on. 
-
 ## Choosing a dialect
 
 The dialect determines what SQL is generated for various Tableau actions. Choosing the right dialect is a critical part of writing a connector.
@@ -70,7 +66,8 @@ The dialect determines what SQL is generated for various Tableau actions. Choosi
 - VerticaDialect
 
 ### Should I create a dialect definition file?
-You don’t need a dialect definition file if your connector uses the same SQL dialect as the connector it’s based on, such as mysql_odbc. However, to make changes to an existing Tableau dialect or define a new dialect, you’ll need a new dialect definition file. For more information, see [Create a Tableau Dialect Definition (TDD) File]({{ site.baseurl }}/docs/dialect). 
+You don’t need a dialect definition file if your connector uses the same SQL dialect as the connector it’s based on, such as mysql_odbc. However, to make changes to an existing Tableau dialect or define a new dialect, you’ll need a new dialect definition file. For more information, see [Create a Tableau Dialect Definition (TDD) File]({{ site.baseurl }}/docs/dialect).
+**If your connector inherits from 'odbc' or 'jdbc', you must create a dialect definition file.**
 
 ## Setting connection capabilities
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -66,8 +66,7 @@ The dialect determines what SQL is generated for various Tableau actions. Choosi
 - VerticaDialect
 
 ### Should I create a dialect definition file?
-You don’t need a dialect definition file if your connector uses the same SQL dialect as the connector it’s based on, such as mysql_odbc. However, to make changes to an existing Tableau dialect or define a new dialect, you’ll need a new dialect definition file. For more information, see [Create a Tableau Dialect Definition (TDD) File]({{ site.baseurl }}/docs/dialect).
-**If your connector inherits from 'odbc' or 'jdbc', you must create a dialect definition file.**
+If you want to customize the generated SQL, or your connector inherits from 'odbc' or 'jdbc', then you need a dialect file. Without a file, the dialect from the superclass is used. For more information, see [Create a Tableau Dialect Definition (TDD) File]({{ site.baseurl }}/docs/dialect).
 
 ## Setting connection capabilities
 

--- a/docs/example.md
+++ b/docs/example.md
@@ -62,7 +62,7 @@ The Connection Resolver knows how to use these attributes to format an ODBC or J
 
 ![]({{ site.baseurl }}/assets/pce-tdr.png)
 
-## ![4]({{ site.baseurl }}/assets/pce-4.png) connectionBuilder.js
+## ![4]({{ site.baseurl }}/assets/pce-4.png) Connection Builder
 
 The ODBC connection string and the JDBC connection URL are created by calling the Connection Builder script and passing in a map of attributes that define how the connection is configured.
 Some values come from the connection dialog and are entered by the user (like username, password, and database name).
@@ -91,7 +91,7 @@ You may also set any other connection string options that you would like to pass
 })
 ```
 
-## ![5]({{ site.baseurl }}/assets/pce-5.png) connectionProperties.js
+## ![5]({{ site.baseurl }}/assets/pce-5.png) Connection Properties
 
 This script is needed only if you're using a JDBC driver.
 
@@ -124,24 +124,34 @@ This script is needed only if you're using a JDBC driver.
 })
 ```
 
-## ![6]({{ site.baseurl }}/assets/pce-6.png) connectionMatcher.js
+## ![6]({{ site.baseurl }}/assets/pce-6.png) Connection Matcher
 
 This script defines how connections are matched.
 In most cases, the default behavior works, so you don't have to include the <span style= "font-family: courier new">connection-matcher</span> section in your \*.tdr file.
 
-## ![7]({{ site.baseurl }}/assets/pce-7.png) connectionRequired.js
+## ![7]({{ site.baseurl }}/assets/pce-7.png) Connection Normalizer
 
-This script defines what makes up a unique connection. The following values work for most cases.
+The component defines what makes up a unique connection. This can be implemented in javascript or directly in the xml. Writing the required attributes list in the xml is more performant,
+and is recommended for most connectors.
 
 ```
-(function requiredAttrs(attr) {
-    return ["class", "server", "port", "dbname", "username", "password"];
-})
+<required-attributes>
+        <setImpersonateAttributes/>
+        <attribute-list>
+          <attr>server</attr>
+          <attr>port</attr>
+          <attr>dbname</attr>
+          <attr>username</attr>
+          <attr>password</attr>
+          <attr>one-time-sql</attr>
+        </attribute-list>
+</required-attributes>
 ```
+`<setImpersonateAttributes/>` and `<attr>one-time-sql</attr>` add support for impersonate attributes and initial sql respectively, and should be in every connector.
 
 ## ![8]({{ site.baseurl }}/assets/pce-8.png) Example connection
 
-The Tableau Connection Resolver file (\*.tdr) generates an ODBC ConnectString or a JDBC Connection URL, which you can find in tabprotosvr.txt.
+The Tableau Connection Resolver file (\*.tdr) generates an ODBC ConnectString or a JDBC Connection URL, which you can find in tabprotosrv.txt.
 
 For ODBC, search for <span style= "font-family: courier new">ConnectString</span> to find something like this example:
 
@@ -158,7 +168,8 @@ JDBCProtocol Connection URL: jdbc:postgresql://postgres:5342/TestV1?user=test&pa
 ## ![9]({{ site.baseurl }}/assets/pce-9.png) \*.tdd
 
 After connection, Tableau uses your _.tdd dialect file to determine which SQL to generate when retrieving information from your database.
-You can define your own dialect in the _.tdd file, or your connector can inherit a dialect from its parent.
+You can define your own dialect in the _.tdd file, or your connector can inherit a dialect from its parent. If you are using the 'odbc' or 'jdbc' superclasses you must 
+define a dialect, since those superclasses do not have dialects.
 
 ### Example dialect.tdd
 

--- a/docs/example.md
+++ b/docs/example.md
@@ -131,8 +131,7 @@ In most cases, the default behavior works, so you don't have to include the <spa
 
 ## ![7]({{ site.baseurl }}/assets/pce-7.png) Connection Normalizer
 
-The component defines what makes up a unique connection. This can be implemented in javascript or directly in the xml. Writing the required attributes list in the xml is more performant,
-and is recommended for most connectors.
+The component defines what makes up a unique connection. This can be implemented in javascript or directly in the xml. Writing the required attributes list in the xml is more performant, and is recommended for most connectors.
 
 ```
 <required-attributes>

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ You need to do these things before you start:
 - Install Tableau Desktop 2019.2 or later on a Windows or Mac computer.
 
 ## Using a Connector
-You must start Tableau Desktop or Tableau Server with a special command line argument that tells Tableau where to find your Connector. See [Share Your Connector]({{ site.baseurl }}/docs/share) for more information.
+You must start Tableau Desktop or Tableau Server with a special command line argument that tells Tableau where to find your Connector. See [Run Your Connector]({{ site.baseurl }}/docs/share) for more information.
 
 **Tableau Desktop:** 
 

--- a/docs/share.md
+++ b/docs/share.md
@@ -1,16 +1,9 @@
 ---
-title: Share Your Connector
+title: Run Your Connector
 ---
-
-You've created and tested your connector.
-Now you'd like to get the connector, or at least the data that your connector can access, to your users.
 
 **IMPORTANT:** This is beta software and should be used in a test environment.
 Do not deploy the connector to a production environment.
-
-You can share the data your connector accesses by connecting to the data, creating an extract, and publishing the extract to Tableau Server or Tableau Online.
-
-Or, if you prefer to have your users test the connector, you can place the connector files in the directories and then run the commands as follows:
 
 **Tableau Desktop:** 
 


### PR DESCRIPTION
- Removed outdated section on web authoring
- Changed headings of resolver methods since the normalizer might not be a .js file
- Change normalizer example to the recommended xml implementation
- Highlight that odbc and jdbc need a dialect file
- Change name of "Share your connector" page to "Run your connector". The most it says about sharing is "don't do it" since it's in beta, and actually running the connector is a bit hidden even with Logan's addition to the getting started page. This is the one I'm not as sure of, I'm open to suggestions on the best way to highlight running the connector (maybe split it into two separate pages?)