### PR TITLE
Make sample links https

### DIFF
--- a/samples/plugins/mysql_odbc/manifest.xml
+++ b/samples/plugins/mysql_odbc/manifest.xml
@@ -3,8 +3,8 @@
 <connector-plugin class='mysql_odbc_sample' superclass='mysql_odbc' plugin-version='0.0.0' name='Sample MySQL ODBC' version='18.1' min-version-tableau='2019.4'>
   <vendor-information>
     <company name='TestCompany' />
-    <support-link url='http://example.com' />
-    <driver-download-link url="http://drivers.example.com"/>
+    <support-link url='https://example.com' />
+    <driver-download-link url="https://drivers.example.com"/>
   </vendor-information>
   <connection-customization class="mysql_odbc_sample" enabled="true" version="10.0">
     <vendor name="vendor"/>

--- a/samples/plugins/postgres_jdbc/manifest.xml
+++ b/samples/plugins/postgres_jdbc/manifest.xml
@@ -3,8 +3,8 @@
 <connector-plugin class='postgres_jdbc' superclass='jdbc' plugin-version='0.0.0' name='PostgreSQL JDBC' version='18.1' min-version-tableau='2019.4'>
   <vendor-information>
       <company name="Company Name"/>
-      <support-link url="http://example.com"/>
-      <driver-download-link url="http://drivers.example.com"/>
+      <support-link url="https://example.com"/>
+      <driver-download-link url="https://drivers.example.com"/>
   </vendor-information>
   <connection-customization class="postgres_jdbc" enabled="true" version="10.0">
     <vendor name="vendor"/>

--- a/samples/plugins/postgres_odbc/manifest.xml
+++ b/samples/plugins/postgres_odbc/manifest.xml
@@ -4,8 +4,8 @@
 <connector-plugin class='postgres_odbc' superclass='odbc' plugin-version='0.0.0' name='PostgreSQL ODBC' version='18.1' min-version-tableau='2019.4'>
   <vendor-information>
       <company name="Company Name"/>
-      <support-link url="http://example.com"/>
-      <driver-download-link url="http://drivers.example.com"/>
+      <support-link url="https://example.com"/>
+      <driver-download-link url="https://drivers.example.com"/>
   </vendor-information>
   <connection-customization class="postgres_odbc" enabled="true" version="10.0">
     <vendor name="vendor"/>


### PR DESCRIPTION
Right now these cannot be packaged with the packager change to enforce https. Doing this as a hotfix since it's technically a regression.