### PR TITLE
Enforce OAuth instanceurl usage in packager

### DIFF
--- a/connector-packager/connector_packager/xsd_validator.py
+++ b/connector-packager/connector_packager/xsd_validator.py
@@ -163,6 +163,21 @@ def validate_file_specific_rules(file_to_test: ConnectorFile, path_to_file: Path
                                                  " already exists. Cannot have multiple fields with the same name.")
 
                     return False
+                if field_name == 'instanceurl':
+                    used_for_oauth = False
+                    for conditions in child.iter("conditions"):
+                        for condition in conditions.iter("condition"):
+                            if 'field' in condition.attrib:
+                                if condition.attrib['field'] == 'authentication':
+                                    if 'value' in condition.attrib:
+                                        if condition.attrib['value'] == 'oauth':
+                                            used_for_oauth = True
+                    if not used_for_oauth:
+                        xml_violations_buffer.append("Element 'field', attribute 'name'='instanceurl' can only be used conditional on field " + 
+                                                     "'authentication' with 'value'='oauth'. See 'Connection Field Platform Integration' section " + 
+                                                     "of documentation for more information.")
+                        return False
+
                 field_names.add(field_name)
 
             if 'category' in child.attrib:

--- a/connector-packager/tests/test_resources/instanceurl/connectionFields.xml
+++ b/connector-packager/tests/test_resources/instanceurl/connectionFields.xml
@@ -26,11 +26,7 @@
       </conditions>
     </field>
 
-    <field name="instanceurl" label="OAuth Instance Url" category="authentication" value-type="string">
-      <conditions>
-        <condition field="authentication" value="oauth" />
-      </conditions>
-      <validation-rule reg-exp="^https:\/\/(.+\.)?(snowflakecomputing\.(com|us|cn|de))(.*)"/>
-    </field>
+    <!-- unconditional usage of instanceurl is not supported, oauth specific -->
+    <field name="instanceurl" label="OAuth Instance Url" category="authentication" value-type="string" />
 
 </connection-fields>

--- a/connector-packager/tests/test_xsd_validator.py
+++ b/connector-packager/tests/test_xsd_validator.py
@@ -119,3 +119,18 @@ class TestXSDValidator(unittest.TestCase):
         logging.debug("test_validate_duplicate_fields_absent xml violations:")
         for violation in xml_violations_buffer:
             logging.debug(violation)
+
+    def test_validate_instanceurl(self):
+        test_file = TEST_FOLDER / "oauth_connector/connectionFields.xml"
+        file_to_test = ConnectorFile("connectionFields.xml", "connection-fields")
+        xml_violations_buffer = []
+
+        self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer),
+                        "Valid XML file not marked as valid")
+
+        test_file = TEST_FOLDER / "instanceurl/connectionFields.xml"
+        file_to_test = ConnectorFile("connectionFields.xml", "connection-fields")
+        xml_violations_buffer = []
+
+        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer),
+                        "An instanceurl field must be conditional to authentication field with value=oauth")


### PR DESCRIPTION
Field 'instanceurl' is only supported when used with 'authentication'='oauth'.
- add check to packager
- add tests for positive and negative case

All tests pass: `python setup.py test`

There might be a more compact way to write this check.  Please suggest if so, thanks!