### PR TITLE
Fix MySQL Sample ssl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - New SQLite Extract-Only Sample
 - Removed unnecessary attribute from samples
+- Fix issue with SSL in the MySQL ODBC sample
 ### Changed
 ### Removed
 

--- a/samples/plugins/mysql_odbc/connectionBuilder.js
+++ b/samples/plugins/mysql_odbc/connectionBuilder.js
@@ -11,6 +11,14 @@
 
     params["OPTION"] = "1048576"
 
+    if (attr["sslmode"] == "require")
+    {
+        params["SSLMODE"] = "required";
+    }
+    else{
+        params["SSLMODE"] = "disabled";
+    }
+
     var formattedParams = [];
 
     formattedParams.push(connectionHelper.formatKeyValuePair(driverLocator.keywordDriver, driverLocator.locateDriver(attr)));

--- a/samples/plugins/mysql_odbc/connectionDialog.tcd
+++ b/samples/plugins/mysql_odbc/connectionDialog.tcd
@@ -2,5 +2,6 @@
   <connection-config>
     <authentication-mode value='BasicNoValidateFields' />
     <port-prompt value="Port: " default="3306" />
+    <show-ssl-checkbox value="true" />
   </connection-config>
 </connection-dialog>

--- a/samples/plugins/mysql_odbc/connectionResolver.tdr
+++ b/samples/plugins/mysql_odbc/connectionResolver.tdr
@@ -13,6 +13,7 @@
           <attr>username</attr>
           <attr>password</attr>
           <attr>port</attr>
+          <attr>sslmode</attr>
           <attr>odbc-connect-string-extras</attr>
           <attr>source-charset</attr>
         </attribute-list>

--- a/samples/plugins/mysql_odbc/connectionResolver.tdr
+++ b/samples/plugins/mysql_odbc/connectionResolver.tdr
@@ -24,8 +24,5 @@
     <driver-match>
       <driver-name type='exact'>MySQL ODBC 8.0 Unicode Driver</driver-name>
     </driver-match>
-    <driver-match>
-      <driver-name type='exact'>MySQL ODBC 5.3 Unicode Driver</driver-name>
-    </driver-match>
   </driver-resolver>
 </tdr>


### PR DESCRIPTION
Our sample connector did not disable ssl properly. Since it was trivial, added the ssl checkbox. Removed the 5.3 driver from the driver resolver since it'd need different logic for the ssl mode parameters and it is past EOL.