### PR TITLE
Fix Staples smoke test

### DIFF
--- a/tdvt/tdvt/exprtests/pretest/connection_tests/staples/setup.staples_connection_test.xml
+++ b/tdvt/tdvt/exprtests/pretest/connection_tests/staples/setup.staples_connection_test.xml
@@ -53,7 +53,7 @@
             <identifierExp class="logical-expression" identifier="[Sales Total]" />
           </binding>
         </expressions>
-        <relationOp class="logical-operator" connection="leaf" name="[Staples]">
+        <relationOp class="logical-operator" connection="leaf" name="$Staples$">
           <relation name="Staples" table="[Staples]" type="table" />
           <cols>
           </cols>


### PR DESCRIPTION
Fix bug causing `TableauException: No such table: [Staples]` errors when running smoke tests. This PR closes #587 

- [ ] update test files
- [ ] bump version.py
- [ ] update TDVT readme
- [ ] update SDK readme

## Testing:
- Run on DS without smoke tests
  - postgres

  - mssql

- Run on DS with smoke tests
  - postgres

  - mssql