### PR TITLE
Update allowed field names to include vendor1, vendor2 and vendor3

### DIFF
--- a/connector-packager/connector_packager/xsd_validator.py
+++ b/connector-packager/connector_packager/xsd_validator.py
@@ -15,7 +15,7 @@ logger = logging.getLogger('packager_logger')
 MAX_FILE_SIZE = 1024 * 256  # This is based on the max file size we will load on the Tableau side
 PATH_TO_XSD_FILES = Path("../validation").absolute()
 VALID_XML_EXTENSIONS = ['tcd', 'tdr', 'tdd', 'xml']  # These are the file extensions that we will validate
-PLATFORM_FIELD_NAMES = ['server', 'port', 'sslmode', 'authentication', 'username', 'password']
+PLATFORM_FIELD_NAMES = ['server', 'port', 'sslmode', 'authentication', 'username', 'password', 'vendor1', 'vendor2', 'vendor3']
 VENDOR_FIELD_NAME_PREFIX = 'v-'
 
 # Holds the mapping between file type and XSD file name

--- a/connector-packager/tests/test_resources/modular_dialog_connector/connectionFields.xml
+++ b/connector-packager/tests/test_resources/modular_dialog_connector/connectionFields.xml
@@ -14,5 +14,11 @@
   <field name="password" label="Password" value-type="string" category="authentication" secure="true" />
   
   <field name="v-custom2" label="Advanced Custom" value-type="string" category="advanced" optional="false" default-value="test" />
+  
+  <field name="vendor1" label="Advanced Vendor1" value-type="string" category="advanced" optional="false" default-value="testVendor1" />
+  
+  <field name="vendor2" label="Advanced Vendor2" value-type="string" category="advanced" optional="false" default-value="testVendor2" />
+  
+  <field name="vendor3" label="Advanced Vendor3" value-type="string" category="advanced" optional="false" default-value="testVendor3" />
 
 </connection-fields>


### PR DESCRIPTION

DataConnectionAttrs::attrVendor1, 2, 3 were added for plugin authors in connection dialog v1.  They have no platform meaning but are reserved to be used by plugins. Add these field names to the list of allowed fields so that the packager does not flag it as invalid and validation goes through successfully.

Tested by running the command locally : 

`D:\dev\git\connector-plugin-sdk\connector-packager>python -m connector_packager.package --validate-only D:\dev\git\connector-plugin-sdk\connector-packager\tests\test_resources\modular_dialog_connector
The log path D:\dev\git\connector-plugin-sdk\connector-packager exists
Validation succeeded.`