### PR TITLE
Add commands in tdvt to run the connectors test command already added to tabquerycli

### DIFF
--- a/tdvt/tdvt/config/tdvt/tdvt.ini
+++ b/tdvt/tdvt/config/tdvt/tdvt.ini
@@ -1,3 +1,3 @@
 [DEFAULT]
-TAB_CLI_EXE_X64 = D:\dev\near_jai\tableau-1.3\build\Release-x64\tabquerycli.exe
-TAB_CLI_EXE_MAC = D:\dev\near_jai\tableau-1.3\build\Release-x64\tabquerycli.exe
+TAB_CLI_EXE_X64 = C:/Program Files/Tableau/Tableau 2019.2/bin/tabquerytool.exe
+TAB_CLI_EXE_MAC = /Applications/Tableau 2019.2.app/Contents/MacOS/tabquerytool

--- a/tdvt/tdvt/config/tdvt/tdvt.ini
+++ b/tdvt/tdvt/config/tdvt/tdvt.ini
@@ -1,3 +1,3 @@
 [DEFAULT]
-TAB_CLI_EXE_X64 = C:/Program Files/Tableau/Tableau 2019.2/bin/tabquerytool.exe
-TAB_CLI_EXE_MAC = /Applications/Tableau 2019.2.app/Contents/MacOS/tabquerytool
+TAB_CLI_EXE_X64 = D:\dev\near_jai\tableau-1.3\build\Release-x64\tabquerycli.exe
+TAB_CLI_EXE_MAC = D:\dev\near_jai\tableau-1.3\build\Release-x64\tabquerycli.exe

--- a/tdvt/tdvt/tabquery.py
+++ b/tdvt/tdvt/tabquery.py
@@ -41,10 +41,18 @@ def build_tabquery_command_line(work):
     cmdline = tb.build_tabquery_command_line(work)
     return cmdline
 
+def build_tabquery_command_line_connectors(connTestName, connTestFileName):
+    global tab_cli_exe
+    cmdline = [tab_cli_exe]
+    cmdline.extend(["--conn-test", connTestName])
+    cmdline.extend(["--conn-test-file", connTestFileName])
+    return cmdline
+    
 class TabqueryCommandLine(object):
     def extend_command_line(self, cmdline, work):
         pass
 
+    
     def build_tabquery_command_line(self, work):
         """Build the command line string for calling tabquerycli."""
         global tab_cli_exe

--- a/tdvt/tdvt/tabquery.py
+++ b/tdvt/tdvt/tabquery.py
@@ -41,18 +41,17 @@ def build_tabquery_command_line(work):
     cmdline = tb.build_tabquery_command_line(work)
     return cmdline
 
-def build_tabquery_command_line_connectors(connTestName, connTestFileName):
+def build_connectors_test_tabquery_command_line(connTestName, connTestFileName):
     global tab_cli_exe
     cmdline = [tab_cli_exe]
     cmdline.extend(["--conn-test", connTestName])
     cmdline.extend(["--conn-test-file", connTestFileName])
     return cmdline
-    
+
 class TabqueryCommandLine(object):
     def extend_command_line(self, cmdline, work):
         pass
 
-    
     def build_tabquery_command_line(self, work):
         """Build the command line string for calling tabquerycli."""
         global tab_cli_exe

