### PR TITLE
Adding legal and privacy links to footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
       This site is open source. Suggestions and pull requests are welcome on our
       <a href="https://github.com/tableau/connector-plugin-sdk">GitHub page</a>.
     </p>
-    <p>&copy; Copyright <script>document.write(new Date().getFullYear())</script> Tableau</p>
+    <p><a href="https://www.tableau.com/en-us/legal" class="aLegal">LEGAL</a> <a href="https://www.tableau.com/en-us/privacy" class="aLegal">PRIVACY</a> &copy; 2003&ndash;<script>document.write(new Date().getFullYear())</script> TABLEAU SOFTWARE LLC. ALL RIGHTS RESERVED</p>
     <sub>Documentation last generated on: {{ site.time }}</sub>
   </div>
 </footer>

--- a/css/main.css
+++ b/css/main.css
@@ -273,4 +273,8 @@ html {
 .size-1of2 { width: 50%; }
 .size-1of3 { width: 33.333%; }
 
-
+/* Legal and Privacy Links */
+.aLegal  {
+    word-spacing:  8px;
+    padding-right: 8px;
+}


### PR DESCRIPTION
Doc update:

- For GDPR compliance, adding legal and privacy links
- Updating styles and formatting of copyright text



