### PR TITLE
TFSID1121798: [SDK][Docs] remove 'base-types' from tdd samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@
 ### Changed
 ### Removed
 
-## 2020-12-11
+## 2020-06-11
+### Removed
+- Remove `base-types` from tdd samples. Intended functionality is exposed in `<format-column-definition>`
+
+## 2020-06-02
 ### Changed
 - Date functions in dialect examples to have only `<formula part='week'>` for functions with `localstr` as last argument. See [isuue](https://github.com/tableau/connector-plugin-sdk/issues/505) for details
-
 
 ## 2019-12-11
 ### Added

--- a/samples/components/dialects/Annotated.tdd
+++ b/samples/components/dialects/Annotated.tdd
@@ -1107,18 +1107,6 @@
   -->
   <sql-format>
     <!--
-      base-types
-      Map of Tableau types to basic DB types
-    -->
-    <base-types>
-      <local-type name='real' value='DOUBLE' />
-      <local-type name='int' value='BIGINT' />
-      <local-type name='str' value='VARCHAR' />
-      <local-type name='bool' value='TINYINT' />
-      <local-type name='date' value='DATE' />
-      <local-type name='datetime' value='TIMESTAMP' />
-    </base-types>
-    <!--
       date-literal-escape
       Used with the DATEPARSE function.
       Defines how Tableau formats literals in a date format string.


### PR DESCRIPTION
This is unreferenced in the code.  Intended functionality is exposed in <format-column-definition>