### PR TITLE
Add all_options.ini sample

### DIFF
--- a/tdvt/samples/config/all_options_example.ini
+++ b/tdvt/samples/config/all_options_example.ini
@@ -1,0 +1,90 @@
+[Datasource]
+
+Name = your_datasource_name  #i.e. mydb
+
+CommandLineOverride = -DLogLevel=Debug -DConnectPluginsPath=[path_to_unpackaged_connector] #Space separated list of arguments that are passed through unchanged to tabquerytool. Most Tableau arguments require a prepended '-D'.
+#If you are testing a connector, be sure to add the command line argument -DConnectPluginsPath and have it pointed at the folder where your connector is located
+
+MaxThread = 6   #You can add this to control Max Thread number when you use TDVT to run single datasource, it cannot apply with multi datasource
+
+TimeoutSeconds = 6000 # You can overload the timeout for queries if your queries are running slow. By default this is set to 3600.
+
+LogicalQueryFormat = dbo
+
+#You can add a new logical config here and use it above. These are example attributes; you wouldn't set them all since some are mutually exclusive.
+
+[LogicalConfig]
+Name = my_logical_query
+tablename = SomePrefix_$dsName #$dsName will be substituted with Calcs or Staples.
+tablePrefix = [MySchema].
+tablePostfix = [MySchema].
+tablenameUpper = True
+tablenameLower = True
+bool_underscore = True
+fieldnameDate_underscore = True
+fieldnameLower = True
+fieldnameUpper = True
+fieldnameNoSpace = True
+fieldnameLower_underscore = True
+fieldnameUnderscoreNotSpace = True
+
+
+[StandardTests]
+
+#You can put in comma-separated string values that match part or all of a test name to exclude them. The asterisk works as a wildcard.
+
+LogicalExclusions_Calcs = string.right
+
+LogicalExclusions_Staples = Filter.Trademark
+
+ExpressionExclusions_Standard = string.ascii,string.char,logical
+
+#If you remove this section then your test suite will not include the Level of Detail tests.
+
+[LODTests]
+
+#You don't need to specify anything to add this test suite, but you can exclude tests here, too:
+
+LogicalExclusions_Staples =
+
+ExpressionExclusions_Calcs =
+
+#This test will verify that your Staples table is loaded correctly.
+
+[StaplesDataTest]
+
+#Recommended INI file for full test coverage:
+
+[StandardTests]
+
+[ConnectionTests]
+# An auto-generated section that is used to run tests to verify TDVT can connect to the Staples & cast_calcs tables.
+# The Connection Tests, and any other tests with the attribute `SmokeTest = True`, are run before the other tests.
+# They can be run by themselves using the --verify flag (e.g. tdvt run postgres --verify).
+CastCalcsTestEnabled = True
+StaplesTestEnabled = True
+
+[LODTests]
+
+[UnionTest]
+
+#Advanced:
+#You can add a new arbitrary test suite like this.
+
+[SomeTests] #This is just a section header defining the test.
+
+Type = expression #expression or logical.
+
+Name = expression_test1. #This name should be unique among test suites.
+
+TDS = cast_calcs.your_datasource_name.tds
+
+Exclusions = string.ascii
+
+TestPath = tests/mytests/ #This could point to a local directory relative to your TDVT working directory named 'tests'. Or for a logicaltest it would be 'tests/logical/setup/mytests/setup.\.xml
+
+SmokeTest = True # Setting this attribute will cause the test to be run with the Connection Tests.
+                 # Any section can have this attribute.
+
+Enabled = False # When `Enabled = False`, test(s) from this section will not be run and will be counted as
+                # test failures. Any section can have this attribute added.

--- a/tdvt/samples/config/all_options_example.ini
+++ b/tdvt/samples/config/all_options_example.ini
@@ -9,7 +9,7 @@ MaxThread = 6   #You can add this to control Max Thread number when you use TDVT
 
 TimeoutSeconds = 6000 # You can overload the timeout for queries if your queries are running slow. By default this is set to 3600.
 
-LogicalQueryFormat = dbo
+LogicalQueryFormat = my_logical_query
 
 #You can add a new logical config here and use it above. These are example attributes; you wouldn't set them all since some are mutually exclusive.
 
@@ -70,6 +70,8 @@ StaplesTestEnabled = True
 
 #Advanced:
 #You can add a new arbitrary test suite like this.
+#Not needed for general usage
+
 
 [SomeTests] #This is just a section header defining the test.
 


### PR DESCRIPTION
The documentation for TDVT has a gigantic 90-line ini file as the only documentation for how to make one of these. It's large and intimidating, and is hard to parse when trying to figure out something specific.

As part of my TDVT doc update, I'm rewriting that section and removing this giant blob of text. However, this may still be useful to people to see the syntax or something, so I'm adding it as a standalone example file.