### PR TITLE
Fix issue with logging

### DIFF
--- a/connector-packager/connector_packager/helper.py
+++ b/connector-packager/connector_packager/helper.py
@@ -1,14 +1,13 @@
 import os
 import logging
 
-from imp import reload
 from pathlib import Path
 
 from .version import __version__
 
 
 PATH_ENVIRON = "PATH"
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('packager_logger')
 
 
 def check_jdk_environ_variable(exe_name: str) -> bool:
@@ -23,21 +22,3 @@ def check_jdk_environ_variable(exe_name: str) -> bool:
     logger.error("Java Error: jdk_create_jar: no jdk set up in PATH environment variable, "
                  "please download JAVA JDK and add it to PATH")
     return False
-
-
-def init_logging(log_path: str, verbose: bool = False) -> logging.Logger:
-    reload(logging)
-    # Create logger.
-    logging.basicConfig(level=logging.DEBUG, format='%(asctime)s | %(message)s', filename=log_path, filemode='w')
-    logger = logging.getLogger()
-    ch = logging.StreamHandler()
-    if verbose:
-        # Log to console also.
-        ch.setLevel(logging.DEBUG)
-    else:
-        ch.setLevel(logging.INFO)
-    logger.addHandler(ch)
-
-    logger.debug("Starting Tableau Connector Packaging Version " + __version__)
-
-    return logger

--- a/connector-packager/connector_packager/jar_jdk_packager.py
+++ b/connector-packager/connector_packager/jar_jdk_packager.py
@@ -14,7 +14,7 @@ from .version import __min_version_tableau__
 JAR_EXECUTABLE_NAME = "jar"
 if os.name == 'nt':
     JAR_EXECUTABLE_NAME += ".exe"
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('packager_logger')
 MANIFEST_FILE_TYPE = "manifest"
 MANIFEST_FILE_NAME = MANIFEST_FILE_TYPE + ".xml"
 MANIFEST_FILE_COPY_NAME = MANIFEST_FILE_TYPE + "_copy.xml"

--- a/connector-packager/connector_packager/jar_jdk_signer.py
+++ b/connector-packager/connector_packager/jar_jdk_signer.py
@@ -12,7 +12,7 @@ from .helper import check_jdk_environ_variable
 JARSIGNER_EXECUTABLE_NAME = "jarsigner"
 if os.name == 'nt':
     JARSIGNER_EXECUTABLE_NAME += ".exe"
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('packager_logger')
 
 KEYSTORE_PWD_PROMPT_LENGTH = len("Enter Passphrase for keystore: ")
 ALIAS_PWD_PROMPT_LENGTH = len("Enter key password for : ")

--- a/connector-packager/connector_packager/package.py
+++ b/connector-packager/connector_packager/package.py
@@ -1,14 +1,15 @@
 import os
+import logging
 
 from argparse import ArgumentParser
 
 from pathlib import Path
 
-from .helper import init_logging
 from .jar_jdk_packager import jdk_create_jar
 from .jar_jdk_signer import jdk_sign_jar, validate_signing_input
 from .xsd_validator import validate_all_xml
 from .xml_parser import XMLParser
+from .version import __version__
 
 PACKAGED_EXTENSION = ".taco"
 
@@ -30,6 +31,33 @@ def create_arg_parser() -> ArgumentParser:
     parser.add_argument('-ks', '--keystore', dest='keystore',
                         help='keystore location, default is the jks file in user home directory', required=False)
     return parser
+
+
+def init_logging(log_path: str, verbose: bool = False) -> logging.Logger:
+    # Create logger.
+    logger = logging.getLogger('packager_logger')
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+
+    fh = logging.FileHandler(log_path, mode='w')
+    fh.setLevel(logging.DEBUG)
+
+    formatter = logging.Formatter('%(asctime)s [%(levelname)s] | %(message)s')
+    fh.setFormatter(formatter)
+
+    ch = logging.StreamHandler()
+    if verbose:
+        # Log to console also.
+        ch.setLevel(logging.DEBUG)
+    else:
+        ch.setLevel(logging.INFO)
+
+    logger.addHandler(ch)
+    logger.addHandler(fh)
+
+    logger.debug("Starting Tableau Connector Packaging Version " + __version__)
+
+    return logger
 
 
 def main():

--- a/connector-packager/connector_packager/xml_parser.py
+++ b/connector-packager/connector_packager/xml_parser.py
@@ -9,7 +9,8 @@ from defusedxml.ElementTree import parse
 from .connector_file import ConnectorFile
 from .xsd_validator import validate_single_file
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('packager_logger')
+
 
 TRANSLATABLE_STRING_PREFIX = "@string/"
 TABLEAU_SUPPORTED_LANGUAGES = ["de_DE", "en_GB", "en_US", "es_ES", "fr_FR", "ga_IE", "ja_JP", "ko_KR", "pt_BR", "zh_CN",

--- a/connector-packager/connector_packager/xsd_validator.py
+++ b/connector-packager/connector_packager/xsd_validator.py
@@ -8,7 +8,7 @@ from xmlschema import XMLSchema
 
 from .connector_file import ConnectorFile
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('packager_logger')
 
 MAX_FILE_SIZE = 1024 * 256  # This is based on the max file size we will load on the Tableau side
 PATH_TO_XSD_FILES = Path("../validation").absolute()


### PR DESCRIPTION
One of the imported modules must have set the root logger and that messed our logging up. Got it to a working state, tested against 3.7.4. Had to move the initialization of the logger to package.py from helper.py as part of the fix.

Opening as a hotfix against master, since I'm not sure if we've cleaned up dev. Will also merge into dev once it's merged into master.