### PR TITLE
Dev tdvt lriggs

### DIFF
--- a/tdvt/tdvt/config_gen/datasource_list.py
+++ b/tdvt/tdvt/config_gen/datasource_list.py
@@ -24,7 +24,7 @@ def print_ds(ds, ds_reg):
     for x in test_config.get_logical_tests():
         print("\t" * 2 + str(x))
         root_directory = get_root_dir()
-        tests = x.generate_test_file_list_from_config()
+        tests = x.generate_test_file_list()
         for test in tests:
             print("\t" * 3 + test.test_path)
 
@@ -32,7 +32,7 @@ def print_ds(ds, ds_reg):
     for x in test_config.get_expression_tests():
         print("\t" * 2 + str(x))
         root_directory = get_root_dir()
-        tests = x.generate_test_file_list_from_config()
+        tests = x.generate_test_file_list()
         for test in tests:
             print("\t" * 3 + test.test_path)
 

--- a/tdvt/tdvt/config_gen/test_config.py
+++ b/tdvt/tdvt/config_gen/test_config.py
@@ -65,7 +65,7 @@ class TestSet(object):
            Return the sorted list of tests.
 
         """
-        if self.test_list_checked == True:
+        if self.test_list_checked:
             return self.test_list_cached
 
         final_test_list = self.__generate_test_file_list()

--- a/tdvt/tdvt/config_gen/test_config.py
+++ b/tdvt/tdvt/config_gen/test_config.py
@@ -41,6 +41,8 @@ class TestSet(object):
         self.smoke_test = smoke_test
         self.test_is_enabled = test_is_enabled
         self.test_is_skipped = test_is_skipped
+        self.test_list_cached = None
+        self.test_list_checked = False
 
 
     def is_logical_test(self):
@@ -63,24 +65,20 @@ class TestSet(object):
            Return the sorted list of tests.
 
         """
-        final_test_list = self.generate_test_file_list_from_config()
+        if self.test_list_checked == True:
+            return self.test_list_cached
 
-        logging.debug("Found final list of " + str(len(final_test_list)) + " tests to run.")
-        if len(final_test_list) == 0:
-            logging.warning("Did not find any tests to run.")
-            print("Did not find any tests to run.")
-            return final_test_list
+        final_test_list = self.__generate_test_file_list()
 
-        for x in final_test_list:
-            logging.debug("final test path " + x.test_path)
-
-        return final_test_list
+        self.test_list_cached = final_test_list
+        self.test_list_checked = True
+        return self.test_list_cached
 
     def get_test_dirs(self):
         return (self.root_dir, get_local_test_dir())
 
-    def generate_test_file_list_from_config(self):
-        """Read the config file and generate a list of tests."""
+    def __generate_test_file_list(self):
+        """Private function to generate the list of tests."""
         allowed_tests = []
         exclude_tests = self.get_exclusions()
         exclude_tests.append('expected.')
@@ -182,7 +180,7 @@ class FileTestSet(TestSet):
     def append_test_file(self, file_path):
         self.test_paths.append(file_path)
 
-    def generate_test_file_list_from_config(self):
+    def generate_test_file_list(self):
         tests_to_run = []
         for test_file in self.test_paths:
             added_test = False

--- a/tdvt/tdvt/config_gen/test_config.py
+++ b/tdvt/tdvt/config_gen/test_config.py
@@ -6,6 +6,7 @@
 import glob
 import re
 from ..resources import *
+from ..tabquery_path import TabQueryPath
 
 class TestFile(object):
     """
@@ -248,30 +249,6 @@ def build_config_name(prefix, dsname):
 
 def build_tds_name(prefix, dsname):
     return prefix + dsname + '.tds'
-
-class TabQueryPath(object):
-    def __init__(self, linux_path, mac_path, windows_path):
-        self.linux_path = linux_path
-        self.mac_path = mac_path
-        self.windows_path = windows_path
-
-    @staticmethod
-    def from_array(paths):
-        if len(paths) != 3:
-            raise IndexError
-        t = TabQueryPath(paths[0], paths[1], paths[2])
-        return t
-
-    def to_array(self):
-        return [self.linux_path, self.mac_path, self.windows_path]
-
-    def get_path(self, os):
-        if os.startswith("darwin"):
-            return self.mac_path
-        elif os.startswith("linux"):
-            return self.linux_path
-        else:
-            return self.windows_path
 
 class RunTimeTestConfig(object):
     """

--- a/tdvt/tdvt/tabquery.py
+++ b/tdvt/tdvt/tabquery.py
@@ -2,6 +2,8 @@ import configparser
 import sys
 
 from .resources import *
