### PR TITLE
Add a logical query option for fieldnamePostfix

### DIFF
--- a/tdvt/CHANGELOG.md
+++ b/tdvt/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Add logical query format option for fieldname postfix
 
 ## [2.3.1] - 2020-12-23
 - Revert Staples smoke test to be Expression; will fix in 2.3.2.
@@ -17,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated: Fixed some test cases with P3 defects initially checked in to use the correct functions (eg. DATENAME vs. DATETRUNC).
 
 ## [2.1.22] - 2020-10-05
-- Added a expected file expected.setup.cast.str.13.txt to support Postgres 12 database server output. PR 626 
+- Added a expected file expected.setup.cast.str.13.txt to support Postgres 12 database server output. PR 626
 
 ## [2.1.21] - 2020-10-02
 - Fixed a 'No tests found' error caused by a missing test metadata file.

--- a/tdvt/tdvt/config_gen/gentests.py
+++ b/tdvt/tdvt/config_gen/gentests.py
@@ -16,7 +16,7 @@ debug = False
 
 def get_logical_config_templates(ds_registry):
     all_templates = template_attributes.copy()
-    
+
     for ds in ds_registry.dsnames:
         info = ds_registry.get_datasource_info(ds)
         if not info:
@@ -50,7 +50,7 @@ def get_customized_table_name(attributes, base_table):
         table_name= table_name.lower()
 
     if 'tablenamePrefix' in attributes:
-        table_name = attributes['tablenamePrefix'] + table_name 
+        table_name = attributes['tablenamePrefix'] + table_name
     if 'tablenamePostfix' in attributes:
         table_name += attributes['tablenamePostfix']
 
@@ -69,7 +69,7 @@ def get_new_field_name(field, attrs):
             new_field = '[' + m.group(1) + '_]'
 
     if 'fieldnameLower' in attrs:
-        new_field = new_field.lower()        
+        new_field = new_field.lower()
     if 'fieldnameUpper' in attrs:
         new_field = new_field.upper()
     if 'fieldnameNoSpace' in attrs:
@@ -78,6 +78,10 @@ def get_new_field_name(field, attrs):
         new_field = new_field.lower().replace(' ', '_')
     if 'fieldnameUnderscoreNotSpace' in attrs:
         new_field = new_field.replace(' ', '_')
+    if 'fieldnamePostfix' in attrs:
+        m = re.search('\[(.*)\]', new_field, flags=re.IGNORECASE)
+        if m:
+            new_field = '[' + m.group(1) + attrs['fieldnamePostfix'] + ']'
 
     return new_field
 


### PR DESCRIPTION
If you add the following to your logical query config:
`fieldnamePostfix = __C`
The fieldnames will have `__C` appended to the end (ie str0__C)
