### PR TITLE
Update packaging logger to create logging dir if it does not exist

### DIFF
--- a/connector-packager/CHANGELOG.md
+++ b/connector-packager/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Update `package.py` to create directory for logs if it does not exist.
 
 ## [0.0.1] - 10-3-2019
 Initial release of the Connector Packaging Tool

--- a/connector-packager/connector_packager/package.py
+++ b/connector-packager/connector_packager/package.py
@@ -1,5 +1,6 @@
-import os
 import logging
+import os
+import sys
 
 from argparse import ArgumentParser
 
@@ -33,7 +34,7 @@ def create_arg_parser() -> ArgumentParser:
     return parser
 
 
-def init_logging(log_path: str, verbose: bool = False) -> logging.Logger:
+def init_logging(log_path: Path, verbose: bool = False) -> logging.Logger:
     # Create logger.
     logger = logging.getLogger('packager_logger')
     logger.setLevel(logging.DEBUG)
@@ -59,11 +60,24 @@ def init_logging(log_path: str, verbose: bool = False) -> logging.Logger:
 
     return logger
 
+def log_path_checker(path_to_logs: str) -> Path:
+    proper_path = Path(path_to_logs)
+    if os.path.isdir(path_to_logs):
+        print("The log path {} exists".format(str(proper_path)))
+    else:
+        print("The specified log path does not exist - attempting to create " + path_to_logs)
+        try:
+            os.mkdir(path_to_logs)
+            logging.info("Created " + path_to_logs)
+        except:
+            print("Unable to create log directory. Exiting.")
+            sys.exit(-1)
+    return Path(Path(path_to_logs) / 'packaging_logs.txt')
 
 def main():
     parser = create_arg_parser()
     args = parser.parse_args()
-    log_file = args.log_path + '/packaging_log.txt'
+    log_file = log_path_checker(args.log_path)
     logger = init_logging(log_file, args.verbose)
 
     path_from_args = Path(args.input_dir)
@@ -79,7 +93,7 @@ def main():
     if files_to_package and validate_all_xml(files_to_package, path_from_args):
         logger.info("Validation succeeded.")
     else:
-        logger.info("Validation failed. Check " + log_file + " for more information.")
+        logger.info("Validation failed. Check " + str(log_file) + " for more information.")
         return
 
     # Double check that all files exist
@@ -98,7 +112,7 @@ def main():
     package_name = xmlparser.class_name + PACKAGED_EXTENSION
 
     if not jdk_create_jar(path_from_args, files_to_package, package_name, package_dest_path):
-        logger.info("Taco packaging failed. Check " + log_file + " for more information.")
+        logger.info("Taco packaging failed. Check " + str(log_file) + " for more information.")
         return
 
     if args.package_only:
@@ -109,11 +123,11 @@ def main():
     keystore_from_args = args.keystore
 
     if not validate_signing_input(package_dest_path, package_name, alias_from_args, keystore_from_args):
-        logger.debug("Signing input validation failed. check " + log_file + " for more information.")
+        logger.debug("Signing input validation failed. check " + str(log_file) + " for more information.")
         return
 
     if not jdk_sign_jar(package_dest_path, package_name, alias_from_args, keystore_from_args):
-        logger.info("Signing failed. check console output and " + log_file + " for more information.")
+        logger.info("Signing failed. check console output and " + str(log_file) + " for more information.")
         return
 
 

--- a/connector-packager/connector_packager/package.py
+++ b/connector-packager/connector_packager/package.py
@@ -60,6 +60,7 @@ def init_logging(log_path: Path, verbose: bool = False) -> logging.Logger:
 
     return logger
 
+
 def log_path_checker(path_to_logs: str) -> Path:
     proper_path = Path(path_to_logs)
     if os.path.isdir(path_to_logs):
@@ -69,7 +70,7 @@ def log_path_checker(path_to_logs: str) -> Path:
         try:
             os.mkdir(path_to_logs)
             logging.info("Created " + path_to_logs)
-        except:
+        except Exception:
             print("Unable to create log directory. Exiting.")
             sys.exit(-1)
     return Path(Path(path_to_logs) / 'packaging_logs.txt')


### PR DESCRIPTION
Ref: TFS1025155

Updates `connector-packager` to check if the logging directory exists. If it does not, the directory is created. Includes error handling for not being able to create the dir.

Since this happens _before_ logging is initialized, the updated code just prints to console rather than using `logging`.

Also, updated `log_file` to be a `Path` object. I'm not opposed to reverting it to string if that'd be better. I'm not sure that we get much out of making it a Path obj, tbh.

![image](https://user-images.githubusercontent.com/5643640/70001798-1212b800-1513-11ea-9d93-9b4a88e21df3.png)
