### PR TITLE
Add elements to XML schema for validating custom vendor properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 ### Added
+- Add `vendor[1,2,3]-prompt` as options to ConnectionConfig-CT in `tcd_latest.xsd`.
+
 ### Changed
 ### Removed
 

--- a/validation/tcd_latest.xsd
+++ b/validation/tcd_latest.xsd
@@ -30,6 +30,9 @@
       <xs:element minOccurs="0" name="show-uncommitted-data-checkbox" type="BooleanProperty-CT"/>
       <xs:element minOccurs="0" name="ssl-requires-certificate" type="BooleanProperty-CT"/>
       <xs:element minOccurs="0" name="warehouse-prompt" type="TextField-CT"/>
+      <xs:element minOccurs="0" name="vendor1-prompt" type="TextField-CT"/>
+      <xs:element minOccurs="0" name="vendor2-prompt" type="TextField-CT"/>
+      <xs:element minOccurs="0" name="vendor3-prompt" type="TextField-CT"/>
     </xs:all>
   </xs:complexType>
   <xs:complexType name="AuthMode-CT">

--- a/validation/tcd_latest.xsd
+++ b/validation/tcd_latest.xsd
@@ -29,10 +29,10 @@
       <xs:element minOccurs="0" name="show-ssl-checkbox" type="BooleanProperty-CT"/>
       <xs:element minOccurs="0" name="show-uncommitted-data-checkbox" type="BooleanProperty-CT"/>
       <xs:element minOccurs="0" name="ssl-requires-certificate" type="BooleanProperty-CT"/>
-      <xs:element minOccurs="0" name="warehouse-prompt" type="TextField-CT"/>
       <xs:element minOccurs="0" name="vendor1-prompt" type="TextField-CT"/>
       <xs:element minOccurs="0" name="vendor2-prompt" type="TextField-CT"/>
       <xs:element minOccurs="0" name="vendor3-prompt" type="TextField-CT"/>
+      <xs:element minOccurs="0" name="warehouse-prompt" type="TextField-CT"/>
     </xs:all>
   </xs:complexType>
   <xs:complexType name="AuthMode-CT">


### PR DESCRIPTION
Addresses issue #561 by adding custom vendor properties to validation schema (of form `vendorx-prompt`), to properly validate connectors using custom vendor properties

+CHANGELOG.md update