### PR TITLE
Keep all .txt and .log files including jdbc server log.

### DIFF
--- a/tdvt/CHANGELOG.md
+++ b/tdvt/CHANGELOG.md
@@ -6,3 +6,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 - Update handling of args.run_file to use Path
+- Include all relevant log files in the zip archive.

--- a/tdvt/tdvt/tdvt.py
+++ b/tdvt/tdvt/tdvt.py
@@ -372,49 +372,44 @@ list_usage_text = '''
     
 run_usage_text = '''
     The 'run' argument can take a single datasource, a list of data sources, or a test suite name in any combination.
-        run vertica
-        run sqlserver,vertica
-        run standard
+        run postgres_odbc,postgres_jdbc
 
     The 'run' argument can also take the --verify flag to run a connection test against tests with SmokeTest = True set.
-        run postgres --verify
+        run postgres_odbc --verify
 
     Both logical and expression tests are run by default.
-    Run all sqlserver expression tests
-       run -e sqlserver
+    Run all expression tests
+       run postgres_odbc -e
 
-    Run all vertica logical tests
-        run -q vertica
+    Run all logical tests
+        run postgres_odbc -q
 
     There are multiple suites of expression tests, for example, standard and LOD (level of detail). The config files that drive the tests
     are named expression_test.sqlserver.cfg and expression.lod.sqlserver.cfg.
     To run just one of those try entering part of the config name as an argument:
-        run -e lod --run sqlserver
+        run postgres_odbc -e lod 
 
-    And you can run all the LOD tests against the 'standard' datasource suite like
-        run -e lod --run standard
 '''
 
 run_pattern_usage_text = '''
-    Run one test against many datasources
-        run-pattern --exp exprtests/standard/setup.date.datepart.second*.txt --tdp cast_calcs.*.tds sqlserver,vertica
-
-    The 'exp' argument is a glob pattern that is used to find the test file. It is the same style as what you will find
-    in the existing *.cfg files.
-    The 'test-ex' argument can be used to exclude test files. This is a regular expression pattern.
-    The tds pattern is used to find the tds. Use a '*' character where the tds name will be substituted,
-    ie cast_calcs.*.tds for cast_calcs.sqlserver.tds etc.
+    Run one expression test against many datasources
+        run-pattern postgres_odbc --exp exprtests/standard/setup.date.datepart.second*.txt --tdp cast_calcs.*.tds 
 
     Run one logical query test against many datasources
-        run-pattern --logp logicaltests/setup/calcs/setup.BUGS.B1713.?.xml --tdp cast_calcs.*.tds postgres
+        run-pattern postgres_odbc --logp logicaltests/setup/calcs/setup.BUGS.B1713.?.xml --tdp cast_calcs.*.tds
+
+    The 'exp' argument is a glob pattern that is used to find the test file using the relative test path.
+    The 'test-ex' argument can be used to exclude test files. This is a regular expression pattern.
+    The tds pattern is used to find the tds. Use a '*' character where the tds name will be substituted,
+    ie cast_calcs.*.tds
 
     This can be combined with * to run an arbitrary set of 'correct' logical query tests against a datasources
-        run-pattern --logp logicaltests/setup/calcs/setup.BUGS.*.?.xml --tdp cast_calcs.*.tds postgres
+        run-pattern postgres_odbc --logp logicaltests/setup/calcs/setup.BUGS.*.?.xml --tdp cast_calcs.*.tds
     Alternatively
-        run-pattern --logp logicaltests/setup/calcs/setup.BUGS.*.dbo.xml --tdp cast_calcs.*.tds sqlserver
+        run-pattern postgres_odbc --logp logicaltests/setup/calcs/setup.BUGS.*.dbo.xml --tdp cast_calcs.*.tds
 
     But skip 59740?
-        run-pattern --logp logicaltests/setup/calcs/setup.BUGS.*.dbo.xml --tdp cast_calcs.*.tds --test-ex 59740 sqlserver
+        run-pattern postgres_odbc --logp logicaltests/setup/calcs/setup.BUGS.*.dbo.xml --tdp cast_calcs.*.tds --test-ex 59740
 
     '''
 

--- a/tdvt/tdvt/tdvt.py
+++ b/tdvt/tdvt/tdvt.py
@@ -8,26 +8,21 @@ import sys
 if sys.version_info[0] < 3:
     raise EnvironmentError("TDVT requires Python 3 or greater.")
 
-from zipfile import ZipFile
 import argparse
 import glob
 import json
-import logging
-import os
 import pathlib
 import queue
 import shutil
-import subprocess
 import threading
 import time
+import zipfile
 from pathlib import Path
 from typing import List
 
 from .config_gen.datasource_list import print_ds, print_configurations, print_logical_configurations
-from .config_gen.gentests import list_configs, list_config
 from .config_gen.tdvtconfig import TdvtInvocation
 from .config_gen.test_config import TestSet, SingleLogicalTestSet, SingleExpressionTestSet, FileTestSet, TestConfig, RunTimeTestConfig
-from .resources import make_temp_dir
 from .setup_env import create_test_environment, add_datasource
 from .tabquery import *
 from .tdvt_core import generate_files, run_diff, run_tests
@@ -102,12 +97,12 @@ class TestRunner():
         optional_dir_name = self.test_config.config_file.replace('.', '_')
         if is_logs is True:
             log_dir = os.path.join(src_dir, optional_dir_name)
-            glob_path = glob.glob(os.path.join(log_dir, 'log*.txt'))
-            glob_path.extend(glob.glob(os.path.join(log_dir, 'tabprotosrv*.txt')))
+            glob_path = glob.glob(os.path.join(log_dir, '*.txt'))
+            glob_path.extend(glob.glob(os.path.join(log_dir, '*.log')))
             glob_path.extend(glob.glob(os.path.join(log_dir, 'crashdumps/*')))
         else:
             glob_path = glob.glob(os.path.join(src_dir, 'actual.*'))
-        with ZipFile(dst, mode) as myzip:
+        with zipfile.ZipFile(dst, mode, zipfile.ZIP_DEFLATED) as myzip:
             for actual in glob_path:
                 path = pathlib.PurePath(actual)
                 file_to_be_zipped = path.name


### PR DESCRIPTION
Keep all .txt and .log files including jdbc server log. Remove unneeded imports. Actually compress the log zip file.

Standardize help descriptions.