### PR TITLE
Add some documentation on running tacos

### DIFF
--- a/_includes/docs_menu.html
+++ b/_includes/docs_menu.html
@@ -11,6 +11,7 @@
     <li><a href="{{ site.baseurl }}/docs/tdvt">Test Your Connector Using TDVT</a></li>
     <li><a href="{{ site.baseurl }}/docs/manual-test">Test Your Connector Using Manual Tests</a></li>
     <li><a href="{{ site.baseurl }}/docs/localize">Localize Your Connector</a></li>
+    <li><a href="{{ site.baseurl }}/docs/run-taco">How to Run your Packaged Connector (Taco)</a></li>
     <li><a href="{{ site.baseurl }}/docs/share">How to Run Your "Under Development" Connector</a></li>
     <li><a href="{{ site.baseurl }}/docs/package-sign">How to Package and Sign Your Connector for Distribution</a></li>
     <li>Reference</li>

--- a/_includes/docs_menu.html
+++ b/_includes/docs_menu.html
@@ -11,9 +11,9 @@
     <li><a href="{{ site.baseurl }}/docs/tdvt">Test Your Connector Using TDVT</a></li>
     <li><a href="{{ site.baseurl }}/docs/manual-test">Test Your Connector Using Manual Tests</a></li>
     <li><a href="{{ site.baseurl }}/docs/localize">Localize Your Connector</a></li>
-    <li><a href="{{ site.baseurl }}/docs/run-taco">How to Run your Packaged Connector (Taco)</a></li>
     <li><a href="{{ site.baseurl }}/docs/share">How to Run Your "Under Development" Connector</a></li>
     <li><a href="{{ site.baseurl }}/docs/package-sign">How to Package and Sign Your Connector for Distribution</a></li>
+    <li><a href="{{ site.baseurl }}/docs/run-taco">How to Run your Packaged Connector (Taco)</a></li>
     <li>Reference</li>
     <li><a href="{{ site.baseurl }}/docs/api-reference">API Reference</a></li>
     <li><a href="{{ site.baseurl }}/docs/capabilities">Capabilities</a></li>

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,9 +25,9 @@ See the relationship between the connector files (in blue) and the Tableau **Con
 ![]({{ site.baseurl }}/assets/files-overview.png)
 
 # What is a Taco?
-A .taco file is a packaged Tableau connector file that can be dropped into your `My Tableau Repository/Connectors` folder. They will be automatically loaded by Tableau.
+A `.taco` file is a packaged Tableau connector file that can be dropped into your `My Tableau Repository/Connectors` folder. They will be automatically loaded by Tableau.
 
-For more information about packaging your connector into a .taco, refer to [How to Package and Sign Your Connector for Distribution]({{ site.baseurl }}/docs/package-sign)
+For more information about packaging your connector into a Taco, refer to [How to Package and Sign Your Connector for Distribution]({{ site.baseurl }}/docs/package-sign)
 
 # Before you Begin
 
@@ -39,7 +39,7 @@ You need to do these things before you start:
 # Using a Connector
 
 ## Packaged Connector (Taco)
-Simply drop your packaged taco file into your `My Tableau Repository/Connectors` and launch Tableau.
+Simply drop your packaged `.taco` file into your `My Tableau Repository/Connectors` and launch Tableau.
 
 Note: Support for loading Taco files was added in the 2019.4 release of Tableau.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ With the Tableau Connector SDK, you can add a new connector that you can use to 
 When you create a connector, you can add customizations to the connector, use the connectivity test harness to validate the connector behavior during the development process, and then package and distribute the connector to users.
 This document describes the files that make up a connector.
 
-# What is a connector?
+# What is a Connector?
 
 A connector is a set of files that describe:
 
@@ -24,12 +24,12 @@ See the relationship between the connector files (in blue) and the Tableau **Con
 
 ![]({{ site.baseurl }}/assets/files-overview.png)
 
