### PR TITLE
Align samples with documentation recommendations

### DIFF
--- a/samples/components/dialogs/new_text_field/connection-dialog.tcd
+++ b/samples/components/dialogs/new_text_field/connection-dialog.tcd
@@ -2,7 +2,7 @@
   <connection-config>
     <authentication-mode value='Basic' />
     <authentication-options>
-      <option name="UsernameAndPassword" />
+      <option name="UsernameAndPassword" default="true" value="auth-user-pass" />
     </authentication-options>
     <db-name-prompt value="Database: " />
     <has-pre-connect-database value="true" />

--- a/samples/components/resolvers/simple_example.tdr
+++ b/samples/components/resolvers/simple_example.tdr
@@ -5,6 +5,7 @@
       <required-attributes>
         <attribute-list>
           <attr>server</attr>
+          <attr>authentication</attr>
           <attr>username</attr>
           <attr>password</attr>
         </attribute-list>

--- a/samples/plugins/postgres_jdbc/connection-dialog.tcd
+++ b/samples/plugins/postgres_jdbc/connection-dialog.tcd
@@ -2,7 +2,7 @@
   <connection-config>
     <authentication-mode value='Basic' />
     <authentication-options>
-      <option name="UsernameAndPassword" default="true" />
+      <option name="UsernameAndPassword" default="true" value="auth-user-pass" />
     </authentication-options>
     <db-name-prompt value="Database: " />
     <has-pre-connect-database value="true" />

--- a/samples/plugins/postgres_jdbc/connectionResolver.tdr
+++ b/samples/plugins/postgres_jdbc/connectionResolver.tdr
@@ -10,6 +10,7 @@
           <attr>server</attr>
           <attr>port</attr>
           <attr>dbname</attr>
+          <attr>authentication</attr>
           <attr>username</attr>
           <attr>password</attr>
           <attr>sslmode</attr>

--- a/samples/plugins/postgres_odbc/connection-dialog.tcd
+++ b/samples/plugins/postgres_odbc/connection-dialog.tcd
@@ -2,7 +2,7 @@
   <connection-config>
     <authentication-mode value='Basic' />
     <authentication-options>
-      <option name="UsernameAndPassword" default="true" />
+      <option name="UsernameAndPassword" default="true" value="auth-user-pass" />
     </authentication-options>
     <db-name-prompt value="Database: " />
     <has-pre-connect-database value="true" />

--- a/samples/plugins/postgres_odbc/connectionResolver.tdr
+++ b/samples/plugins/postgres_odbc/connectionResolver.tdr
@@ -10,6 +10,7 @@
           <attr>server</attr>
           <attr>port</attr>
           <attr>dbname</attr>
+          <attr>authentication</attr>
           <attr>username</attr>
           <attr>password</attr>
           <attr>sslmode</attr>

--- a/samples/scenarios/vendor_attributes/postgres_vendor/connection-dialog.tcd
+++ b/samples/scenarios/vendor_attributes/postgres_vendor/connection-dialog.tcd
@@ -2,7 +2,7 @@
   <connection-config>
     <authentication-mode value='Basic' />
     <authentication-options>
-      <option name="UsernameAndPassword" default="true" />
+      <option name="UsernameAndPassword" default="true" value="auth-user-pass" />
     </authentication-options>
     <db-name-prompt value="Database: " />
     <has-pre-connect-database value="true" />

--- a/samples/scenarios/vendor_attributes/postgres_vendor/connectionResolver.tdr
+++ b/samples/scenarios/vendor_attributes/postgres_vendor/connectionResolver.tdr
@@ -13,6 +13,7 @@
           <attr>vendor3</attr>
           <attr>port</attr>
           <attr>dbname</attr>
+          <attr>authentication</attr>
           <attr>username</attr>
           <attr>password</attr>
           <attr>sslmode</attr>


### PR DESCRIPTION
In username password scenarios
- 'authentication' should be in `required-attributes` list 
- .tcd UsernameAndPassword option value should be `auth-user-pass`

Documentation reference used: https://tableau.github.io/connector-plugin-sdk/docs/auth-modes