### PR TITLE
Add fieldnamePostfix doc change, remove column rename workaround

### DIFF
--- a/docs/tdvt.md
+++ b/docs/tdvt.md
@@ -462,27 +462,6 @@ The first thing TDVT does is try and connect to your database using the .tds fil
 
 1. Check tabquerytool.exe. This file should be placed in your Tableau bin directory and tdvt/config/tdvt_override.ini should be updated to point at that executable.
 
-__Tests fail with "Reference to undefined field..."__
-The first thing to check is that the column exists in your test database. If it doesn't, you will need to load the data again.
-
-TDVT expects the column names to exactly match those in the TestV1 datasets provided. It is recommended to match the column names exactly, as TDVT tests referencing those fields will fail otherwise.
-
-If for some reason the columns in your test database have to be named something different, you can work around that by adding column definitions to your TDS file that do match. For example, if your instance of the Staples table has the field Discounts with a trailing underscore, like so:
-
-```xml
-<column caption='Discount_' datatype='real' name='[discount_]' role='measure' type='quantitative' />
-```
-
-Add the following column definition:
-
-```xml
-<column datatype='real' name='[discount]' role='measure' type='quantitative'>
-    <calculation class='tableau' formula='[discount_]' />
-</column>
-```
-
-The new column will have the same data, and TDVT will be able to find it.
-
 __Boolean data types are not recognized or your database doesn't support them__
 You may need to rename a column in the TDS file.
 For example, the database may integer columns instead of Booleans for the **bool0**, **bool1**, **bool2**, and **bool3** columns.

--- a/docs/tdvt.md
+++ b/docs/tdvt.md
@@ -220,6 +220,7 @@ fieldnameLower | True | N/A | Set to true if the column names are all lowercase 
 fieldnameNoSpace | True | N/A | Set to true if the column names have no spaces | No
 fieldnameLower_underscore | True | N/A | Set to true if the column names have underscores and are all lowercase | No
 fieldnameUnderscoreNotSpace | True | N/A | Set to true if the column names replace spaces with underscores | No
+fieldnamePostfix | SomePostfix | N/A | Postfix that is applied to every column name | No
 
 ### [StandardTests]
 This is required to run the standard tests.


### PR DESCRIPTION
Added the new fieldnamePostfix option to the documentation on logical query format. Removed the calculated field workaround for not being able to change column names, since while it worked in expression tests it didn't work in the logical tests.