### PR TITLE
Pvanderknyff/docs 2020 1

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -62,7 +62,7 @@ an object of key/value pairs that will be written to the properties file(recomme
 array of formatted key=value pairs that will be written to the properties file
 
 ```javascript
-["UID=myusername", "Host=myserver.somewhere.net", "PWD=mypassword"];
+{"UID" : "myusername", "Host" : "myserver.somewhere.net", "PWD" : "mypassword"};
 ```
 
 ---
@@ -227,3 +227,10 @@ Example:
 
     formattedParams.push(connectionHelper.FormatKeyValuePair(driverLocator.keywordDriver, driverLocator.LocateDriver(attr)));
 
+## Deprecated API
+
+### SetImpersonateAttributes connection helper
+This connection helper is deprecated as of Tableau 2020.1, since we always set impersonate attributes for all connectors. Trying to use this in a JavaScript component will throw an error when attempting to connect.
+
+### <setImpersonateAttributes/> XML tag
+This xml tag is deprecated as of Tableau 2020.1, though it has not yet been removed from the XSD. Since we always set this property starting with 2020.1, this tag is redundant.

--- a/docs/example.md
+++ b/docs/example.md
@@ -169,8 +169,7 @@ JDBCProtocol Connection URL: jdbc:postgresql://postgres:5342/TestV1?user=test&pa
 ## ![9]({{ site.baseurl }}/assets/pce-9.png) \*.tdd
 
 After connection, Tableau uses your _.tdd dialect file to determine which SQL to generate when retrieving information from your database.
-You can define your own dialect in the _.tdd file, or your connector can inherit a dialect from its parent. If you are using the 'odbc' or 'jdbc' superclasses you must
-define a dialect, since those superclasses do not have dialects.
+You can define your own dialect in the _.tdd file, or your connector can inherit a dialect from its parent. If you are using the 'odbc' or 'jdbc' superclasses you must define a dialect, since those superclasses do not have dialects.
 
 ### Example dialect.tdd
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -42,9 +42,9 @@ connection-resolver.tdr
       <required-attributes>
       <attribute-list>
         ...
-        <attr> vendor1 </attr> 
-        <attr> vendor2 </attr> 
-        <attr> vendor3 </attr> 
+        <attr> vendor1 </attr>
+        <attr> vendor2 </attr>
+        <attr> vendor3 </attr>
 
       </attribute-list>
       </required-attributes>
@@ -65,7 +65,7 @@ connection-dialog.tcd
       </connection-dialog>
 ```
 
-connectionBuilder.js (Non-JDBC)
+connectionBuilder.js (ODBC)
 ```js
 (function dsbuilder(attr)
   {
@@ -80,7 +80,7 @@ connectionBuilder.js (Non-JDBC)
     params["protocolVersion"] = attr[connectionHelper.attributeVendor2];
     params["charSet"] = attr[connectionHelper.attributeVendor3];
     ...
-      
+
 ```
 
 connectionProperties.js (For JDBC only)
@@ -94,7 +94,7 @@ connectionProperties.js (For JDBC only)
       if (attr[connectionHelper.attributeSSLMode] == "require")
       {
       ...
-      
+
 ```
 
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -17,7 +17,7 @@ The connector is displayed as "[Display Name] by [Company Name]" in the connecti
 "For support, contact [Company Name]" is displayed at the bottom left of the connector. Clicking this link sends the user to the support link defined in the manifest. This link also displays in error messages. The support link must use HTTPS to be packaged into a `.taco` file.
 
 These elements are defined in the manifest.xml file:
-```
+```xml
 <connector-plugin class='postgres_odbc' superclass='odbc' plugin-version='0.0.0' name='PostgreSQL ODBC' version='18.1'>
   <vendor-information>
       <company name="Company Name"/>
@@ -27,10 +27,83 @@ These elements are defined in the manifest.xml file:
 </connector-plugin>
 ```
 
+## Vendor Attributes (Custom Fields)
+Vendors can add customized attributes to their connector plugin by using the vendor attributes.
+
+These fields have a custom label and can be used for attributes in the connection strings that are not available in the attribute list. You can currently add 3 custom fields in your connector plugin.
+
+To add a custom vendor-attribute, you will need to modify your connection-dialog.tcd, connectionResolver.tdr and connectionBuilder.js.
+**For JDBC based plugins, you will need to modify connectionProperties.js instead of connectionBuilder.js**
+
+connection-resolver.tdr
+
+```xml
+    ...
+      <required-attributes>
+      <attribute-list>
+        ...
+        <attr> vendor1 </attr> 
+        <attr> vendor2 </attr> 
+        <attr> vendor3 </attr> 
+
+      </attribute-list>
+      </required-attributes>
+    ...
+```
+
+connection-dialog.tcd
+
+```xml
+ <connector-plugin class='postgres_jdbc' superclass='jdbc' plugin-version='0.0.0' name='PostgreSQL JDBC' version='18.1'>
+          <connection-config>
+            ...
+            <vendor1-prompt value="Log Level: "/>
+            <vendor2-prompt value="Protocol Version: "/>
+            <vendor3-prompt value="Char Set: "/>
+
+        </connection-config>
+      </connection-dialog>
+```
+
+connectionBuilder.js (Non-JDBC)
+```js
+(function dsbuilder(attr)
+  {
+    var params = {};
+
+    params["SERVER"] = attr[connectionHelper.attributeServer];
+    params["PORT"] = attr[connectionHelper.attributePort];
+    params["DATABASE"] = attr[connectionHelper.attributeDatabase];
+    params["UID"] = attr[connectionHelper.attributeUsername];
+    params["PWD"] = attr[connectionHelper.attributePassword];
+    params["loglevel"] = attr[connectionHelper.attributeVendor1];
+    params["protocolVersion"] = attr[connectionHelper.attributeVendor2];
+    params["charSet"] = attr[connectionHelper.attributeVendor3];
+    ...
+      
+```
+
+connectionProperties.js (For JDBC only)
+```js
+      ...
+      props["password"] = attr[connectionHelper.attributePassword];
+      props["logLevel"] = attr[connectionHelper.attributeVendor1];
+      props["protocolVersion"] = attr[connectionHelper.attributeVendor2];
+      props["charSet"] = attr[connectionHelper.attributeVendor3];
+
+      if (attr[connectionHelper.attributeSSLMode] == "require")
+      {
+      ...
+      
+```
+
+
+For complete files, [Click Here](https://github.com/tableau/connector-plugin-sdk/tree/dev/samples/components/dialogs/new_text_field)
+
 ## The Tableau Custom Dialog File
 
 The UI elements you see in the dialog are determined in the .tcd file:
-```
+```xml
 <connection-dialog class='postgres_odbc'>
   <connection-config>
     <authentication-mode value='Basic' />
@@ -49,6 +122,6 @@ The `authentication-mode` and `authentication-options` tags control how a user i
 
 The other tags control what prompts show up in the connection dialog. For example, `<port-prompt value="Port: " default="5432" />` shows the Port prompt with the label of Port and a default value of 5432.
 
-## Localizing you connector
+## Localizing your connector
 
 For information on localizing your connection dialogs, see [Localize Your Connector]({{ site.baseurl }}/docs/localize)


### PR DESCRIPTION
The 2020.1 changes to the documentation. Mainly a couple of stray typos being fixed and Saugat's vendor attributes documentation.
