### PR TITLE
Update min version for dialogs v2

### DIFF
--- a/connector-packager/tests/test_jar_packager.py
+++ b/connector-packager/tests/test_jar_packager.py
@@ -13,7 +13,7 @@ from connector_packager.version import __default_min_version_tableau__
 TEST_FOLDER = Path("tests/test_resources")
 MANIFEST_FILE_NAME = "manifest.xml"
 
-VERSION_2020_2 = "2020.2"
+VERSION_2020_3 = "2020.3"
 
 
 class TestJarPackager(unittest.TestCase):
@@ -96,7 +96,7 @@ class TestJarPackager(unittest.TestCase):
 
         manifest = ET.parse(path_to_extracted_manifest)
         self.assertEqual(manifest.getroot().get("min-version-tableau"),
-                         VERSION_2020_2, "wrong min-version-tableau attr or doesn't exist")
+                         VERSION_2020_3, "wrong min-version-tableau attr or doesn't exist")
 
         if dest_dir.exists():
             shutil.rmtree(dest_dir)


### PR DESCRIPTION
Also shows the version we stamp, and why. 

`(.venv) D:\connector-plugin-sdk\connector-packager>python -m connector_packager.package D:\connector-plugin-sdk\samples\scenarios\multi_auth
The log path D:\connector-plugin-sdk\connector-packager exists
Validation succeeded.
Detected minimum Tableau version required: 2020.3
-Connector uses Connection Dialogs V2, which was added in the 2020.3 release
Taco packaged. To sign taco file, use jarsigner.`