### PR TITLE
warn if 'authentication' attribute is missing in required attributes list

### DIFF
--- a/connector-packager/connector_packager/xsd_validator.py
+++ b/connector-packager/connector_packager/xsd_validator.py
@@ -105,7 +105,6 @@ def validate_single_file(file_to_test: ConnectorFile, path_to_file: Path, xml_vi
         return False
 
     manifest_schema = XMLSchema(str(PATH_TO_XSD_FILES / Path(xsd_file)))
-    saved_error = None
 
     # If the file is too big, we shouldn't try and parse it, just log the violation and move on
     if path_to_file.stat().st_size > MAX_FILE_SIZE:
@@ -179,12 +178,41 @@ def validate_file_specific_rules(file_to_test: ConnectorFile, path_to_file: Path
 
     return True
 
+
 # Check if connector file content contains warnings needs to notify connector developer
 def warn_file_specific_rules(file_to_test: ConnectorFile, path_to_file: Path):
 
     if file_to_test.file_type == 'dialect':
-        xml_tree = parse(str(path_to_file))
-        root = xml_tree.getroot()
-        if 'base' in root.attrib and root.attrib['base'] == 'DefaultSQLDialect':
-            logger.warning('Warning: DefaultSQLDialect is not a recommended base to inherit from, ' \
-                           'please see the documentation for current best practices: https://tableau.github.io/connector-plugin-sdk/docs/design#choose-a-dialect')
+        warn_file_specific_rules_dialect(path_to_file)
+    elif file_to_test.file_type == 'connection-resolver':
+        warn_file_specific_rules_tdr(path_to_file)
+
+
+def warn_file_specific_rules_dialect(path_to_file: Path):
+
+    xml_tree = parse(str(path_to_file))
+    root = xml_tree.getroot()
+    if 'base' in root.attrib and root.attrib['base'] == 'DefaultSQLDialect':
+        logger.warning('Warning: DefaultSQLDialect is not a recommended base to inherit from, '
+                       'please see the documentation for current best practices: '
+                       'https://tableau.github.io/connector-plugin-sdk/docs/design#choose-a-dialect')
+
+
+def warn_file_specific_rules_tdr(path_to_file: Path):
+
+    xml_tree = parse(str(path_to_file))
+    root = xml_tree.getroot()
+    attribute_list = root.find('.//connection-normalizer/required-attributes/attribute-list')
+
+    if not attribute_list:
+        return
+
+    authentication_attr_exists = False
+    for attr in attribute_list.iter('attr'):
+        if attr.text == 'authentication':
+            authentication_attr_exists = True
+            break
+
+    if not authentication_attr_exists:
+        logger.warning("Warning: 'authentication' attribute is missing from "
+                       "<connection-normalizer>/<required-attributes>/<attribute-list> in " + str(path_to_file) + ".")


### PR DESCRIPTION
Manual tests:

```
(.venv) E:\github\connector-plugin-sdk\connector-packager>python -m connector_packager.package --validate-only F:\test\plugin_with_authentication
The log path E:\github\connector-plugin-sdk\connector-packager exists
Validation succeeded.

(.venv) E:\github\connector-plugin-sdk\connector-packager>python -m connector_packager.package --validate-only F:\test\plugin_without_authentication
The log path E:\github\connector-plugin-sdk\connector-packager exists
Warning: 'authentication' attribute is missing from <connection-normalizer>/<required-attributes>/<attribute-list> in F:\test\plugin_without_authentication\connection-resolver.tdr.
Validation succeeded.
```
