### PR TITLE
Update tabquery.py to look for env var

### DIFF
--- a/tdvt/CHANGELOG.md
+++ b/tdvt/CHANGELOG.md
@@ -6,3 +6,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 - Update handling of args.run_file to use Path
+- Update tabquery to check for an environment variable path to tabquerycli before looking in config files.

--- a/tdvt/tdvt/tabquery.py
+++ b/tdvt/tdvt/tabquery.py
@@ -15,8 +15,12 @@ def configure_tabquery_path():
     tabquery_envvar = os.environ.get('TABQUERY_CLI_PATH')
     logging.debug("TABQUERY_CLI_PATH environment variable is {}".format(tabquery_envvar))
 
+    if tabquery_envvar and not os.path.isfile(tabquery_envvar):
+        logging.warn(
+            "The environment variable TABQUERY_CLI_PATH={} is not a file and will not be used.".format(tabquery_envvar)
+        )
 
-    if tabquery_envvar:
+    if tabquery_envvar and os.path.isfile(tabquery_envvar):
         tab_cli_exe = tabquery_envvar
         logging.debug("tabquerycli path set via environment variable")
     elif sys.platform.startswith("darwin"):

--- a/tdvt/tdvt/tabquery.py
+++ b/tdvt/tdvt/tabquery.py
@@ -12,14 +12,19 @@ def configure_tabquery_path():
     tdvt_cfg = get_ini_path_local_first('config/tdvt', 'tdvt')
     logging.debug("Reading tdvt ini file [{}]".format(tdvt_cfg))
     config.read(tdvt_cfg)
+    tabquery_envvar = os.environ.get('TABQUERY_CLI_PATH')
+    logging.debug("TABQUERY_CLI_PATH environment variable is {}".format(tabquery_envvar))
 
-    if sys.platform.startswith("darwin"):
+
+    if tabquery_envvar:
+        tab_cli_exe = tabquery_envvar
+    elif sys.platform.startswith("darwin"):
         tab_cli_exe = config['DEFAULT']['TAB_CLI_EXE_MAC']
     elif sys.platform.startswith("linux"):
         tab_cli_exe = config['DEFAULT']['TAB_CLI_EXE_LINUX']
     else:
         tab_cli_exe = config['DEFAULT']['TAB_CLI_EXE_X64']
-    logging.debug("Reading tdvt ini file tabquerycli path is [{}]".format(tab_cli_exe))
+    logging.debug("tabquerycli path set as [{}]".format(tab_cli_exe))
 
 def get_max_process_level_of_parallelization(desired_threads):
     if sys.platform.startswith("darwin") and 'tabquerytool' in tab_cli_exe:
@@ -92,13 +97,13 @@ def tabquerycli_exists():
     global tab_cli_exe
     tabquery_envvar = os.environ.get('TABQUERY_CLI_PATH')
 
-    if os.path.isfile(tabquery_envvar):
-        logging.debug("Found tabquery at [{0}]".format(tabquery_envvar))
+    if tabquery_envvar and os.path.isfile(tabquery_envvar):
+        logging.debug("Found tabquery via environment variable at [{0}]".format(tabquery_envvar))
         return True
 
     if os.path.isfile(tab_cli_exe):
-        logging.debug("Found tabquery at [{0}]".format(tab_cli_exe))
+        logging.debug("Found tabquery via config file at [{0}]".format(tab_cli_exe))
         return True
 
-    logging.debug("Could not find tabquery at [{0}]".format(tab_cli_exe))
+    logging.debug("Could not find tabquery at [{0} {1}]".format(tabquery_envvar, tab_cli_exe))
     return False

--- a/tdvt/tdvt/tabquery.py
+++ b/tdvt/tdvt/tabquery.py
@@ -18,6 +18,7 @@ def configure_tabquery_path():
 
     if tabquery_envvar:
         tab_cli_exe = tabquery_envvar
+        logging.debug("tabquerycli path set via environment variable")
     elif sys.platform.startswith("darwin"):
         tab_cli_exe = config['DEFAULT']['TAB_CLI_EXE_MAC']
     elif sys.platform.startswith("linux"):