-# What is a taco?
-A .taco is a packaged Tableau connector file that can be dropped into your `My Tableau Repository/Connectors` folder. They will be automatically loaded by Tableau.
+# What is a Taco?
+A .taco file is a packaged Tableau connector file that can be dropped into your `My Tableau Repository/Connectors` folder. They will be automatically loaded by Tableau.
 
 For more information about packaging your connector into a .taco, refer to [How to Package and Sign Your Connector for Distribution]({{ site.baseurl }}/docs/package-sign)
 
-# Before you begin
+# Before you Begin
 
 You need to do these things before you start:
 
@@ -38,7 +38,7 @@ You need to do these things before you start:
 
 # Using a Connector
 
-## Packaged Connector (.taco)
+## Packaged Connector (Taco)
 Simply drop your packaged taco file into your `My Tableau Repository/Connectors` and launch Tableau.
 
 Note: Support for loading Taco files was added in the 2019.4 release of Tableau.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ With the Tableau Connector SDK, you can add a new connector that you can use to 
 When you create a connector, you can add customizations to the connector, use the connectivity test harness to validate the connector behavior during the development process, and then package and distribute the connector to users.
 This document describes the files that make up a connector.
 
-## What is a connector?
+# What is a connector?
 
 A connector is a set of files that describe:
 
@@ -24,38 +24,24 @@ See the relationship between the connector files (in blue) and the Tableau **Con
 
 ![]({{ site.baseurl }}/assets/files-overview.png)
 
-## Before you begin
+# What is a taco?
+A .taco is a packaged Tableau connector file that can be dropped into your `My Tableau Repository/Connectors` folder. They will be automatically loaded by Tableau.
+
+For more information about packaging your connector into a .taco, refer to [How to Package and Sign Your Connector for Distribution]({{ site.baseurl }}/docs/package-sign)
+
+# Before you begin
 
 You need to do these things before you start:
 
 - Install the ODBC or JDBC driver that you’ll use with the connector you’ll create.
 - Install Tableau Desktop 2019.2 or later on a Windows or Mac computer.
 
-## Using a Connector
+# Using a Connector
 
-You must start Tableau Desktop or Tableau Server with a special command line argument that tells Tableau where to find your Connector. See [Run Your Connector]({{ site.baseurl }}/docs/share) for more information.
+## Packaged Connector (.taco)
+Simply drop your packaged taco file into your `My Tableau Repository/Connectors` and launch Tableau.
 
-**Tableau Desktop:** 
+Note: Support for loading Taco files was added in the 2019.4 release of Tableau.
 
-For Windows:
-1. Create a directory for Tableau connectors. For example: `C:\tableau_connectors`
-1. Put the folder containing your connector's manifest.xml file in this directory. Each connector should have its own folder. For example: `C:\tableau_connectors\my_connector`
-1. Run Tableau using the `-DConnectPluginsPath` command line argument, pointing to your connector directory. For example: 
-
-    ```
-    tableau.exe -DConnectPluginsPath=C:\tableau_connectors
-    ```
-
-For macOS:
-
-In the following examples, replace [user name] with your name (for example /Users/agarcia/tableau_connectors) and [Tableau version] with the version of Tableau that you’re running (for example, 2019.3.app).
-
-1. Create a directory for Tableau connectors. For example: `/Users/[user name]/tableau_connectors`
-1. Put the folder containing your connector's manifest.xml file in this directory. Each connector should have its own folder. For example: `/Users/[user name]/tableau_connector/my connector`
-1. Run Tableau using the `-DConnectPluginsPath` command line argument, pointing to your connector directory. For example: 
-
-    ```
-    /Applications/Tableau\ Desktop\ [Tableau version].app/Contents/MacOS/Tableau -DConnectPluginsPath=/Users/[user name]/tableau_connectors
-        
-    ```
-
+## Developer Path
+You can tell Tableau to load un-packaged connectors with a special command line argument that tells Tableau where to find your Connector. See [Run Your Connector]({{ site.baseurl }}/docs/share) for more information.

