### PR TITLE
Fix logging bug in packaging tool

### DIFF
--- a/connector-packager/connector_packager/helper.py
+++ b/connector-packager/connector_packager/helper.py
@@ -1,6 +1,7 @@
 import os
 import logging
 
+from imp import reload
 from pathlib import Path
 
 from .version import __version__
@@ -25,8 +26,9 @@ def check_jdk_environ_variable(exe_name: str) -> bool:
 
 
 def init_logging(log_path: str, verbose: bool = False) -> logging.Logger:
+    reload(logging)
     # Create logger.
-    logging.basicConfig(filename=log_path, level=logging.DEBUG, filemode='w', format='%(asctime)s | %(message)s')
+    logging.basicConfig(level=logging.DEBUG, format='%(asctime)s | %(message)s', filename=log_path, filemode='w')
     logger = logging.getLogger()
     ch = logging.StreamHandler()
     if verbose:

--- a/connector-packager/connector_packager/xsd_validator.py
+++ b/connector-packager/connector_packager/xsd_validator.py
@@ -2,7 +2,7 @@ import sys
 import logging
 
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 from xmlschema import XMLSchema
 
@@ -119,7 +119,7 @@ def validate_single_file(file_to_test: ConnectorFile, path_to_file: Path, xml_vi
 
 
 # Return the XSD file to test against
-def get_xsd_file(file_to_test: ConnectorFile) -> str:
+def get_xsd_file(file_to_test: ConnectorFile) -> Optional[str]:
     """
     Arguments:
         file_to_test {ConnectorFile} -- the file we want to find an XSD file for


### PR DESCRIPTION
Our logger was not actually logging anything – [per this Stack Overflow thread](https://stackoverflow.com/a/53553516/3389827) I fixed by reloading the `logging` module before calling `.basicConfig`.