### PR TITLE
Update copyright date from 2018 to 2020

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,6 +6,6 @@
       This site is open source. Suggestions and pull requests are welcome on our
       <a href="https://github.com/tableau/connector-plugin-sdk">GitHub page</a>.
     </p>
-    <p>&copy; 2018 Tableau.</p>
+    <p>&copy; 2020 Tableau.</p>
   </div>
 </footer>


### PR DESCRIPTION
Not entirely sure of the legal ramifications, but it's a simple enough code change.