### PR TITLE
Added validation rule enforcing default values for non-optional fields in the advanced category

### DIFF
--- a/connector-packager/connector_packager/xsd_validator.py
+++ b/connector-packager/connector_packager/xsd_validator.py
@@ -159,4 +159,11 @@ def validate_file_specific_rules(file_to_test: ConnectorFile, path_to_file: Path
                                                  "' not an allowed value. See 'Connection Field Platform Integration' section of documentation for allowed values.")
                     return False
 
+                category = child.attrib['category']
+                optional = 'optional' not in child.attrib or child.attrib['optional'] == 'true'
+                if category == 'advanced' and not optional and 'default-value' not in child.attrib:
+                    xml_violations_buffer.append("Element 'field', attribute 'name'='" + field_name +
+                                                 "': Required fields in the Advanced category must be assigned a default value.")
+                    return False
+
     return True

--- a/connector-packager/connector_packager/xsd_validator.py
+++ b/connector-packager/connector_packager/xsd_validator.py
@@ -161,8 +161,9 @@ def validate_file_specific_rules(file_to_test: ConnectorFile, path_to_file: Path
 
             if 'category' in child.attrib:
                 category = child.attrib['category']
-                optional = 'optional' not in child.attrib or child.attrib['optional'] == 'true'
-                if category == 'advanced' and not optional and 'default-value' not in child.attrib:
+                optional = child.attrib.get('optional','true') == 'true'
+                default_present = child.attrib.get('default-value','') != ''
+                if category == 'advanced' and not optional and not default_present:
                     xml_violations_buffer.append("Element 'field', attribute 'name'='" + field_name +
                                                  "': Required fields in the Advanced category must be assigned a default value.")
                     return False

--- a/connector-packager/connector_packager/xsd_validator.py
+++ b/connector-packager/connector_packager/xsd_validator.py
@@ -159,6 +159,7 @@ def validate_file_specific_rules(file_to_test: ConnectorFile, path_to_file: Path
                                                  "' not an allowed value. See 'Connection Field Platform Integration' section of documentation for allowed values.")
                     return False
 
+            if 'category' in child.attrib:
                 category = child.attrib['category']
                 optional = 'optional' not in child.attrib or child.attrib['optional'] == 'true'
                 if category == 'advanced' and not optional and 'default-value' not in child.attrib:

--- a/connector-packager/tests/test_resources/advanced_required_missing_default/connectionFields.xml
+++ b/connector-packager/tests/test_resources/advanced_required_missing_default/connectionFields.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<connection-fields>
+  <field name="v-custom" label="Custom" value-type="string" category="advanced" optional="false" />
+
+</connection-fields>

--- a/connector-packager/tests/test_resources/modular_dialog_connector/connectionFields.xml
+++ b/connector-packager/tests/test_resources/modular_dialog_connector/connectionFields.xml
@@ -12,5 +12,7 @@
   <field name="username" label="Username" value-type="string" category="authentication" />
 
   <field name="password" label="Password" value-type="string" category="authentication" secure="true" />
+  
+  <field name="v-custom2" label="Advanced Custom" value-type="string" category="advanced" optional="false" default-value="" />
 
 </connection-fields>

--- a/connector-packager/tests/test_resources/modular_dialog_connector/connectionFields.xml
+++ b/connector-packager/tests/test_resources/modular_dialog_connector/connectionFields.xml
@@ -13,6 +13,6 @@
 
   <field name="password" label="Password" value-type="string" category="authentication" secure="true" />
   
-  <field name="v-custom2" label="Advanced Custom" value-type="string" category="advanced" optional="false" default-value="" />
+  <field name="v-custom2" label="Advanced Custom" value-type="string" category="advanced" optional="false" default-value="test" />
 
 </connection-fields>

--- a/connector-packager/tests/test_xsd_validator.py
+++ b/connector-packager/tests/test_xsd_validator.py
@@ -83,3 +83,21 @@ class TestXSDValidator(unittest.TestCase):
         logging.debug("test_validate_vendor_prefix xml violations:")
         for violation in xml_violations_buffer:
             logging.debug(violation)
+
+    def test_validate_required_advanced_field_has_default_value(self):
+
+        test_file = TEST_FOLDER / "modular_dialog_connector/connectionFields.xml"
+        file_to_test = ConnectorFile("connectionFields.xml", "connection-fields")
+        xml_violations_buffer = []
+
+        self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer),
+                        "Valid XML file not marked as valid")
+
+        print("\nTest missing default-value for non-optional advanced field. Throws XML validation error.")
+        test_file = TEST_FOLDER / "advanced_required_missing_default/connectionFields.xml"
+        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer),
+                         "XML file containing required field in 'advanced' category with no default value marked as valid")
+
+        logging.debug("test_validate_required_advanced_field_has_default_value xml violations:")
+        for violation in xml_violations_buffer:
+            logging.debug(violation)


### PR DESCRIPTION
This kind of requirement isn't really enforceable in XSD, so I added it in the python validator.