### PR TITLE
Packager warn during validation about using DefaultSQLDialect

### DIFF
--- a/connector-packager/connector_packager/xsd_validator.py
+++ b/connector-packager/connector_packager/xsd_validator.py
@@ -17,8 +17,6 @@ PATH_TO_XSD_FILES = Path("../validation").absolute()
 VALID_XML_EXTENSIONS = ['tcd', 'tdr', 'tdd', 'xml']  # These are the file extensions that we will validate
 PLATFORM_FIELD_NAMES = ['server', 'port', 'sslmode', 'authentication', 'username', 'password', 'vendor1', 'vendor2', 'vendor3']
 VENDOR_FIELD_NAME_PREFIX = 'v-'
-DEFAULTSQLDIALECT_AS_BASE_WARNING_MESSAGE = 'Warning: DefaultSQLDialect is not a recommended base to inherit from, ' \
-                                            'please choose base dialect from the recommended base dialect list here: https://tableau.github.io/connector-plugin-sdk/docs/design#choose-a-dialect'
 
 # Holds the mapping between file type and XSD file name
 XSD_DICT = {
@@ -71,7 +69,7 @@ def validate_all_xml(files_list: List[ConnectorFile], folder_path: Path) -> bool
         else:
             xml_violations_found += 1
 
-        check_file_content(file_to_test, path_to_file)
+        warn_file_specific_rules(file_to_test, path_to_file)
 
     if xml_violations_found <= 0:
         logger.debug("No XML violations found")
@@ -182,10 +180,11 @@ def validate_file_specific_rules(file_to_test: ConnectorFile, path_to_file: Path
     return True
 
 # Check if connector file content contains warnings needs to notify connector developer
-def check_file_content(file_to_test: ConnectorFile, path_to_file: Path):
+def warn_file_specific_rules(file_to_test: ConnectorFile, path_to_file: Path):
 
     if file_to_test.file_type == 'dialect':
         xml_tree = parse(str(path_to_file))
         root = xml_tree.getroot()
         if 'base' in root.attrib and root.attrib['base'] == 'DefaultSQLDialect':
-            logger.warning(DEFAULTSQLDIALECT_AS_BASE_WARNING_MESSAGE)
+            logger.warning('Warning: DefaultSQLDialect is not a recommended base to inherit from, ' \
+                           'please see the documentation for current best practices: https://tableau.github.io/connector-plugin-sdk/docs/design#choose-a-dialect')

--- a/connector-packager/connector_packager/xsd_validator.py
+++ b/connector-packager/connector_packager/xsd_validator.py
@@ -69,6 +69,8 @@ def validate_all_xml(files_list: List[ConnectorFile], folder_path: Path) -> bool
         else:
             xml_violations_found += 1
 
+        check_file_content(file_to_test, path_to_file)
+
     if xml_violations_found <= 0:
         logger.debug("No XML violations found")
     else:
@@ -176,3 +178,13 @@ def validate_file_specific_rules(file_to_test: ConnectorFile, path_to_file: Path
                     return False
 
     return True
+
+# Check if connector file content contains warnings needs to notify connector developer
+def check_file_content(file_to_test: ConnectorFile, path_to_file: Path):
+
+    if file_to_test.file_type == 'dialect':
+        xml_tree = parse(str(path_to_file))
+        root = xml_tree.getroot()
+        if 'base' in root.attrib and root.attrib['base'] == 'DefaultSQLDialect':
+            logger.warning("Warning: DefaultSQLDialect is not a recommended base to inherit from, please change your base dialect to a better one, "
+                            "you can find the recommended base dialect list on our SDK documentation page.")

--- a/connector-packager/connector_packager/xsd_validator.py
+++ b/connector-packager/connector_packager/xsd_validator.py
@@ -17,6 +17,8 @@ PATH_TO_XSD_FILES = Path("../validation").absolute()
 VALID_XML_EXTENSIONS = ['tcd', 'tdr', 'tdd', 'xml']  # These are the file extensions that we will validate
 PLATFORM_FIELD_NAMES = ['server', 'port', 'sslmode', 'authentication', 'username', 'password', 'vendor1', 'vendor2', 'vendor3']
 VENDOR_FIELD_NAME_PREFIX = 'v-'
+DEFAULTSQLDIALECT_AS_BASE_WARNING_MESSAGE = 'Warning: DefaultSQLDialect is not a recommended base to inherit from, ' \
+                                            'please choose base dialect from the recommended base dialect list here: https://tableau.github.io/connector-plugin-sdk/docs/design#choose-a-dialect'
 
 # Holds the mapping between file type and XSD file name
 XSD_DICT = {
@@ -186,5 +188,4 @@ def check_file_content(file_to_test: ConnectorFile, path_to_file: Path):
         xml_tree = parse(str(path_to_file))
         root = xml_tree.getroot()
         if 'base' in root.attrib and root.attrib['base'] == 'DefaultSQLDialect':
-            logger.warning("Warning: DefaultSQLDialect is not a recommended base to inherit from, please change your base dialect to a better one, "
-                            "you can find the recommended base dialect list on our SDK documentation page.")
+            logger.warning(DEFAULTSQLDIALECT_AS_BASE_WARNING_MESSAGE)

--- a/connector-packager/tests/test_resources/defaultSQLDialect_as_base/dialect.tdd
+++ b/connector-packager/tests/test_resources/defaultSQLDialect_as_base/dialect.tdd
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dialect name='SimplePostgres'
+         class='postgres_odbc'
+         base='DefaultSQLDialect'
+         version='18.1'>
+ </dialect>

--- a/connector-packager/tests/test_xsd_validator.py
+++ b/connector-packager/tests/test_xsd_validator.py
@@ -2,7 +2,7 @@ import unittest
 import logging
 from pathlib import Path
 
-from connector_packager.xsd_validator import validate_all_xml, validate_single_file, check_file_content, DEFAULTSQLDIALECT_AS_BASE_WARNING_MESSAGE
+from connector_packager.xsd_validator import validate_all_xml, validate_single_file, warn_file_specific_rules
 from connector_packager.connector_file import ConnectorFile
 
 logger = logging.getLogger(__name__)
@@ -126,7 +126,8 @@ class TestXSDValidator(unittest.TestCase):
         file_to_test = ConnectorFile("dialect.tdd", "dialect")
 
         with self.assertLogs('packager_logger', level='WARNING') as cm:
-            check_file_content(file_to_test, test_dialect_file)
+            warn_file_specific_rules(file_to_test, test_dialect_file)
 
-        self.assertIn('WARNING:packager_logger:' + DEFAULTSQLDIALECT_AS_BASE_WARNING_MESSAGE, cm.output)
+        self.assertEqual(len(cm.output), 1)
+        self.assertIn('DefaultSQLDialect', cm.output[0], "DefaultSQLDialect not found in warning message")
 

--- a/connector-packager/tests/test_xsd_validator.py
+++ b/connector-packager/tests/test_xsd_validator.py
@@ -2,7 +2,7 @@ import unittest
 import logging
 from pathlib import Path
 
-from connector_packager.xsd_validator import validate_all_xml, validate_single_file
+from connector_packager.xsd_validator import validate_all_xml, validate_single_file, check_file_content, DEFAULTSQLDIALECT_AS_BASE_WARNING_MESSAGE
 from connector_packager.connector_file import ConnectorFile
 
 logger = logging.getLogger(__name__)
@@ -119,3 +119,14 @@ class TestXSDValidator(unittest.TestCase):
         logging.debug("test_validate_duplicate_fields_absent xml violations:")
         for violation in xml_violations_buffer:
             logging.debug(violation)
+
+    def test_warn_defaultSQLDialect_as_base(self):
+
+        test_dialect_file = TEST_FOLDER / "defaultSQLDialect_as_base/dialect.tdd"
+        file_to_test = ConnectorFile("dialect.tdd", "dialect")
+
+        with self.assertLogs('packager_logger', level='WARNING') as cm:
+            check_file_content(file_to_test, test_dialect_file)
+
+        self.assertIn('WARNING:packager_logger:' + DEFAULTSQLDIALECT_AS_BASE_WARNING_MESSAGE, cm.output)
+


### PR DESCRIPTION
The packager warns the partner when they are using DefaultSQLDialect that DefaultSQLDialect isn't recommended.

Manually tested it with empty base, DefaultSQLDialect as base, and regular base, worked as expected.