### PR TITLE
Enforce platform reserved Connection Field name values 

### DIFF
--- a/connector-packager/connector_packager/xsd_validator.py
+++ b/connector-packager/connector_packager/xsd_validator.py
@@ -6,6 +6,8 @@ from typing import List, Optional
 
 from xmlschema import XMLSchema
 
+from defusedxml.ElementTree import parse
+
 from .connector_file import ConnectorFile
 
 logger = logging.getLogger('packager_logger')
@@ -13,6 +15,8 @@ logger = logging.getLogger('packager_logger')
 MAX_FILE_SIZE = 1024 * 256  # This is based on the max file size we will load on the Tableau side
 PATH_TO_XSD_FILES = Path("../validation").absolute()
 VALID_XML_EXTENSIONS = ['tcd', 'tdr', 'tdd', 'xml']  # These are the file extensions that we will validate
+PLATFORM_FIELD_NAMES = ['server', 'port', 'sslmode', 'authentication', 'username', 'password']
+VENDOR_FIELD_NAME_PREFIX = 'v-'
 
 # Holds the mapping between file type and XSD file name
 XSD_DICT = {
@@ -118,6 +122,10 @@ def validate_single_file(file_to_test: ConnectorFile, path_to_file: Path, xml_vi
         logger.error("XML Validation failed for " + file_to_test.file_name)
         return False
 
+    if not validate_file_specific_rules(file_to_test, path_to_file, xml_violations_buffer):
+        logger.error("XML Validation failed for " + file_to_test.file_name)
+        return False
+
     return True
 
 
@@ -135,3 +143,20 @@ def get_xsd_file(file_to_test: ConnectorFile) -> Optional[str]:
         return xsd_file + ".xsd"
     else:
         return None
+
+
+def validate_file_specific_rules(file_to_test: ConnectorFile, path_to_file: Path, xml_violations_buffer: List[str]) -> bool:
+
+    if file_to_test.file_type == 'connection-fields':
+        xml_tree = parse(str(path_to_file))
+        root = xml_tree.getroot()
+
+        for child in root.iter('field'):
+            if 'name' in child.attrib:
+                field_name = child.attrib['name']
+                if not (field_name in PLATFORM_FIELD_NAMES or field_name.startswith(VENDOR_FIELD_NAME_PREFIX)):
+                    xml_violations_buffer.append("Element 'field', attribute 'name'='" + field_name +
+                                                 "' not an allowed value. See 'Connection Field Platform Integration' section of documentation for allowed values.")
+                    return False
+
+    return True

--- a/connector-packager/tests/test_resources/broken_xml/connectionFields.xml
+++ b/connector-packager/tests/test_resources/broken_xml/connectionFields.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <connection-fields>
-  <field name="server" label="Server" value-type="string" category="endpoint" >
-    <validation-rule reg-exp="^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$"/>
-  </field>
+  <field name="server" label="Server" value-type="string" category="endpoint" />
 
   <field name="port" label="Port" value-type="string" category="endpoint" default-value="5432" />
 
-  <field name="v-custom" label="Custom" value-type="string" category="endpoint" />
+  <field name="warehouse" label="Warehouse" value-type="string" category="metadata" />
 
   <field name="username" label="Username" value-type="string" category="authentication" />
 

--- a/connector-packager/tests/test_resources/modular_dialog_connector/connectionResolver.xml
+++ b/connector-packager/tests/test_resources/modular_dialog_connector/connectionResolver.xml
@@ -11,6 +11,7 @@
           <attr>server</attr>
           <attr>port</attr>
           <attr>dbname</attr>
+          <attr>v-custom</attr>
           <attr>username</attr>
           <attr>password</attr>
         </attribute-list>

--- a/connector-packager/tests/test_xsd_validator.py
+++ b/connector-packager/tests/test_xsd_validator.py
@@ -65,3 +65,20 @@ class TestXSDValidator(unittest.TestCase):
         logging.debug("test_validate_single_file xml violations:")
         for violation in xml_violations_buffer:
             logging.debug(violation)
+
+    def test_validate_vendor_prefix(self):
+
+        test_file = TEST_FOLDER / Path("modular_dialog_connector/connectionFields.xml")
+        file_to_test = ConnectorFile("connectionFields.xml", "connection-fields")
+        xml_violations_buffer = []
+
+        self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer),
+                        "Valid XML file not marked as valid")
+
+        test_file = TEST_FOLDER / Path("broken_xml/connectionFields.xml")
+        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer),
+                         "XML file that doesn't follow valid name values marked as valid")
+
+        logging.debug("test_validate_vendor_prefix xml violations:")
+        for violation in xml_violations_buffer:
+            logging.debug(violation)

--- a/connector-packager/tests/test_xsd_validator.py
+++ b/connector-packager/tests/test_xsd_validator.py
@@ -68,7 +68,7 @@ class TestXSDValidator(unittest.TestCase):
 
     def test_validate_vendor_prefix(self):
 
-        test_file = TEST_FOLDER / Path("modular_dialog_connector/connectionFields.xml")
+        test_file = TEST_FOLDER / "modular_dialog_connector/connectionFields.xml"
         file_to_test = ConnectorFile("connectionFields.xml", "connection-fields")
         xml_violations_buffer = []
 
@@ -76,7 +76,7 @@ class TestXSDValidator(unittest.TestCase):
                         "Valid XML file not marked as valid")
 
         print("\nTest malformed xml. Throws XML validation error.")
-        test_file = TEST_FOLDER / Path("broken_xml/connectionFields.xml")
+        test_file = TEST_FOLDER / "broken_xml/connectionFields.xml"
         self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer),
                          "XML file that doesn't follow valid name values marked as valid")
 

--- a/connector-packager/tests/test_xsd_validator.py
+++ b/connector-packager/tests/test_xsd_validator.py
@@ -75,6 +75,7 @@ class TestXSDValidator(unittest.TestCase):
         self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer),
                         "Valid XML file not marked as valid")
 
+        print("\nTest malformed xml. Throws XML validation error.")
         test_file = TEST_FOLDER / Path("broken_xml/connectionFields.xml")
         self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer),
                          "XML file that doesn't follow valid name values marked as valid")

--- a/connector-packager/tests/test_xsd_validator.py
+++ b/connector-packager/tests/test_xsd_validator.py
@@ -78,7 +78,7 @@ class TestXSDValidator(unittest.TestCase):
         print("\nTest malformed xml. Throws XML validation error.")
         test_file = TEST_FOLDER / "broken_xml/connectionFields.xml"
         self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer),
-                         "XML file that doesn't follow valid name values marked as valid")
+                         "XML file with invalid name values marked as valid")
 
         logging.debug("test_validate_vendor_prefix xml violations:")
         for violation in xml_violations_buffer:


### PR DESCRIPTION
See documentation in 'Connection Field Platform Integration' section of [Connection Dialog V2](https://tableau.github.io/connector-plugin-sdk/docs/mcd) 

Enforce allowed names: server, port, sslmode, authentication, username, password or prefix v-

More details in TFS1092438.