### PR TITLE
Add documentataion for DATEPARSE

### DIFF
--- a/docs/dialect.md
+++ b/docs/dialect.md
@@ -64,6 +64,12 @@ The function <span style="font-family: courier new">name</span> must be one of t
   
   Like <span style="font-family: courier new">function</span>, <span style="font-family: courier new">date-function</span> requires name and return-type, but unlike <span style="font-family: courier new">function</span>, group is not required. 
 
+  - __DATEPARSE function__  
+  The <span style="font-family: courier new">DATEPARSE</span> function is used to define which parts of your field are which parts of a date. It uses the <span style="font-family: courier new">icu-date-token-map</span> instead of the <span style="font-family: courier new">date-part-group</span> formula used primarily by the other date function. As a modifier for the date string to be converted into a date, it uses the <span style="font-family: courier new">date-literal-escape</span>. 
+  As an example, for the [DATEPARSE function](https://github.com/tableau/connector-plugin-sdk/blob/master/samples/components/dialects/Annotated.tdd#L945) with arguments <span style="font-family: courier new">%1</span> and <span style="font-family: courier new">%2</span>, 
+  the string values for <span style="font-family: courier new">%1</span> are defined by [icu-token-map](https://github.com/tableau/connector-plugin-sdk/blob/master/samples/components/dialects/Annotated.tdd#L1369) and the string values for <span style="font-family: courier new">%2</span> are defined by [date-literal-escape](https://github.com/tableau/connector-plugin-sdk/blob/master/samples/components/dialects/Annotated.tdd#L1130) .
+
+
 - __remove-function element__  
 The <span style="font-family: courier new">remove-function</span> is used to remove existing functions in a function map without overriding them. It requires only a <span style="font-family: courier new">name</span> attribute and doesn't require you to specify any <span style="font-family: courier new">formula</span>. 
 

--- a/docs/dialect.md
+++ b/docs/dialect.md
@@ -64,7 +64,7 @@ The function <span style="font-family: courier new">name</span> must be one of t
   
   Like <span style="font-family: courier new">function</span>, <span style="font-family: courier new">date-function</span> requires name and return-type, but unlike <span style="font-family: courier new">function</span>, group is not required. 
 
-  - __DATEPARSE function__  
+    **DATEPARSE function**  
   The <span style="font-family: courier new">DATEPARSE</span> function is used to define which parts of your field are which parts of a date. It uses the <span style="font-family: courier new">icu-date-token-map</span> instead of the <span style="font-family: courier new">date-part-group</span> formula used primarily by the other date function. As a modifier for the date string to be converted into a date, it uses the <span style="font-family: courier new">date-literal-escape</span>. 
   As an example, for the [DATEPARSE function](https://github.com/tableau/connector-plugin-sdk/blob/master/samples/components/dialects/Annotated.tdd#L945) with arguments <span style="font-family: courier new">%1</span> and <span style="font-family: courier new">%2</span>, 
   the string values for <span style="font-family: courier new">%1</span> are defined by [icu-token-map](https://github.com/tableau/connector-plugin-sdk/blob/master/samples/components/dialects/Annotated.tdd#L1369) and the string values for <span style="font-family: courier new">%2</span> are defined by [date-literal-escape](https://github.com/tableau/connector-plugin-sdk/blob/master/samples/components/dialects/Annotated.tdd#L1130) .

--- a/docs/dialect.md
+++ b/docs/dialect.md
@@ -63,6 +63,8 @@ return-type | Y | Indicates the return type of the function. For a list of allow
 The <span style="font-family: courier new">date-function</span> element is a specialized variant of <span style="font-family: courier new">function</span>. In addition to the base formula, you can specify one or more datepart formulas, which are used instead of the generic formula when available.  
 The function <span style="font-family: courier new">name</span> must be one of these: DATEADD, DATEDIFF, DATENAME, DATEPARSE, DATEPART, DATETRUNC.   
 
+ Like <span style="font-family: courier new">function</span>, <span style="font-family: courier new">date-function</span> requires name and return-type, but unlike <span style="font-family: courier new">function</span>, group is not required. 
+
   **Example: DATEPART without custom start of week**
 
     ```xml
@@ -118,9 +120,6 @@ The function <span style="font-family: courier new">name</span> must be one of t
   The <span style="font-family: courier new">DATEPARSE</span> function is used to define which parts of your field are which parts of a date. It uses the <span style="font-family: courier new">icu-date-token-map</span> instead of the <span style="font-family: courier new">date-part-group</span> formula used primarily by the other date function. As a modifier for the date string to be converted into a date, it uses the <span style="font-family: courier new">date-literal-escape</span>. 
   As an example, for the [DATEPARSE function](https://github.com/tableau/connector-plugin-sdk/blob/master/samples/components/dialects/Annotated.tdd#L945) with arguments <span style="font-family: courier new">%1</span> and <span style="font-family: courier new">%2</span>, 
   the string values for <span style="font-family: courier new">%1</span> are defined by [icu-token-map](https://github.com/tableau/connector-plugin-sdk/blob/master/samples/components/dialects/Annotated.tdd#L1369) and the string values for <span style="font-family: courier new">%2</span> are defined by [date-literal-escape](https://github.com/tableau/connector-plugin-sdk/blob/master/samples/components/dialects/Annotated.tdd#L1130) .
-
-  
-  Like <span style="font-family: courier new">function</span>, <span style="font-family: courier new">date-function</span> requires name and return-type, but unlike <span style="font-family: courier new">function</span>, group is not required. 
 
 - __remove-function element__  
 The <span style="font-family: courier new">remove-function</span> is used to remove existing functions in a function map without overriding them. It requires only a <span style="font-family: courier new">name</span> attribute and doesn't require you to specify any <span style="font-family: courier new">formula</span>. 


### PR DESCRIPTION
Add a section under the date-functions for dateparse as it is a little different from the other usual date functions.

Kept it a little short, like the other paras on the page and also linked an example of dateparse from Annoteted.tdd file for now . We may want to re-link it to the postgres_odbc or postgres_jdbc that will be added in future if required. Also tried to explain a little based off the example so its better to understand,