--- a/docs/run-taco.md
+++ b/docs/run-taco.md
@@ -5,11 +5,11 @@ title: How to Run your Packaged Connector (Taco)
 The ability to load taco files was added in 2019.4 Beta 1. For loading un-packaged connectors in earlier versions of Tableau, refer to [How to Run Your "Under Development" Connector]({{ site.baseurl }}/docs/share)
 
 # Tableau Desktop
-Simply drop your taco file into your `My Tableau Repository/Connectors` and launch Tableau.
+Simply drop your `.taco` file into your `My Tableau Repository/Connectors` and launch Tableau.
 
 # Tableau Server
 1. Create a directory for Tableau connectors. For example: `C:\tableau_connectors`
-1. Drop your taco file into the folder your created
+1. Drop your `.taco` file into the folder your created
 1. Set the `native_api.connect_plugins_path` option. For example:
 
     ```
@@ -31,6 +31,6 @@ For information about using TSM to set the option, see [tsm configuration set Op
 # Troubleshooting
 
 ## Package signature verification failed during connection creation.
-This means that the connector couldn't be verified. To be loaded in Tableau, a .taco must be signed by a trusted certificate. For more information about signing tacos, refer to [How to Package and Sign Your Connector for Distribution]({{ site.baseurl }}/docs/package-sign) and [Signature Verification Log Entries]({{ site.baseurl }}/docs/log-entries)
+This means that the connector couldn't be verified. To be loaded in Tableau, a `.taco` must be signed by a trusted certificate. For more information about signing Tacos, refer to [How to Package and Sign Your Connector for Distribution]({{ site.baseurl }}/docs/package-sign) and [Signature Verification Log Entries]({{ site.baseurl }}/docs/log-entries)
 
 As a workaround, you can disable taco verification in Tableau by using the command line argument `-DDisableVerifyConnectorPluginSignature=true`.

--- a/docs/run-taco.md
+++ b/docs/run-taco.md
@@ -1,0 +1,34 @@
+---
+title: How to Run your Packaged Connector (Taco)
+---
+
+# Tableau Desktop
+Simply drop your taco file into your `My Tableau Repository/Connectors` and launch Tableau.
+
+# Tableau Server
+1. Create a directory for Tableau connectors. For example: `C:\tableau_connectors`
+1. Drop your taco file into the folder your created
+1. Set the `native_api.connect_plugins_path` option. For example:
+
+    ```
+    tsm configuration set -k native_api.connect_plugins_path -v C:/tableau_connectors
+    ```
+
+    If you get a configuration error during this step, try adding the `--force-keys` option to the end of the command.
+
+1. Apply the pending configuration changes.  This will restart the server.
+
+    ```
+    tsm pending-changes apply
+    ```
+
+    Note that whenever you add, remove, or update a connector, you need to restart the server to see the changes.
+
+For information about using TSM to set the option, see [tsm configuration set Options](https://onlinehelp.tableau.com/current/server-linux/en-us/cli_configuration-set_tsm.htm) in the Tableau Server help.
+
+# Troubleshooting
+
+## Package signature verification failed during connection creation.
+This means that the connector couldn't be verified. To be loaded in Tableau, a .taco must be signed by a trusted certificate. For more information about signing tacos, refer to [How to Package and Sign Your Connector for Distribution]({{ site.baseurl }}/docs/package-sign) and [Signature Verification Log Entries]({{ site.baseurl }}/docs/log-entries)
+
+As a workaround, you can disable taco verification in Tableau by using the command line argument `-DDisableVerifyConnectorPluginSignature=true`.

--- a/docs/run-taco.md
+++ b/docs/run-taco.md
@@ -2,6 +2,8 @@
 title: How to Run your Packaged Connector (Taco)
 ---
 
+The ability to load taco files was added in 2019.4 Beta 1. For loading un-packaged connectors in earlier versions of Tableau, refer to [How to Run Your "Under Development" Connector]({{ site.baseurl }}/docs/share)
+
 # Tableau Desktop
 Simply drop your taco file into your `My Tableau Repository/Connectors` and launch Tableau.
 

--- a/docs/share.md
+++ b/docs/share.md
@@ -5,12 +5,12 @@ title: How to Run Your "Under Development" Connector
 **IMPORTANT:** This is beta software and should be used in a test environment.
 Do not deploy the connector to a production environment.
 
-**Tableau Desktop:** 
+# Tableau Desktop:
 
 For Windows:
 1. Create a directory for Tableau connectors. For example: `C:\tableau_connectors`
 1. Put the folder containing your connector's manifest.xml file in this directory. Each connector should have its own folder. For example: `C:\tableau_connectors\my_connector`
-1. Run Tableau using the `-DConnectPluginsPath` command line argument, pointing to your connector directory. For example: 
+1. Run Tableau using the `-DConnectPluginsPath` command line argument, pointing to your connector directory. For example:
 
     ```
     tableau.exe -DConnectPluginsPath=C:\tableau_connectors
