### PR TITLE
Pvanderknyff/sample unification

### DIFF
--- a/samples/plugins/mysql_odbc/manifest.xml
+++ b/samples/plugins/mysql_odbc/manifest.xml
@@ -2,7 +2,7 @@
 
 <connector-plugin class='mysql_odbc_sample' superclass='mysql_odbc' plugin-version='0.0.0' name='Sample MySQL ODBC' version='18.1' min-version-tableau='2019.4'>
   <vendor-information>
-    <company name='TestCompany' />
+    <company name='Company Name' />
     <support-link url='https://example.com' />
     <driver-download-link url="https://drivers.example.com"/>
   </vendor-information>

--- a/samples/plugins/mysql_odbc/manifest.xml
+++ b/samples/plugins/mysql_odbc/manifest.xml
@@ -3,7 +3,7 @@
 <connector-plugin class='mysql_odbc_sample' superclass='mysql_odbc' plugin-version='0.0.0' name='Sample MySQL ODBC' version='18.1' min-version-tableau='2019.4'>
   <vendor-information>
     <company name='Company Name' />
-    <support-link url='https://example.com' />
+    <support-link url='https://tableau.github.io/connector-plugin-sdk/' />
     <driver-download-link url="https://drivers.example.com"/>
   </vendor-information>
   <connection-customization class="mysql_odbc_sample" enabled="true" version="10.0">

--- a/samples/plugins/mysql_odbc/manifest.xml
+++ b/samples/plugins/mysql_odbc/manifest.xml
@@ -4,7 +4,7 @@
   <vendor-information>
     <company name='Company Name' />
     <support-link url='https://tableau.github.io/connector-plugin-sdk/' />
-    <driver-download-link url="https://drivers.example.com"/>
+    <driver-download-link url="https://dev.mysql.com/downloads/connector/odbc/"/>
   </vendor-information>
   <connection-customization class="mysql_odbc_sample" enabled="true" version="10.0">
     <vendor name="vendor"/>

--- a/samples/plugins/postgres_jdbc/manifest.xml
+++ b/samples/plugins/postgres_jdbc/manifest.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<connector-plugin class='postgres_jdbc' superclass='jdbc' plugin-version='0.0.0' name='PostgreSQL JDBC' version='18.1' min-version-tableau='2019.4'>
+<connector-plugin class='postgres_jdbc' superclass='jdbc' plugin-version='0.0.0' name='Sample PostgreSQL JDBC' version='18.1' min-version-tableau='2019.4'>
   <vendor-information>
       <company name="Company Name"/>
       <support-link url="https://example.com"/>

--- a/samples/plugins/postgres_jdbc/manifest.xml
+++ b/samples/plugins/postgres_jdbc/manifest.xml
@@ -4,7 +4,7 @@
   <vendor-information>
       <company name="Company Name"/>
       <support-link url="https://tableau.github.io/connector-plugin-sdk/"/>
-      <driver-download-link url="https://drivers.example.com"/>
+      <driver-download-link url="https://jdbc.postgresql.org/"/>
   </vendor-information>
   <connection-customization class="postgres_jdbc" enabled="true" version="10.0">
     <vendor name="vendor"/>

--- a/samples/plugins/postgres_jdbc/manifest.xml
+++ b/samples/plugins/postgres_jdbc/manifest.xml
@@ -3,7 +3,7 @@
 <connector-plugin class='postgres_jdbc' superclass='jdbc' plugin-version='0.0.0' name='Sample PostgreSQL JDBC' version='18.1' min-version-tableau='2019.4'>
   <vendor-information>
       <company name="Company Name"/>
-      <support-link url="https://example.com"/>
+      <support-link url="https://tableau.github.io/connector-plugin-sdk/"/>
       <driver-download-link url="https://drivers.example.com"/>
   </vendor-information>
   <connection-customization class="postgres_jdbc" enabled="true" version="10.0">

