### PR TITLE
Create pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 **A Helpful Guide For Navigating Our Branches**
 
 * If this is a hotfix, make your PR against `master`.
-* If your change can ship immediately, make your PR against `dev`.
+* If your change can ship immediately, make your PR against `dev-tdvt`.
 * If your change is for a future release, make your PR against the appropriate holding branch (eg `dev-2020.1`)
 
 _Also:_

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**A Helpful Guide For Navigating Our Branches**
+
+* If this is a hotfix, make your PR against `master`.
+* If your change can ship immediately, make your PR against `dev`.
+* If your change is for a future release, make your PR against the appropriate holding branch (eg `dev-2020.1`)
+
+_Also:_
+* Please update the changelog of the project you modified, either under `vNext` or under a point release if you bumped the version.
+* If you are merging into master, update the root `README.md` if the PR includes a release of the SDK, Connector Packager, or TDVT.
+
+Thank you and feel free to delete this from your PR description!


### PR DESCRIPTION
I thought it might be useful to always show some guidelines when a PR is opened. The text would show up at the top of any Pull Request description when you open it and can be removed.