--- a/tdvt/tdvt/tabquery.py
+++ b/tdvt/tdvt/tabquery.py
@@ -8,7 +8,7 @@ def configure_tabquery_path():
     """Setup the tabquery path from ini settings."""
     global tab_cli_exe
     config = configparser.ConfigParser()
-    
+
     tdvt_cfg = get_ini_path_local_first('config/tdvt', 'tdvt')
     logging.debug("Reading tdvt ini file [{}]".format(tdvt_cfg))
     config.read(tdvt_cfg)
@@ -90,11 +90,15 @@ class TabqueryCommandLine(object):
 
 def tabquerycli_exists():
     global tab_cli_exe
+    tabquery_envvar = os.environ.get('TABQUERY_CLI_PATH')
+
+    if os.path.isfile(tabquery_envvar):
+        logging.debug("Found tabquery at [{0}]".format(tabquery_envvar))
+        return True
+
     if os.path.isfile(tab_cli_exe):
         logging.debug("Found tabquery at [{0}]".format(tab_cli_exe))
         return True
 
     logging.debug("Could not find tabquery at [{0}]".format(tab_cli_exe))
     return False
-
-


### PR DESCRIPTION
Updates `tabquery.py` to look for a `TABQUERY_CLI_PATH` environment variable before looking for a value in tdvt_config or tdvt_override.

I'm making this chance so it's easier to set up automation. We have a change like this in the `dev-tdvt` branch at a481b0fe5e02a29739cf10a8f3faf21315e72ebb

Logging now looks like this:

**no envvar:**
```
2019-11-08 12:54:46,995 Reading registry ini file [/Users/lpetschauer/PycharmProjects/connector-plugin-sdk/tdvt/samples/config/registry/mac.ini]
2019-11-08 12:54:46,996 Reading tdvt ini file [/Users/lpetschauer/PycharmProjects/connector-plugin-sdk/tdvt/samples/config/tdvt/tdvt.ini]
2019-11-08 12:54:46,997 TABQUERY_CLI_PATH environment variable is None
2019-11-08 12:54:46,997 tabquerycli path set as [/Applications/Tableau.app/Contents/MacOs/tabquerytool]
```

**with envvar:**
```
2019-11-08 13:01:38,727 Reading registry ini file [/Users/lpetschauer/PycharmProjects/connector-plugin-sdk/tdvt/samples/config/registry/mac.ini]
2019-11-08 13:01:38,728 Reading tdvt ini file [/Users/lpetschauer/PycharmProjects/connector-plugin-sdk/tdvt/samples/config/tdvt/tdvt.ini]
2019-11-08 13:01:38,729 TABQUERY_CLI_PATH environment variable is /Applications/Tableau Desktop 2019.3.app/Contents/MacOS/tabquerytool
2019-11-08 13:01:38,729 tabquerycli path set via environment variable
2019-11-08 13:01:38,729 tabquerycli path set as [/Applications/Tableau Desktop 2019.3.app/Contents/MacOS/tabquerytool]
```

**envvar with bad path:**
```
2019-11-08 13:39:58,227 Reading registry ini file [/Users/lpetschauer/PycharmProjects/connector-plugin-sdk/tdvt/samples/config/registry/mac.ini]
2019-11-08 13:39:58,228 Reading tdvt ini file [/Users/lpetschauer/PycharmProjects/connector-plugin-sdk/tdvt/samples/config/tdvt/tdvt.ini]
2019-11-08 13:39:58,228 TABQUERY_CLI_PATH environment variable is /Applications/Tableau Desktop 2019.3.app/Contents/MacOS/tabqueryto
2019-11-08 13:39:58,228 The TABQUERY_CLI_PATH /Applications/Tableau Desktop 2019.3.app/Contents/MacOS/tabqueryto is not a file.
2019-11-08 13:39:58,228 tabquerycli path set as [/Applications/Tableau.app/Contents/MacOs/tabquerytool]
2019-11-08 13:39:58,228 Checking generated logical setup files...
```