### PR TITLE
Remove references to setImpersonateAttributes  from samples

### DIFF
--- a/samples/plugins/postgres_jdbc/connectionResolver.tdr
+++ b/samples/plugins/postgres_jdbc/connectionResolver.tdr
@@ -6,7 +6,6 @@
     </connection-builder>
     <connection-normalizer>
       <required-attributes>
-        <setImpersonateAttributes/>
         <attribute-list>
           <attr>server</attr>
           <attr>port</attr>

--- a/samples/plugins/postgres_odbc/connectionResolver.tdr
+++ b/samples/plugins/postgres_odbc/connectionResolver.tdr
@@ -6,7 +6,6 @@
     </connection-builder>
     <connection-normalizer>
       <required-attributes>
-        <setImpersonateAttributes/>
         <attribute-list>
           <attr>server</attr>
           <attr>port</attr>

--- a/samples/scenarios/db_impersonation/connectionResolver.tdr
+++ b/samples/scenarios/db_impersonation/connectionResolver.tdr
@@ -6,7 +6,6 @@
     </connection-builder>
     <connection-normalizer>
       <required-attributes>
-        <setImpersonateAttributes/>
         <attribute-list>
           <attr>class</attr>
           <attr>server</attr>

--- a/samples/scenarios/extract_only/sqlite_extract/connectionResolver.xml
+++ b/samples/scenarios/extract_only/sqlite_extract/connectionResolver.xml
@@ -6,7 +6,6 @@
     </connection-builder>
     <connection-normalizer>
         <required-attributes>
-            <setImpersonateAttributes/>
             <attribute-list>
             <attr>server</attr>
             <attr>authentication</attr>

--- a/samples/scenarios/mysql_based/mysql_odbc/connectionResolver.tdr
+++ b/samples/scenarios/mysql_based/mysql_odbc/connectionResolver.tdr
@@ -6,7 +6,6 @@
     </connection-builder>
     <connection-normalizer>
       <required-attributes>
-        <setImpersonateAttributes/>
         <attribute-list>
           <attr>server</attr>
           <attr>dbname</attr>

--- a/samples/scenarios/vendor_attributes/postgres_vendor/connectionResolver.tdr
+++ b/samples/scenarios/vendor_attributes/postgres_vendor/connectionResolver.tdr
@@ -6,7 +6,6 @@
     </connection-builder>
     <connection-normalizer>
       <required-attributes>
-        <setImpersonateAttributes/>
         <attribute-list>
           <attr>server</attr>
           <attr>vendor1</attr>


### PR DESCRIPTION
Remove references to setImpersonateAttributes  from samples as it is already done in product code and there is no need to add it to the plugin code