### PR TITLE
Document inferred connection resolver

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -223,7 +223,7 @@ Example:
 
 ## Deprecated API
 
-### ConnectionNormalizer and ConnectionMatcher JavaSscript files
+### ConnectionNormalizer and ConnectionMatcher JavaScript files
 The JavaScript files for connection normalizer and connection matcher are deprecated as of Tableau 2020.3. This means the element  `<script file="fileName.js"/>` (which was added inside the `<connection-matcher>` and `<connection-normalizer>` element) and the `<connection-matcher>` element itself are deprecated as of 2020.3. The `<connection-normalizer>` component can be added to the connectionResolver.tdr fie as shown in the connection-normalizer section above.
 
 ### SetImpersonateAttributes connection helper

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -77,6 +77,8 @@ Similar to connection-builder but is used to build the JDBC properties file. For
 
 Defines the unique set of connection attributes which is used to generate a connection "key" and has important security considerations. Connections can be reused and shared within Tableau processes based on this key, so it must contain attributes whose values will be unique in a given security context. Username is a commonly used attribute that will make a unique connection for each user, for example.
 
+Starting in Tableau 2021.1 a connector using Connection Dialog V2 style, connection-fields, can let the system determine at runtime the correct connection-normalizer by not defining it. Any connection-normalizer defined in the tdr file will take precedence at runtime. To use set min-version-tableau='2021.1' or newer in the manifest file.
+
 **Type:** XML
 
 The connection-normalizer is represented using a xml component in the [connectionResolver.tdr](https://github.com/tableau/connector-plugin-sdk/blob/master/samples/plugins/postgres_odbc/connectionResolver.tdr) file. An example is :

--- a/docs/example.md
+++ b/docs/example.md
@@ -181,15 +181,9 @@ This is an example Connection Builder script for JDBC:
 
 ```
 (function dsbuilder(attr) {
-    var urlBuilder = "jdbc:postgresql://" + attr["server"] + ":" + attr["port"] + "/" + attr["dbname"] + "?";
-    var params = [];
-    params["user"] = attr["username"];
-    params["password"] = attr["password"];
-    var formattedParams = [];
-    for (var key in params) {
-        formattedParams.push(connectionHelper.formatKeyValuePair(key, params[key]));
-    }
-    urlBuilder += formattedParams.join("&")
+    var urlBuilder = "jdbc:postgresql://" + attr[connectionHelper.attributeServer] + ":" + attr[connectionHelper.attributePort] + 
+        "/" + attr[connectionHelper.attributeDatabase] + "?";
+
     return [urlBuilder];
 })
 ```

--- a/docs/example.md
+++ b/docs/example.md
@@ -86,6 +86,8 @@ The TDR file also contains the connection-normalizer and the driver-resolver sec
 
 ```
 
+Starting in Tableau 2021.1 a connector using [Connection Dialog V2]({{ site.baseurl }}/docs/mcd) can let the system determine at runtime the correct <span style="font-family: courier new">connection-normalizer</span> by not defining it. See [API Reference]({{ site.baseurl }}/docs/api-reference#connection-normalizer) for more details.
+
 The <span style="font-family: courier new">driver-resolver</span> is currently only used for ODBC drivers. JDBC connectors can specify the driver name in the URL built by the connection builder JavaScript. 
 
 Tableau database connections have a unique type, the <span style="font-family: courier new">class</span> attribute.

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -37,7 +37,7 @@ To add a custom vendor attribute for an ODBC-based connector, you must modify th
 - connectionResolver.tdr
 - connectionBuilder.js
 
-To add a custom vendor attribute for an ODBC-based connector, you must modify these files:
+To add a custom vendor attribute for an JDBC-based connector, you must modify these files:
 - connection-dialog.tcd
 - connectionResolver.tdr
 - connectionProperties.js


### PR DESCRIPTION
Mentioned inferred connection resolver to both places connection-resolver is documented in the SDK.  Also fixed a few typos.  See individual commits for details.