### PR TITLE
Remove support for non-declarative normalizer and matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Tableau Connector SDK Changelog
 
-## Unreleased
+## 2020-01-22
+### Removed
+- Remove support for `script` element and `cacheSize` attribute in ConnectionNormalizer-CT and ConnectionMatcher-CT in `tdr_latest.xsd`.  This has not been a recommended pattern since initial release and deprecated in 2020.3 release.  Documentation, samples and [API Reference](https://tableau.github.io/connector-plugin-sdk/docs/api-reference) have been previously updated.
 
 ## 2020-10-01
 ### Added

--- a/samples/components/dialogs/new_text_field/connection-dialog.tcd
+++ b/samples/components/dialogs/new_text_field/connection-dialog.tcd
@@ -11,9 +11,6 @@
     <server-prompt value="Server: " />
     <!-- You can resuse the service field as an arbitrary text box. -->
     <service-prompt value="A new service text field" />
-	<show-service-prompt value="true" />
-	<show-ssl-checkbox value="true" />
-    <!-- You can resuse the warehouse field as an arbitrary text box. -->
-    <warehouse-prompt value="Another new warehouse text field" />
+	  <show-service-prompt value="true" />
   </connection-config>
 </connection-dialog>

--- a/samples/components/dialogs/new_text_field/connectionRequired.js
+++ b/samples/components/dialogs/new_text_field/connectionRequired.js
@@ -1,4 +1,0 @@
-(function requiredAttrs(attr)
-{
-    return [connectionHelper.attributeServer, connectionHelper.attributePort, connectionHelper.attributeDatabase, connectionHelper.attributeUsername, connectionHelper.attributePassword, connectionHelper.attributeWarehouse, "service"];
-})

--- a/samples/components/dialogs/new_text_field/connectionResolver.tdr
+++ b/samples/components/dialogs/new_text_field/connectionResolver.tdr
@@ -5,7 +5,17 @@
       <script file='connectionBuilder.js'/>
     </connection-builder>
     <connection-normalizer>
-      <script file='connectionRequired.js'/>
+      <required-attributes>
+        <attribute-list>
+          <attr>server</attr>
+          <attr>port</attr>
+          <attr>service</attr>
+          <attr>dbname</attr>
+          <attr>authentication</attr>
+          <attr>username</attr>
+          <attr>password</attr>
+        </attribute-list>
+      </required-attributes>
     </connection-normalizer>
 	</connection-resolver>
 	<driver-resolver>

--- a/validation/tdr_latest.xsd
+++ b/validation/tdr_latest.xsd
@@ -107,21 +107,15 @@
       <xs:annotation>
         <xs:documentation>Matches two sets of protocol attributes. This is used to establish when a connection can be shared.</xs:documentation>
       </xs:annotation>
-      <xs:element name="script" minOccurs="0" type="ScriptElement-CT"/>
     </xs:sequence>
-    <xs:attribute name="cacheSize" type="xs:integer"/>
   </xs:complexType>
   <xs:complexType name="ConnectionNormalizer-CT">
     <xs:sequence>
       <xs:annotation>
         <xs:documentation>Normalize attributes required for protocol matching. This is used to establish when a connection can be shared.</xs:documentation>
       </xs:annotation>
-      <xs:choice>
-        <xs:element name="required-attributes" minOccurs="0" type="RequiredAttributes-CT"/>
-        <xs:element name="script" minOccurs="0" type="ScriptElement-CT"/>
-      </xs:choice>
+      <xs:element name="required-attributes" minOccurs="0" type="RequiredAttributes-CT"/>
     </xs:sequence>
-    <xs:attribute name="cacheSize" type="xs:integer"/>
   </xs:complexType>
   <xs:complexType name="ConnectionProperties-CT">
     <xs:sequence>


### PR DESCRIPTION
The script based normalizer and matcher was previously deprecated with 2020.3 release.  This change removes support with XSD changes that will enforce it is not used during packaging.
- update XSD with **breaking change** for packaging enforcement
- previously usage of this pattern was removed from the samples, but new_text_field was missed, update it
- update changelog with description 
- remove the notion of Unreleased for the changelog, it doesn't make much sense with the current branching structure