### PR TITLE
Add news section and initial post

### DIFF
--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -31,7 +31,8 @@ layout: news
                     {{ post.abstract }}
                 </p>
                 {% if post.photoname %}
-                <img class="img-responsive" src="{{ site.baseurl }}/assets/{{ post.photoname}}" alt=""> {% endif %}
+                <img class="img-responsive" src="{{ site.baseurl }}/assets/{{ post.photoname}}" alt="">
+                {% endif %}
                 <hr>
                 <div class="blog-content">
                     {{ post.content }}

--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -1,0 +1,46 @@
+---
+layout: news
+---
+<!DOCTYPE html>
+<html>
+
+<head>
+    {% include head.html %}
+</head>
+
+<body>
+    <div class="container">
+        {% include header.html %}
+        <div>
+		<h3>Connector SDK News</h3>
+		    <ul class=posts >
+			  {% for post in site.posts %}
+	          <li><a href="#{{ post.id }}" >{{ post.title }}</a> &nbsp;  <span style="font-size:80%;">({{ post.date | date_to_string }})</span></li>
+	         {% endfor %}
+		    </ul>
+			<hr/>
+	   </div>
+        <ul class="blogul">
+            {% for post in site.posts %}
+            <div>
+                <h1 id="{{post.id}}">{{ post.title }} </a></h1>
+                <hr>
+                <p><span class="glyphicon glyphicon-time"></span> Posted on {{ post.date | date: "%-d %B %Y" }}</p>
+                <hr>
+                <p class="lead">
+                    {{ post.abstract }}
+                </p>
+                {% if post.photoname %}
+                <img class="img-responsive" src="{{ site.baseurl }}/assets/{{ post.photoname}}" alt=""> {% endif %}
+                <hr>
+                <div class="blog-content">
+                    {{ post.content }}
+                </div>
+            </div>
+            {% endfor %}
+        </ul>
+        {% include footer.html %}
+    </div>
+</body>
+
+</html>

--- a/_posts/2020-03-31-new-release.md
+++ b/_posts/2020-03-31-new-release.md
@@ -3,4 +3,6 @@ title:  "Tableau Connector SDK for 2019.4 Released, latest version of SDK now ta
 abstract: "The Connector SDK for 2019.4 has released for those wishing to target that version. The main SDK branch now targets Tableau 2020.1"
 ---
 
-On March 11th, with the full release of Tableau 2020.1 we moved the latest version of the master branch to target Tableau 2020.1. This means that the samples and connectors made with this version of the SDK may not work with older versions of Tableau. To develop against Tableau 2019.4, please download the "Tableau Connector SDK for Tableau 2019.4" release.
+On March 11th, with the full release of Tableau 2020.1 we moved the latest version of the master branch to target Tableau 2020.1. This means that the samples and connectors made with this version of the SDK may not work with older versions of Tableau. To develop against Tableau 2019.4, please download the [Tableau Connector SDK for Tableau 2019.4](https://github.com/tableau/connector-plugin-sdk/releases/tag/tableau-2019.4) release.
+
+One of the new features is the addition of three new customizable text fields called Vendor Attributes! We have instructions on how to use them in our [documentation](https://github.com/tableau/connector-plugin-sdk/tree/master/samples/plugins/postgres_jdbc), and you can see an example of them in a working connector in our Postgres JDBC sample connector [here](https://github.com/tableau/connector-plugin-sdk/tree/master/samples/plugins/postgres_jdbc).

--- a/_posts/2020-03-31-new-release.md
+++ b/_posts/2020-03-31-new-release.md
@@ -1,0 +1,6 @@
+---
+title:  "Tableau Connector SDK for 2019.4 Released, latest version of SDK now targets 2020.1"
+abstract: "The Connector SDK for 2019.4 has released for those wishing to target that version. The main SDK branch now targets Tableau 2020.1"
+---
+
+On March 11th, with the full release of Tableau 2020.1 we moved the latest version of the master branch to target Tableau 2020.1. This means that the samples and connectors made with this version of the SDK may not work with older versions of Tableau. To develop against Tableau 2019.4, please download the "Tableau Connector SDK for Tableau 2019.4" release.

--- a/index.html
+++ b/index.html
@@ -43,8 +43,7 @@ indexed_by_search: false
             </div>
         </div>
     </div>
-
-<!--    <div class="col-md-3 text-center">
+   <div class="col-md-3 text-center">
         <div class="thumbnail thumb-home">
             <a href="{{ site.baseurl }}/news/"><img src="{{ site.baseurl }}/assets/logo.png" class="img-home" alt="News Link"></a>
             <div class="caption">
@@ -54,4 +53,4 @@ indexed_by_search: false
         </div>
     </div>
 </div>
--->
+

--- a/news/index.md
+++ b/news/index.md
@@ -1,0 +1,5 @@
+---
+title: News
+layout: news
+indexed_by_search: false
+---


### PR DESCRIPTION
I need to beef up the post a bit, but this adds a news section that we can post to. I've tested locally, will try and get it to be visible to other computers as well. You can get a good idea of what it looks like from here (since I borrowed a lot of code from it): https://tableau.github.io/webdataconnector/news/