### PR TITLE
Update Postgres JDBC example to use new properties map return type

### DIFF
--- a/samples/plugins/postgres_jdbc/connectionProperties.js
+++ b/samples/plugins/postgres_jdbc/connectionProperties.js
@@ -1,19 +1,12 @@
 (function propertiesbuilder(attr) {
-    var props = [];
+    var props = {};
     props["user"] = attr[connectionHelper.attributeUsername];
     props["password"] = attr[connectionHelper.attributePassword];
 
-    if (attr[connectionHelper.attributeSSLMode] == "require")
-    {        
+    if (attr[connectionHelper.attributeSSLMode] == "require") {
         props["ssl"] = "true";
         props["sslmode"] = "require";
     }
 
-    var formattedProps = [];
-
-    for (var key in props) {
-        formattedProps.push(connectionHelper.formatKeyValuePair(key, props[key]));
-    }
-    
-    return formattedProps;
+    return props;
 })


### PR DESCRIPTION
Update Postgres JDBC example to use new properties map return type.

Manual test the sample connector can be loaded.