### PR TITLE
Add string.contains.regex test

### DIFF
--- a/tdvt/CHANGELOG.md
+++ b/tdvt/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Add string.contains.regex test to test escaping regex special characters in the Contains function
 
 ## [2.1.5] - 2020-01-08
 - Update test names and setup file locations for CastCalcsTest, StaplesTest, and BadPasswordTest

--- a/tdvt/tdvt/exprtests/standard/expected.setup.string.contains.regex.txt
+++ b/tdvt/tdvt/exprtests/standard/expected.setup.string.contains.regex.txt
@@ -1,0 +1,28 @@
+<results>
+  <test name='CONTAINS(str1, &quot;A(&quot;)'>
+    <table>
+      <schema>
+        <column>[cast_calcs.postgres91].[TEMP(Test)(1234567890)(0)]</column>
+      </schema>
+      <tuple>
+        <value>%null%</value>
+      </tuple>
+      <tuple>
+        <value>false</value>
+      </tuple>
+    </table>
+  </test>
+  <test name='CONTAINS(str1, &quot;A\(&quot;)'>
+    <table>
+      <schema>
+        <column>[cast_calcs.postgres91].[TEMP(Test)(1380546255)(0)]</column>
+      </schema>
+      <tuple>
+        <value>%null%</value>
+      </tuple>
+      <tuple>
+        <value>false</value>
+      </tuple>
+    </table>
+  </test>
+</results>

--- a/tdvt/tdvt/exprtests/standard/setup.string.contains.regex.txt
+++ b/tdvt/tdvt/exprtests/standard/setup.string.contains.regex.txt
@@ -1,0 +1,2 @@
+CONTAINS(str2, "A(")
+CONTAINS(str2, "A\(")


### PR DESCRIPTION
Tests the escaping of regex special characters in the contains function, this would have caught the databricks bug. 