### PR TITLE
fix broken config

### DIFF
--- a/tdvt/samples/config/all_options_example.ini
+++ b/tdvt/samples/config/all_options_example.ini
@@ -55,8 +55,6 @@ ExpressionExclusions_Calcs =
 
 #Recommended INI file for full test coverage:
 
-[StandardTests]
-
 [ConnectionTests]
 # An auto-generated section that is used to run tests to verify TDVT can connect to the Staples & cast_calcs tables.
 # The Connection Tests, and any other tests with the attribute `SmokeTest = True`, are run before the other tests.

--- a/tdvt/samples/config/all_options_example.ini
+++ b/tdvt/samples/config/all_options_example.ini
@@ -62,8 +62,6 @@ ExpressionExclusions_Calcs =
 CastCalcsTestEnabled = True
 StaplesTestEnabled = True
 
-[LODTests]
-
 [UnionTest]
 
 #Advanced:


### PR DESCRIPTION
config had two `[Standard Tests]` sections which caused the list command to break when run in the samples dir.