+from .tabquery_path import TabQueryPath
+
 tab_cli_exe = ''
 
 def configure_tabquery_path():
@@ -88,8 +90,14 @@ class TabqueryCommandLine(object):
         work.test_config.command_line = cmdline
         return cmdline
 
-def tabquerycli_exists():
+def tabquerycli_exists(tabquery_cli_path: TabQueryPath = None):
     global tab_cli_exe
+    if tabquery_cli_path:
+        resolved_path = tabquery_cli_path.get_path(sys.platform)
+        if os.path.isfile(resolved_path):
+            logging.debug("Found tabquery at [{0}]".format(resolved_path))
+            return True
+
     if os.path.isfile(tab_cli_exe):
         logging.debug("Found tabquery at [{0}]".format(tab_cli_exe))
         return True

--- a/tdvt/tdvt/tabquery_path.py
+++ b/tdvt/tdvt/tabquery_path.py
@@ -1,0 +1,23 @@
+class TabQueryPath(object):
+    def __init__(self, linux_path, mac_path, windows_path):
+        self.linux_path = linux_path
+        self.mac_path = mac_path
+        self.windows_path = windows_path
+
+    @staticmethod
+    def from_array(paths):
+        if len(paths) != 3:
+            raise IndexError
+        t = TabQueryPath(paths[0], paths[1], paths[2])
+        return t
+
+    def to_array(self):
+        return [self.linux_path, self.mac_path, self.windows_path]
+
+    def get_path(self, os):
+        if os.startswith("darwin"):
+            return self.mac_path
+        elif os.startswith("linux"):
+            return self.linux_path
+        else:
+            return self.windows_path

--- a/tdvt/tdvt/tdvt.py
+++ b/tdvt/tdvt/tdvt.py
@@ -220,6 +220,10 @@ def enqueue_single_test(args, ds_info: TestConfig, suite):
         test_set = SingleExpressionTestSet(suite, get_root_dir(), args.expression_pattern, args.tds_pattern,
                                            args.test_pattern_exclude, ds_info)
 
+    #Only try and run tests if there are some.
+    if not test_set.generate_test_file_list():
+        return None, None
+
     tdvt_invocation = TdvtInvocation(from_args=args, test_config=ds_info)
     tdvt_invocation.tds = test_set.tds_name
     tdvt_invocation.logical = test_set.is_logical
@@ -327,7 +331,7 @@ def enqueue_tests(ds_info, args, suite):
         return test_set_configs
 
     for x in tests:
-        if not x.generate_test_file_list_from_config():
+        if not x.generate_test_file_list():
             logging.error("No tests found for config " + str(x))
             return test_set_configs
 
@@ -637,9 +641,10 @@ def run_desired_tests(args, ds_registry):
                 print("Setting cannot apply since you are running multiple datasources.")
 
         suite = ds
-        single_test, single_test_config = enqueue_single_test(args, ds_info, suite)
-        if single_test:
-            test_sets.extend([(single_test, single_test_config)])
+        if args.command == 'run-pattern':
+            single_test, single_test_config = enqueue_single_test(args, ds_info, suite)
+            if single_test:
+                test_sets.extend([(single_test, single_test_config)])
         else:
             test_sets.extend(enqueue_tests(ds_info, args, suite))
 

--- a/tdvt/tdvt/tdvt_core.py
+++ b/tdvt/tdvt/tdvt_core.py
@@ -267,7 +267,7 @@ def do_work(work):
     if work.test_set.test_is_skipped is True:
         work.error_state = TestErrorSkippedTest()
 
-    final_test_list = work.test_set.generate_test_file_list_from_config()
+    final_test_list = work.test_set.generate_test_file_list()
     work.run(final_test_list)
     work.process_test_results(final_test_list)
 

--- a/tdvt/test/tdvt_test.py
+++ b/tdvt/test/tdvt_test.py
@@ -101,6 +101,10 @@ class BaseTDVTTest(unittest.TestCase):
             rt.set_tabquery_paths(env_tabquery, env_tabquery, env_tabquery)
             self.test_config.set_run_time_test_config(rt)
 
+        if self.test_config.tested_run_time_config:
+            self.assertTrue(tabquerycli_exists(self.test_config.tested_run_time_config.tabquery_paths))
+        else:
+            self.assertTrue(tabquerycli_exists())
         self.test_config.output_dir = make_temp_dir([self.test_config.suite_name])
 
     def tearDown(self):


### PR DESCRIPTION
Check for tabquery path before running unit tests that need it.
Cache list of tests for test_set. Fixed bug where run-pattern would take several seconds to run 0 tests.