### PR TITLE
Mac packager fix

### DIFF
--- a/connector-packager/connector_packager/helper.py
+++ b/connector-packager/connector_packager/helper.py
@@ -14,7 +14,7 @@ def check_jdk_environ_variable(exe_name: str) -> bool:
     """
     Check if executable needed in jdk is available
     """
-    path_list = os.environ[PATH_ENVIRON].split(';')
+    path_list = os.environ[PATH_ENVIRON].split(os.pathsep)
     for path in path_list:
         if os.path.isfile(Path(path) / exe_name):
             return True

--- a/connector-packager/connector_packager/jar_jdk_packager.py
+++ b/connector-packager/connector_packager/jar_jdk_packager.py
@@ -11,7 +11,9 @@ from .connector_file import ConnectorFile
 from .helper import check_jdk_environ_variable
 from .version import __min_version_tableau__
 
-JAR_EXECUTABLE_NAME = "jar.exe"
+JAR_EXECUTABLE_NAME = "jar"
+if os.name == 'nt':
+    JAR_EXECUTABLE_NAME+= ".exe"
 logger = logging.getLogger(__name__)
 MANIFEST_FILE_TYPE = "manifest"
 MANIFEST_FILE_NAME = MANIFEST_FILE_TYPE + ".xml"

--- a/connector-packager/connector_packager/jar_jdk_packager.py
+++ b/connector-packager/connector_packager/jar_jdk_packager.py
@@ -13,7 +13,7 @@ from .version import __min_version_tableau__
 
 JAR_EXECUTABLE_NAME = "jar"
 if os.name == 'nt':
-    JAR_EXECUTABLE_NAME+= ".exe"
+    JAR_EXECUTABLE_NAME += ".exe"
 logger = logging.getLogger(__name__)
 MANIFEST_FILE_TYPE = "manifest"
 MANIFEST_FILE_NAME = MANIFEST_FILE_TYPE + ".xml"

--- a/connector-packager/connector_packager/jar_jdk_signer.py
+++ b/connector-packager/connector_packager/jar_jdk_signer.py
@@ -9,7 +9,9 @@ from typing import Optional, Tuple
 from .helper import check_jdk_environ_variable
 
 
-JARSIGNER_EXECUTABLE_NAME = "jarsigner.exe"
+JARSIGNER_EXECUTABLE_NAME = "jarsigner"
+if os.name == 'nt':
+    JAR_EXECUTABLE_NAME+= ".exe"
 logger = logging.getLogger(__name__)
 
 KEYSTORE_PWD_PROMPT_LENGTH = len("Enter Passphrase for keystore: ")

--- a/connector-packager/connector_packager/jar_jdk_signer.py
+++ b/connector-packager/connector_packager/jar_jdk_signer.py
@@ -11,7 +11,7 @@ from .helper import check_jdk_environ_variable
 
 JARSIGNER_EXECUTABLE_NAME = "jarsigner"
 if os.name == 'nt':
-    JAR_EXECUTABLE_NAME+= ".exe"
+    JARSIGNER_EXECUTABLE_NAME += ".exe"
 logger = logging.getLogger(__name__)
 
 KEYSTORE_PWD_PROMPT_LENGTH = len("Enter Passphrase for keystore: ")


### PR DESCRIPTION
- changed the path separator character to use the os-specific one
- Removed the .exe from the executable name variables, only adding them back in if it's windows. (Haven't tested it yet, but this should also work for linux.)

Tested on both windows and mac, the test suite passes on both.