### PR TITLE
Sort test results by complexity (number of functions tested)

### DIFF
--- a/tdvt/CHANGELOG.md
+++ b/tdvt/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 - Change Staples smoke test to be logical
 
+## [2.1.20] - 2020-09-22
+- test_results_combined.csv is now sorted by test complexity (number of distinct function tested)
+
 ## [2.1.19] - 2020-09-08
 - test_results_combined.csv now include test priority, categories, and functions.
 

--- a/tdvt/tdvt/tdvt.py
+++ b/tdvt/tdvt/tdvt.py
@@ -9,6 +9,7 @@ if sys.version_info[0] < 3:
     raise EnvironmentError("TDVT requires Python 3 or greater.")
 
 import argparse
+import csv
 import glob
 import json
 import pathlib
@@ -38,31 +39,48 @@ class TestOutputFiles(object):
     output_csv = "test_results_combined.csv"
     output_json = "tdvt_output_combined.json"
     all_output_files = [output_actuals, output_csv, output_json, output_tabquery_log]
+    combined_output = []
 
-    @staticmethod
-    def copy_output_file(src_name, src_dir, dst, trim_header, append=True):
+    @classmethod
+    def copy_output_file(c, src_name, src_dir):
         src = os.path.join(src_dir, src_name)
-        dst = os.path.join(os.getcwd(), dst)
-        logging.debug("Copying {0} to {1}".format(src, dst))
+        logging.debug("Copying {0} to output".format(src))
         try:
-            dst_exists = os.path.isfile(dst)
-            src_file = open(src, 'r', encoding='utf8')
-            mode = 'w' if not dst_exists or not append else 'a'
-            dst_file = open(dst, mode, encoding='utf8')
+            with open(src, 'r', encoding='utf8') as src_file:
+                reader = csv.DictReader(src_file, dialect='tdvt')
+                for row in reader:
+                    c.combined_output.append(row)
 
-            line_count = 0
-            for line in src_file:
-                line_count += 1
-                if line_count == 1 and trim_header and dst_exists:
-                    continue
-                dst_file.write(line)
-
-            src_file.close()
-            dst_file.close()
         except IOError as e:
             logging.debug("Exception while copying files: " + str(e))
             return
 
+    @classmethod
+    def write_test_results_csv(c):
+        if not c.combined_output:
+            logging.debug("write_test_results_csv called with no test output")
+            return
+
+        logging.debug("Copying output to {0}".format(c.output_csv))
+        # Sort combined_output on the number of distinct functions (order of complexity)
+        sort_by_complexity = lambda row: len(row['Functions'].split(','))
+        try:
+            c.combined_output.sort(key=sort_by_complexity)
+        except KeyError as e:
+            logging.debug("Tried to sort output on a key that doesn't exist. Leaving output unsorted.")
+
+        dst = os.path.join(os.getcwd(), c.output_csv)
+        try:
+            dst_exists = os.path.isfile(dst)
+            with open(dst, 'w', encoding='utf8') as dst_file:
+                writer = csv.DictWriter(dst_file, fieldnames=c.combined_output[0],
+                    dialect='tdvt', quoting=csv.QUOTE_MINIMAL)
+                writer.writeheader()
+                for row in c.combined_output:
+                    writer.writerow(row)
+        except IOError as e:
+            logging.debug("Exception while writing to file: " + str(e))
+            return
 
 def do_test_queue_work(i, q):
     """This will be called in a queue.join() context, so make sure to mark all work items as done and
@@ -110,7 +128,7 @@ class TestRunner():
                 myzip.write(actual, inner_output)
 
     def copy_output_files(self):
-        TestOutputFiles.copy_output_file("test_results.csv", self.temp_dir, TestOutputFiles.output_csv, True)
+        TestOutputFiles.copy_output_file("test_results.csv", self.temp_dir)
 
     def copy_test_result_file(self):
         src = os.path.join(self.temp_dir, "tdvt_output.json")
@@ -478,6 +496,14 @@ def create_parser():
     return parser
 
 
+def register_tdvt_dialect():
+    custom_dialect = csv.excel
+    custom_dialect.lineterminator = '\n'
+    custom_dialect.delimiter = ','
+    custom_dialect.strict = True
+    custom_dialect.skipinitialspace = True
+    csv.register_dialect('tdvt', custom_dialect)
+
 def init():
     parser = create_parser()
     args = parser.parse_args()
@@ -498,6 +524,7 @@ def init():
     logging.debug('TDVT Arguments: ' + str(args))
     ds_reg = get_datasource_registry(sys.platform)
     configure_tabquery_path()
+    register_tdvt_dialect()
 
     return parser, ds_reg, args
 
@@ -529,6 +556,7 @@ def test_runner(all_tests, test_queue, max_threads):
         skipped_tests += work.skipped_tests if work.skipped_tests else 0
         disabled_tests += work.disabled_tests if work.disabled_tests else 0
         total_tests += work.total_tests if work.total_tests else 0
+    TestOutputFiles.write_test_results_csv()
     return failed_tests, skipped_tests, disabled_tests, total_tests
 
 

--- a/tdvt/tdvt/tdvt_core.py
+++ b/tdvt/tdvt/tdvt_core.py
@@ -558,12 +558,7 @@ def write_csv_test_output(all_test_results, tds_file, skip_header, output_dir) -
         logging.debug("Could not open output file [{0}].".format(csv_file_path))
         return
 
-    custom_dialect = csv.excel
-    custom_dialect.lineterminator = '\n'
-    custom_dialect.delimiter = ','
-    custom_dialect.strict = True
-    custom_dialect.skipinitialspace = True
-    csv_out = csv.writer(file_out, dialect=custom_dialect, quoting=csv.QUOTE_MINIMAL)
+    csv_out = csv.writer(file_out, dialect='tdvt', quoting=csv.QUOTE_MINIMAL)
     tupleLimitStr = '(' + str(get_tuple_display_limit()) + ')tuples'
     actualTuplesHeader = 'Actual ' + tupleLimitStr
     expectedTuplesHeader = 'Expected ' + tupleLimitStr

--- a/tdvt/tdvt/test_results.py
+++ b/tdvt/tdvt/test_results.py
@@ -19,10 +19,12 @@ class TestMetadata(object):
         self.priority = priority
 
     def add_category(self, category):
-        self.categories.add(category)
+        if category:
+            self.categories.add(category)
 
     def add_function(self, function):
-        self.functions.add(function)
+        if function:
+            self.functions.add(function)
 
     def concat_categories(self):
         return ','.join(self.categories)


### PR DESCRIPTION
Added an intermediary list to store test results instead of copying straight to the final output. Lists in python are thread-safe, so there shouldn't be any threading issues. The results are then sorted by the distinct number of functions tested.