### PR TITLE
Truncate long cmd_output

### DIFF
--- a/tdvt/tdvt/tdvt_core.py
+++ b/tdvt/tdvt/tdvt_core.py
@@ -510,7 +510,7 @@ def get_csv_row_data(tds_name, test_name, test_path, test_result, test_case_inde
 
     # Truncate long process outputs to keep size of csv down
     if len(cmd_output) > 1024:
-        cmd_output = cmd_output[:1022] + ".."
+        cmd_output = cmd_output[:1024] + "<output_truncated>"
 
     priority = test_result.test_metadata.get_priority() if test_result and test_result.test_metadata else 'unknown'
     categories = test_result.test_metadata.concat_categories() if test_result and test_result.test_metadata else 'unknown'

--- a/tdvt/tdvt/tdvt_core.py
+++ b/tdvt/tdvt/tdvt_core.py
@@ -509,8 +509,8 @@ def get_csv_row_data(tds_name, test_name, test_path, test_result, test_case_inde
         test_type = 'logical' if test_result.test_config.logical else 'expression'
 
     # Truncate long process outputs to keep size of csv down
-    if len(cmd_output) > 1024:
-        cmd_output = cmd_output[:1024] + "<output_truncated>"
+    if len(cmd_output) > 4096:
+        cmd_output = cmd_output[:4096] + "<output_truncated>"
 
     priority = test_result.test_metadata.get_priority() if test_result and test_result.test_metadata else 'unknown'
     categories = test_result.test_metadata.concat_categories() if test_result and test_result.test_metadata else 'unknown'

--- a/tdvt/tdvt/tdvt_core.py
+++ b/tdvt/tdvt/tdvt_core.py
@@ -44,7 +44,7 @@ class ConnectorsTest(object):
                                                       timeout=self.timeout_seconds))
         print(self.cmd_output)
         sys.exit(0)
-   
+
 
 class TestResultWork(object):
     def __init__(self, test_file, output_dir, logical):
@@ -507,6 +507,10 @@ def get_csv_row_data(tds_name, test_name, test_path, test_result, test_case_inde
     test_type = 'unknown'
     if test_result and test_result.test_config:
         test_type = 'logical' if test_result.test_config.logical else 'expression'
+
+    # Truncate long process outputs to keep size of csv down
+    if len(cmd_output) > 1024:
+        cmd_output = cmd_output[:1022] + ".."
 
     priority = test_result.test_metadata.get_priority() if test_result and test_result.test_metadata else 'unknown'
     categories = test_result.test_metadata.concat_categories() if test_result and test_result.test_metadata else 'unknown'


### PR DESCRIPTION
Forgot to merge https://github.com/tableau/connector-plugin-sdk/pull/495 for about a year. Opening a new pull request since resolving the merge conflicts would be messier. 

Original description:
Had a tdvt results csv file that became very large since the process output was very large (~20,000 characters). Wrote a check that truncates to 512 [changed to 1024 in new PR] characters instead. Open to ideas of what the cutoff point should be, it may be a bit restrictive as of now.