### PR TITLE
remove ProgressOpenEdgeDialect as base dialect

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -45,7 +45,7 @@ Choosing the right dialect is a critical part of writing a connector. For exampl
 
 - Use superclass's dialect scenario: If you set <span style="font-family: courier new">base</span> to "mysql_odbc" as the parent, you can skip configuring a dialect, and your connector will use the parent’s dialect.
 - Inherit a base dialect scenario: If your database follows the SQL standards of another database that Tableau already supports (listed below), then you can choose that dialect as a starting point, you can also add your own customizations beyond the base dialect.
-- Write a complete dialect on your own scenario: you can create a complete dialect definition without any base dialect. You can refer to [Postgres_odbc sample's full dialect](https://github.com/tableau/connector-plugin-sdk/blob/master/samples/plugins/postgres_odbc/dialect.tdd) as a starting point.
+- Write a complete dialect scenario (recommended): You can create a complete dialect definition without any base dialect. Refer to the [Postgres_odbc sample's full dialect](https://github.com/tableau/connector-plugin-sdk/blob/master/samples/plugins/postgres_odbc/dialect.tdd) as a starting point.
 
 These are valid values for <span style="font-family: courier new">base</span>:
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -45,7 +45,7 @@ Choosing the right dialect is a critical part of writing a connector. For exampl
 
 - Use superclass's dialect scenario: If you set <span style="font-family: courier new">base</span> to "mysql_odbc" as the parent, you can skip configuring a dialect, and your connector will use the parent’s dialect.
 - Inherit a base dialect scenario: If your database follows the SQL standards of another database that Tableau already supports (listed below), then you can choose that dialect as a starting point, you can also add your own customizations beyond the base dialect.
-- Write a complete dialect on your own scenario: you can create a complete dialect definition without any base dialect.
+- Write a complete dialect on your own scenario: you can create a complete dialect definition without any base dialect. You can refer to [Postgres_odbc sample's full dialect](https://github.com/tableau/connector-plugin-sdk/blob/master/samples/plugins/postgres_odbc/dialect.tdd) as a starting point.
 
 These are valid values for <span style="font-family: courier new">base</span>:
 
@@ -70,6 +70,8 @@ These are valid values for <span style="font-family: courier new">base</span>:
 - SybaseIQ151Dialect
 - Teradata1410Dialect
 - VerticaDialect
+
+One warning to note is that a new version of Tableau may change those base dialects' behavior and may cause unintended side effects for connectors inheriting from those base dialects.
 
 ### Should I create a dialect definition file?
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -43,8 +43,9 @@ The dialect determines what SQL is generated for various Tableau actions.
 
 Choosing the right dialect is a critical part of writing a connector. For example:
 
-- If you set <span style="font-family: courier new">base</span> to "mysql_odbc" as the parent, you can skip configuring a dialect, and your connector will use the parent’s dialect.
-- If your database follows the SQL standards of another database that Tableau already supports (listed below), then you can choose that dialect as a starting point.
+- Use superclass's dialect scenario: If you set <span style="font-family: courier new">base</span> to "mysql_odbc" as the parent, you can skip configuring a dialect, and your connector will use the parent’s dialect.
+- Inherit a base dialect scenario: If your database follows the SQL standards of another database that Tableau already supports (listed below), then you can choose that dialect as a starting point, you can also add your own customizations beyond the base dialect.
+- Write a complete dialect on your own scenario: you can create a complete dialect definition without any base dialect.
 
 These are valid values for <span style="font-family: courier new">base</span>:
 
@@ -62,7 +63,6 @@ These are valid values for <span style="font-family: courier new">base</span>:
 - Oracle102Dialect
 - PostgreSQL90Dialect
 - PrestoDialect
-- ProgressOpenEdgeDialect
 - RedShiftDialect
 - SQLServer10Dialect_Datetime2
 - SnowflakeDialect
@@ -73,7 +73,9 @@ These are valid values for <span style="font-family: courier new">base</span>:
 
 ### Should I create a dialect definition file?
 
-If you want to customize the generated SQL, or if your connector inherits from ODBC or JDBC, then you need to create a custom dialect file. Without a file, the dialect from the superclass is used. For more information, see [Create a Tableau Dialect Definition (TDD) File]({{ site.baseurl }}/docs/dialect).
+If you want to customize the generated SQL instead of using the superclass's dialect, or if your connector inherits from ODBC or JDBC, then you need to create a custom dialect file. If your database follows the SQL standards of any database that Tableau currently supports(listed above), then you can choose that base dialect as a starting point.
+
+Without a dialect file, the dialect from the superclass is used. For more information, see [Create a Tableau Dialect Definition (TDD) File]({{ site.baseurl }}/docs/dialect).
 
 ## Set connection capabilities
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -75,7 +75,9 @@ One warning to note is that a new version of Tableau may change those base diale
 
 ### Should I create a dialect definition file?
 
-If you want to customize the generated SQL instead of using the superclass's dialect, or if your connector inherits from ODBC or JDBC, then you need to create a custom dialect file. If your database follows the SQL standards of any database that Tableau currently supports(listed above), then you can choose that base dialect as a starting point.
+If you want to customize the generated SQL, or if your connector inherits from ODBC or JDBC, then you need to create a custom dialect file. 
+
+Only if your database follows the SQL standards of a database that Tableau currently supports (listed above) should you consider choosing that base dialect as a starting point.  Also, any new Tableau version can change those base dialects' behavior, which may cause unintended side effects for connectors inheriting from those base dialects.
 
 Without a dialect file, the dialect from the superclass is used. For more information, see [Create a Tableau Dialect Definition (TDD) File]({{ site.baseurl }}/docs/dialect).
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -43,9 +43,10 @@ The dialect determines what SQL is generated for various Tableau actions.
 
 Choosing the right dialect is a critical part of writing a connector. For example:
 
-- Use superclass's dialect scenario: If you set <span style="font-family: courier new">base</span> to "mysql_odbc" as the parent, you can skip configuring a dialect, and your connector will use the parent’s dialect.
-- Inherit a base dialect scenario: If your database follows the SQL standards of another database that Tableau already supports (listed below), then you can choose that dialect as a starting point, you can also add your own customizations beyond the base dialect.
 - Write a complete dialect scenario (recommended): You can create a complete dialect definition without any base dialect. Refer to the [Postgres_odbc sample's full dialect](https://github.com/tableau/connector-plugin-sdk/blob/master/samples/plugins/postgres_odbc/dialect.tdd) as a starting point.
+- Inherit a base dialect scenario: If your database follows the SQL standards of another database that Tableau already supports (listed below), then you can choose that dialect as a starting point, you can also add your own customizations beyond the base dialect.
+- Use superclass's dialect scenario: If you set <span style="font-family: courier new">base</span> to "mysql_odbc" as the parent, you can skip configuring a dialect, and your connector will use the parent’s dialect.
+
 
 These are valid values for <span style="font-family: courier new">base</span>:
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -71,7 +71,6 @@ These are valid values for <span style="font-family: courier new">base</span>:
 - Teradata1410Dialect
 - VerticaDialect
 
-One warning to note is that a new version of Tableau may change those base dialects' behavior and may cause unintended side effects for connectors inheriting from those base dialects.
 
 ### Should I create a dialect definition file?
 


### PR DESCRIPTION
This change is for [TFS 1198120](https://tfs.tsi.lan/tfs/DefaultCollection/Tableau-Dev/_workitems/edit/1198920) 

The goal is to remove ProgressOpenEdgeDialect as a base dialect, and a few minor changes on how to create dialect.