### PR TITLE
Added metadata files to setup manifest

### DIFF
--- a/tdvt/MANIFEST.in
+++ b/tdvt/MANIFEST.in
@@ -3,4 +3,5 @@ recursive-include tdvt/config *.ini
 recursive-include tdvt/exprtests *.txt
 recursive-include tdvt/logicaltests/expected *.xml
 recursive-include tdvt/logicaltests/generate *.xml
+recursive-include tdvt/metadata *.csv
 include tdvt/tds *.tds


### PR DESCRIPTION
I was wondering why all of the test metadata columns were showing up as "Unknown" in partner test results. Apparently the metadata files needed to be added to the packager manifest. Should work now.