--- a/samples/plugins/postgres_odbc/manifest.xml
+++ b/samples/plugins/postgres_odbc/manifest.xml
@@ -5,7 +5,7 @@
   <vendor-information>
       <company name="Company Name"/>
       <support-link url="https://tableau.github.io/connector-plugin-sdk/"/>
-      <driver-download-link url="https://drivers.example.com"/>
+      <driver-download-link url="https://odbc.postgresql.org/"/>
   </vendor-information>
   <connection-customization class="postgres_odbc" enabled="true" version="10.0">
     <vendor name="vendor"/>

--- a/samples/plugins/postgres_odbc/manifest.xml
+++ b/samples/plugins/postgres_odbc/manifest.xml
@@ -4,7 +4,7 @@
 <connector-plugin class='postgres_odbc' superclass='odbc' plugin-version='0.0.0' name='Sample PostgreSQL ODBC' version='18.1' min-version-tableau='2019.4'>
   <vendor-information>
       <company name="Company Name"/>
-      <support-link url="https://example.com"/>
+      <support-link url="https://tableau.github.io/connector-plugin-sdk/"/>
       <driver-download-link url="https://drivers.example.com"/>
   </vendor-information>
   <connection-customization class="postgres_odbc" enabled="true" version="10.0">

--- a/samples/plugins/postgres_odbc/manifest.xml
+++ b/samples/plugins/postgres_odbc/manifest.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
 
-<connector-plugin class='postgres_odbc' superclass='odbc' plugin-version='0.0.0' name='PostgreSQL ODBC' version='18.1' min-version-tableau='2019.4'>
+<connector-plugin class='postgres_odbc' superclass='odbc' plugin-version='0.0.0' name='Sample PostgreSQL ODBC' version='18.1' min-version-tableau='2019.4'>
   <vendor-information>
       <company name="Company Name"/>
       <support-link url="https://example.com"/>

--- a/samples/plugins/sqlite_extract/manifest.xml
+++ b/samples/plugins/sqlite_extract/manifest.xml
@@ -3,7 +3,7 @@
 <connector-plugin class='sqlite_extract' superclass='odbc' plugin-version='0.0.0' name='Sample SQLite Extract-Only' version='18.1'>
    <vendor-information>
       <company name="Company Name"/>
-      <support-link url = "https://github.com/tableau/connector-plugin-sdk"/>
+      <support-link url = "https://tableau.github.io/connector-plugin-sdk/"/>
   </vendor-information>
   <connection-customization class="sqlite_extract" enabled="true" version="10.0">
     <vendor name="vendor"/>

--- a/samples/plugins/sqlite_extract/manifest.xml
+++ b/samples/plugins/sqlite_extract/manifest.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<connector-plugin class='sqlite_extract' superclass='odbc' plugin-version='0.0.0' name='SQLite Extract-Only' version='18.1'>
+<connector-plugin class='sqlite_extract' superclass='odbc' plugin-version='0.0.0' name='Sample SQLite Extract-Only' version='18.1'>
    <vendor-information>
       <company name="Company Name"/>
       <support-link url = "https://github.com/tableau/connector-plugin-sdk"/>

--- a/samples/plugins/sqlite_extract/manifest.xml
+++ b/samples/plugins/sqlite_extract/manifest.xml
@@ -2,7 +2,7 @@
 
 <connector-plugin class='sqlite_extract' superclass='odbc' plugin-version='0.0.0' name='SQLite Extract-Only' version='18.1'>
    <vendor-information>
-      <company name="Example"/>
+      <company name="Company Name"/>
       <support-link url = "https://github.com/tableau/connector-plugin-sdk"/>
   </vendor-information>
   <connection-customization class="sqlite_extract" enabled="true" version="10.0">


### PR DESCRIPTION
Proposal to unify our samples so that they provide a consistent experience. 

- Display names now have "Sample" in front of them. This way, it's clear they are not a "real" connector and they appear next to each other on the connector list.
- Support link now points to https://tableau.github.io/connector-plugin-sdk/. If, somehow, someone actually nees support with one of these, that's as good a palce as any.
- Added the actual place to download the driver as the driver download link, except for SQLite, as the site to download that does not have https.