@@ -21,22 +21,22 @@ For macOS:
 In the following examples, replace [user name] with your name (for example /Users/agarcia/tableau_connectors) and [Tableau version] with the version of Tableau that you’re running (for example, 2019.3.app).
 1. Create a directory for Tableau connectors. For example: `/Users/[user name]/tableau_connectors`
 1. Put the folder containing your connector's manifest.xml file in this directory. Each connector should have its own folder. For example: `/Users/[user name]/tableau_connector/my connector`
-1. Run Tableau using the `-DConnectPluginsPath` command line argument, pointing to your connector directory. For example: 
+1. Run Tableau using the `-DConnectPluginsPath` command line argument, pointing to your connector directory. For example:
 
     ```
     /Applications/Tableau\ Desktop\ [Tableau version].app/Contents/MacOS/Tableau -DConnectPluginsPath=/Users/[user name]/tableau_connectors
-        
+
     ```
 
-**Tableau Server:** 
+# Tableau Server:
 
 1. For each server node, follow Tableau Desktop's steps 1 and 2 above.
 1. Set the `native_api.connect_plugins_path` option. For example:
 
     ```
-    tsm configuration set -k native_api.connect_plugins_path -v C:/tableau_connectors 
+    tsm configuration set -k native_api.connect_plugins_path -v C:/tableau_connectors
     ```
-  
+
     If you get a configuration error during this step, try adding the `--force-keys` option to the end of the command.
 
 1. Apply the pending configuration changes.  This will restart the server.

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -4,7 +4,7 @@ title: Building the Connection Dialog
 
 ## The Connection Dialog
 
-The Connection Dialog prompts the user to enter connection and authentication information that will passed into the connector builder script to build the connection string. The dialog appears when creating a new connection or editing an existing connection on both Tableau Desktop and Server. 
+The Connection Dialog prompts the user to enter connection and authentication information that will passed into the connector builder script to build the connection string. The dialog appears when creating a new connection or editing an existing connection on both Tableau Desktop and Server.
 
 The Connection Dialog is mainly defined in the Tableau Custom Dialog (.tcd) file.
 
@@ -14,7 +14,7 @@ The Connection Dialog is mainly defined in the Tableau Custom Dialog (.tcd) file
 
 The connector is displayed as "[Display Name] by [Company Name]" in the connection dialog and connection list.
 
-"For support, contact [Company Name]" is displayed at the bottom left of the connector. Clicking on this link will send the user to the support link defined in the manifest. This link also displays in error messages.
+"For support, contact [Company Name]" is displayed at the bottom left of the connector. Clicking on this link will send the user to the support link defined in the manifest. This link also displays in error messages. The support link must be https to be packaged into a taco file.
 
 These elements are defined in the manifest.xml file:
 ```


### PR DESCRIPTION
A quick search on our docs revealed that we had no mentions of tacos beyond the pages on packaging them. Reworked some of the docs and added a page on running tacos.

Also mentioned that support links must be https.