### PR TITLE
Specify dev path connectors must be on same drive

### DIFF
--- a/docs/run-taco.md
+++ b/docs/run-taco.md
@@ -5,7 +5,7 @@ title: Run Your Packaged Connector (TACO file)
 Starting in 2019.4 Beta 1, you can load packaged connectors (otherwise known as TACO files). To use a connector in earlier Tableau versions, see  [Run Your "Under Development" Connector]({{ site.baseurl }}/docs/share)
 
 ## Run a packaged connector in Tableau Desktop
-1. Copy your packaged connector file (with a .taco filename extension) into your My Tableau Repository/Connectors directory. 
+1. Copy your packaged connector file (with a .taco filename extension) into your My Tableau Repository/Connectors directory.
 1. Launch Tableau Desktop.
 
 ## Run a packaged connector in Tableau Server
@@ -17,7 +17,7 @@ For each machine:
 
 
 ### Option 2
-1. Create a directory for Tableau connectors. This needs to be the same path on each machine. For example:   
+1. Create a directory for Tableau connectors. This needs to be the same path on each machine, and on the same drive as the server is installed on. For example:
 `C:\tableau_connectors`
 1. Copy your packaged connector file (with a .taco filename extension) into  the folder your created on each node.
 1. Set the `native_api.connect_plugins_path` option. For example:
@@ -40,11 +40,11 @@ For information about using TSM to set the option, see [tsm configuration set Op
 
 ## Verify the signature
 
-To be loaded in Tableau, a packaged connector must be signed by a trusted certificate. 
+To be loaded in Tableau, a packaged connector must be signed by a trusted certificate.
 
 __Note:__ Signature verification was added to Tableau Desktop in 2019.4 and Tableau Server in 2020.1.
 
-If the connector can't be verified, you will see the following error:    
+If the connector can't be verified, you will see the following error:
 `Package signature verification failed during connection creation`
 
 This can happen because the connector is unsigned, or because the certificate's trust chain does not link back to a trusted certificate authority.
@@ -55,7 +55,7 @@ For more information about signing a packaged connector, see [Package and Sign Y
 
 To use an unsigned packaged connector, you can disable signature verification.
 
-- On Tableau Desktop, you use this command:    
+- On Tableau Desktop, you use this command:
 `-DDisableVerifyConnectorPluginSignature=true`
 
 - On server, you can disable signature verification by setting  `native_api.disable_verify_connector_plugin_signature` to true via TSM.

--- a/docs/share.md
+++ b/docs/share.md
@@ -8,22 +8,22 @@ Do not deploy the connector to a production environment.
 # Set up Tableau Desktop
 
 __For Windows:__
-1. Create a directory for Tableau connectors. For example:   
+1. Create a directory for Tableau connectors. For example:
 `C:\tableau_connectors`
-1. Put the folder containing your connector's manifest.xml file in this directory. Each connector should have its own folder. For example:    
+1. Put the folder containing your connector's manifest.xml file in this directory. Each connector should have its own folder. For example:
 `C:\tableau_connectors\my_connector`
-1. Run Tableau using the <span style="font-family: courier new">-DConnectPluginsPath</span> command-line argument, pointing to your connector directory. For example:   
+1. Run Tableau using the <span style="font-family: courier new">-DConnectPluginsPath</span> command-line argument, pointing to your connector directory. For example:
 `tableau.exe -DConnectPluginsPath=C:\tableau_connectors`
 
 __For macOS:__
 
 __Note:__ In the steps below, replace [username] with your name (for example /Users/agarcia/tableau_connectors) and [version] with the version of Tableau that you’re running (for example, 2019.3.app).
 
-1. Create a directory for Tableau connectors. For example:   
+1. Create a directory for Tableau connectors. For example:
 `/Users/[username]/tableau_connectors`
-1. Put the folder containing your connector's manifest.xml file in this directory. Each connector should have its own folder. For example:   
+1. Put the folder containing your connector's manifest.xml file in this directory. Each connector should have its own folder. For example:
 `/Users/[username]/tableau_connector/my connector`
-1. Run Tableau using the `-DConnectPluginsPath` command-line argument and pointing to your connector directory. For example:    
+1. Run Tableau using the `-DConnectPluginsPath` command-line argument and pointing to your connector directory. For example:
     ```
     /Applications/Tableau\ Desktop\[version].app/Contents/MacOS/Tableau -DConnectPluginsPath=/Users/[username]/tableau_connectors
 
@@ -32,20 +32,20 @@ __Note:__ In the steps below, replace [username] with your name (for example /Us
 # Set up Tableau Server
 
 1. For each server node:
-    - Create a directory for Tableau connectors. For example:   
+    - Create a directory for Tableau connectors. This needs to be the same path on each machine, and on the same drive as the server is installed on. For example:
 `C:\tableau_connectors`
-    - Put the folder containing your connector's manifest.xml file in this directory. Each connector should have its own folder. For example:    
+    - Put the folder containing your connector's manifest.xml file in this directory. Each connector should have its own folder. For example:
 `C:\tableau_connectors\my_connector`
 
-1. Set the `native_api.connect_plugins_path` option. For example:  
+1. Set the `native_api.connect_plugins_path` option. For example:
     ```
     tsm configuration set -k native_api.connect_plugins_path -v C:/tableau_connectors
-    ```   
+    ```
     If you get a configuration error during this step, try adding the `--force-keys` option to the end of the command.
 
-1. Apply the pending configuration changes to restart the server:   
-    `tsm pending-changes apply`    
-    
+1. Apply the pending configuration changes to restart the server:
+    `tsm pending-changes apply`
+
     __Note:__ Whenever you add, remove, or update a connector, you must restart the server to see the changes.
 
 For information about using TSM to set the option, see [tsm configuration set Options](https://onlinehelp.tableau.com/current/server-linux/en-us/cli_configuration-set_tsm.htm) in the Tableau Server Help.


### PR DESCRIPTION
Also seems to have wiped out some trailing whitepsace, I have my visual studio set to remove that automatically. I'm really only changing one line in the two files.
