### PR TITLE
Validate length of company name in manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Add `vendor[1,2,3]-prompt` as options to ConnectionConfig-CT in `tcd_latest.xsd`.
 
 ### Changed
+- Validate length of `name` in Company-G in `connector_plugin_manifest_latest.xsd`
+
 ### Removed
 
 

--- a/validation/connector_plugin_manifest_latest.xsd
+++ b/validation/connector_plugin_manifest_latest.xsd
@@ -111,7 +111,7 @@
     <xs:sequence>
       <xs:element name="company">
         <xs:complexType>
-          <xs:attribute name="name" type="CompanyName-ST" use="required"/>
+          <xs:attribute name="name" type="NonEmptyString-ST" use="required"/>
         </xs:complexType>
       </xs:element>
     </xs:sequence>
@@ -172,7 +172,7 @@
   <xs:complexType name="Platform-ST">
     <xs:attribute name="name" type="OSShortName-ST" use="required"/>
   </xs:complexType>
-  <xs:simpleType name="CompanyName-ST">
+  <xs:simpleType name="NonEmptyString-ST">
     <xs:restriction base="xs:string">
       <xs:minLength value="1"/>
     </xs:restriction>

--- a/validation/connector_plugin_manifest_latest.xsd
+++ b/validation/connector_plugin_manifest_latest.xsd
@@ -111,7 +111,7 @@
     <xs:sequence>
       <xs:element name="company">
         <xs:complexType>
-          <xs:attribute name="name" type="xs:string" use="required"/>
+          <xs:attribute name="name" type="CompanyName-ST" use="required"/>
         </xs:complexType>
       </xs:element>
     </xs:sequence>
@@ -172,4 +172,9 @@
   <xs:complexType name="Platform-ST">
     <xs:attribute name="name" type="OSShortName-ST" use="required"/>
   </xs:complexType>
+  <xs:simpleType name="CompanyName-ST">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
 </xs:schema>


### PR DESCRIPTION
Fixes #571 by validating the length of company name field in manifest.xml

And update CHANGELOG.md

Submitting on behalf of Goldman Sachs