--- a/tdvt/tdvt/tdvt.py
+++ b/tdvt/tdvt/tdvt.py
@@ -417,7 +417,7 @@ run_pattern_usage_text = '''
     '''
 run_connectors_test_usage_text = '''
     The commands below can be used to run the connectors tests.
-    'filename.txt' in the below commands is the path of the xml test file used to run the tests.
+    'filename.xml' in the below commands is the path of the xml test file used to run the tests.
     Run ConnectionBuilderTest
         run-connectors-test --conn-test connectionBuilder --conn-test-file filepath.xml
     Run NormalizeConnectionAttributes Test
@@ -492,8 +492,8 @@ def create_parser():
 
     #Run Connectors Test
     run_connectors_test_parser = subparsers.add_parser('run-connectors-test', help='Run a connectors test using a file', parents=[run_test_common_parser], usage=run_connectors_test_usage_text)
-    run_connectors_test_parser.add_argument('--conn-test', dest='conn_test', help='Name of the Connectors Test to run.',  required=True, default=None, const='', nargs='?')
-    run_connectors_test_parser.add_argument('--conn-test-file', dest='conn_test_file', help='Path to the setup-expected file to run the connectors test',  required=True, default=None, const='', nargs='?')
+    run_connectors_test_parser.add_argument('--conn-test', dest='conn_test', help='Name of the Connectors Test to run.',  required=True)
+    run_connectors_test_parser.add_argument('--conn-test-file', dest='conn_test_file', help='Path to the setup-expected file to run the connectors test',  required=True)
 
     return parser
 

--- a/tdvt/tdvt/tdvt.py
+++ b/tdvt/tdvt/tdvt.py
@@ -25,7 +25,7 @@ from .config_gen.tdvtconfig import TdvtInvocation
 from .config_gen.test_config import TestSet, SingleLogicalTestSet, SingleExpressionTestSet, FileTestSet, TestConfig, RunTimeTestConfig
 from .setup_env import create_test_environment, add_datasource
 from .tabquery import *
-from .tdvt_core import generate_files, run_diff, run_tests
+from .tdvt_core import generate_files, run_diff, run_tests, run_connectors_test_core
 from .version import __version__
 
 # This contains the dictionary of configs you can run.
@@ -415,6 +415,21 @@ run_pattern_usage_text = '''
         run-pattern postgres_odbc --logp logicaltests/setup/calcs/setup.BUGS.*.dbo.xml --tdp cast_calcs.*.tds --test-ex 59740
 
     '''
+run_connectors_test_usage_text = '''
+    The commands below can be used to run the connectors tests.
+    'filename.txt' in the below commands is the path of the xml test file used to run the tests.
+    Run ConnectionBuilderTest
+        run-connectors-test --conn-test connectionBuilder --conn-test-file filepath.xml
+    Run NormalizeConnectionAttributes Test
+        run-connectors-test --conn-test normalizeConnectionAttributes --conn-test-file filepath.xml
+    Run MatchesConnectionAttributesTest
+         run-connectors-test --conn-test matchesConnectionAttributes --conn-test-file filepath.xml
+    Run PropertiesBuilderTest
+        run-connectors-test --conn-test propertiesBuilder --conn-test-file filepath.xml
+    Run ServerVersionTest
+        run-connectors-test --conn-test serverVersion --conn-test-file filepath.xml   
+
+'''
 
 action_usage_text = '''
 '''
@@ -475,6 +490,11 @@ def create_parser():
     run_file_parser = subparsers.add_parser('run-file', help='Run tests from a file.', parents=[run_test_common_parser], usage=run_file_usage_text)
     run_file_parser.add_argument('run_file', help='Json file containing failed tests to run.')
 
+    #Run Connectors Test
+    run_connectors_test_parser = subparsers.add_parser('run-connectors-test', help='Run a connectors test using a file', parents=[run_test_common_parser], usage=run_connectors_test_usage_text)
+    run_connectors_test_parser.add_argument('--conn-test', dest='conn_test', help='Name of the Connectors Test to run.',  required=True, default=None, const='', nargs='?')
+    run_connectors_test_parser.add_argument('--conn-test-file', dest='conn_test_file', help='Path to the setup-expected file to run the connectors test',  required=True, default=None, const='', nargs='?')
+
     return parser
 
 
@@ -502,7 +522,7 @@ def init():
     return parser, ds_reg, args
 
 def is_test(args):
-    return args.command in ['run', 'run-pattern', 'run-file']
+    return args.command in ['run', 'run-pattern', 'run-file', 'run-connectors-test']
 
 def active_thread_count(threads):
     active = 0
@@ -691,6 +711,19 @@ def run_desired_tests(args, ds_registry):
     failed_tests, skipped_tests, disabled_tests, total_tests = run_tests_impl(test_sets, max_threads, args)
     return failed_tests
 
+def run_connectors_test(args):
+    if not tabquerycli_exists():
+        print("Could not find Tabquerycli.")
+        sys.exit(0)
+    connTestName = ''
+    connTestFileName = ''
+
+    if args.conn_test:
+        connTestName = args.conn_test
+    if args.conn_test_file:
+        connTestFileName = args.conn_test_file
+
+    print(run_connectors_test_core(connTestName, connTestFileName))
 
 def run_file(run_file: Path, output_dir: Path, threads: int, args) -> int:
     """Rerun all the failed tests listed in the json file."""
@@ -735,6 +768,9 @@ def main():
             output_dir = os.getcwd()
             max_threads = get_level_of_parallelization(args)
             sys.exit(run_file(Path(args.run_file), Path(output_dir), max_threads, args))
+        if args.command == 'run-connectors-test':
+            run_connectors_test(args)
+            sys.exit(0)
         error_code = run_desired_tests(args, ds_registry)
         sys.exit(error_code)
     elif args.command == 'action' and args.diff:

--- a/tdvt/tdvt/tdvt.py
+++ b/tdvt/tdvt/tdvt.py
@@ -715,15 +715,12 @@ def run_connectors_test(args):
     if not tabquerycli_exists():
         print("Could not find Tabquerycli.")
         sys.exit(0)
-    connTestName = ''
-    connTestFileName = ''
 
-    if args.conn_test:
-        connTestName = args.conn_test
-    if args.conn_test_file:
-        connTestFileName = args.conn_test_file
+    if not args.conn_test or not args.conn_test_file:
+        print("Missing arguments. Not running Connectors Test")
+        sys.exit(0)
 
-    print(run_connectors_test_core(connTestName, connTestFileName))
+    print(run_connectors_test_core( args.conn_test, args.conn_test_file))
 
 def run_file(run_file: Path, output_dir: Path, threads: int, args) -> int:
     """Rerun all the failed tests listed in the json file."""

--- a/tdvt/tdvt/tdvt_core.py
+++ b/tdvt/tdvt/tdvt_core.py
@@ -25,7 +25,7 @@ from .config_gen.gentests import generate_logical_files
 from .config_gen.test_config import TestSet
 from .resources import *
 from .tabquery import build_tabquery_command_line
-from .tabquery import build_tabquery_command_line_connectors
+from .tabquery import build_connectors_test_tabquery_command_line
 from .test_results import *
 
 ALWAYS_GENERATE_EXPECTED = False
@@ -36,8 +36,9 @@ class ConnectorsTest(object):
         self.conn_test_name = conn_test_name
         self.conn_test_file = conn_test_file
         self.timeout_seconds = 10
+
     def run_connectors_test(self):
-        cmdline = build_tabquery_command_line_connectors(self.conn_test_name, self.conn_test_file)
+        cmdline = build_connectors_test_tabquery_command_line(self.conn_test_name, self.conn_test_file)
         self.cmd_output = str(subprocess.check_output(cmdline, stderr=subprocess.STDOUT, universal_newlines=True,
                                                       timeout=self.timeout_seconds))
         print(self.cmd_output)
@@ -710,3 +711,4 @@ def run_tests(tdvt_test_config: TdvtInvocation, test_set: TestSet):
 def run_connectors_test_core(conn_test_name, conn_test_file):
     connectors_test = ConnectorsTest(conn_test_name, conn_test_file)
     connectors_test.run_connectors_test()
+    

--- a/tdvt/tdvt/tdvt_core.py
+++ b/tdvt/tdvt/tdvt_core.py
@@ -711,4 +711,3 @@ def run_tests(tdvt_test_config: TdvtInvocation, test_set: TestSet):
 def run_connectors_test_core(conn_test_name, conn_test_file):
     connectors_test = ConnectorsTest(conn_test_name, conn_test_file)
     connectors_test.run_connectors_test()
-    

--- a/tdvt/tdvt/tdvt_core.py
+++ b/tdvt/tdvt/tdvt_core.py
@@ -25,11 +25,24 @@ from .config_gen.gentests import generate_logical_files
 from .config_gen.test_config import TestSet
 from .resources import *
 from .tabquery import build_tabquery_command_line
+from .tabquery import build_tabquery_command_line_connectors
 from .test_results import *
 
 ALWAYS_GENERATE_EXPECTED = False
 
 
+class ConnectorsTest(object):
+    def __init__(self, conn_test_name, conn_test_file):
+        self.conn_test_name = conn_test_name
+        self.conn_test_file = conn_test_file
+        self.timeout_seconds = 10
+    def run_connectors_test(self):
+        cmdline = build_tabquery_command_line_connectors(self.conn_test_name, self.conn_test_file)
+        self.cmd_output = str(subprocess.check_output(cmdline, stderr=subprocess.STDOUT, universal_newlines=True,
+                                                      timeout=self.timeout_seconds))
+        print(self.cmd_output)
+        sys.exit(0)
+    
 class TestResultWork(object):
     def __init__(self, test_file, output_dir, logical):
         self.relative_test_file = test_file.relative_test_path
@@ -693,3 +706,7 @@ def run_tests(tdvt_test_config: TdvtInvocation, test_set: TestSet):
     all_test_results = run_tests_impl(test_set, tdvt_test_config)
 
     return process_test_results(all_test_results, tds_file, tdvt_test_config.noheader, output_dir)
+
+def run_connectors_test_core(conn_test_name, conn_test_file):
+    connectors_test = ConnectorsTest(conn_test_name, conn_test_file)
+    connectors_test.run_connectors_test()


### PR DESCRIPTION
Based off a discussion with luke on the present flow of control for tdvt which heavily relies on BatchWorkQueue to run all the current datasource specific tdvt tests, adding a separate flow for running the connector tests which does not require any of those and only needs two arguments seemed as the cleanest way forward.

This code review is based on that discussion.

Tested by running the tests from tdvt and the results were as expected and the same as that run using tabquerycli directly.