### PR TITLE
Remove one time sql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Added
 - New SQLite Extract-Only Sample
+- Removed unnecessary attribute from samples
 ### Changed
 ### Removed
 

--- a/samples/plugins/mysql_odbc/connectionResolver.tdr
+++ b/samples/plugins/mysql_odbc/connectionResolver.tdr
@@ -15,7 +15,6 @@
           <attr>port</attr>
           <attr>odbc-connect-string-extras</attr>
           <attr>source-charset</attr>
-          <attr>one-time-sql</attr>
         </attribute-list>
       </required-attributes>
     </connection-normalizer>

--- a/samples/plugins/postgres_jdbc/connectionResolver.tdr
+++ b/samples/plugins/postgres_jdbc/connectionResolver.tdr
@@ -14,7 +14,6 @@
           <attr>username</attr>
           <attr>password</attr>
           <attr>sslmode</attr>
-          <attr>one-time-sql</attr>
         </attribute-list>
       </required-attributes>
     </connection-normalizer>

--- a/samples/plugins/postgres_odbc/connectionResolver.tdr
+++ b/samples/plugins/postgres_odbc/connectionResolver.tdr
@@ -14,7 +14,6 @@
           <attr>username</attr>
           <attr>password</attr>
           <attr>sslmode</attr>
-          <attr>one-time-sql</attr>
         </attribute-list>
       </required-attributes>
     </connection-normalizer>

--- a/samples/plugins/sqlite_extract/connectionResolver.xml
+++ b/samples/plugins/sqlite_extract/connectionResolver.xml
@@ -10,7 +10,6 @@
             <attribute-list>
             <attr>server</attr>
             <attr>authentication</attr>
-            <attr>one-time-sql</attr>
             </attribute-list>
         </required-attributes>
     </connection-normalizer>


### PR DESCRIPTION
one-time-sql is added in the c++ code (like class is). Double-checked the connection strings for 2019.4 to make sure it was being properly propagated. Since it will be added to every plugin, it is redundant to add it in the tdr.