### PR TITLE
Clean up metadata

### DIFF
--- a/tdvt/CHANGELOG.md
+++ b/tdvt/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.4] - 2021-04-12
+- Clean up and simplify test metadata file
+- Fix missing metadata file when running setup.py
+
 ## [2.3.3] - 2021-03-15
 - Refactor calcs_data test
 - Add logical query format option for fieldname postfix
@@ -13,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.3.1] - 2020-12-23
 - Revert Staples smoke test to be Expression; will fix in 2.3.2.
+
 ## [2.3.0] - 2020-12-09
 - Change Staples smoke test to be logical.
 - Added Connectors Tests.

--- a/tdvt/MANIFEST.in
+++ b/tdvt/MANIFEST.in
@@ -3,4 +3,5 @@ recursive-include tdvt/config *.ini
 recursive-include tdvt/exprtests *.txt
 recursive-include tdvt/logicaltests/expected *.xml
 recursive-include tdvt/logicaltests/generate *.xml
+recursive-include tdvt/metadata *.csv
 include tdvt/tds *.tds

--- a/tdvt/tdvt/metadata/test_metadata.csv
+++ b/tdvt/tdvt/metadata/test_metadata.csv
@@ -1086,3 +1086,8 @@ Filters	tdvt/logicaltests/staples	ZTesting.Staples9	>=	Recommended
 Operator	tdvt/logicaltests/staples	ZTesting.Staples9	>=	Recommended
 Logical	tdvt/logicaltests/staples	ZTesting.Staples9	$SYS_NARY_AND$	Recommended
 Date Filters	tdvt/logicaltests/staples	ZTesting.Staples9	DATEPART	Recommended
+Date Aggregation	tdvt/exprtests/standard	calcs_data.dates		Required
+Cast	tdvt/exprtests/standard	date.cast.datetime	DATETIME	Required
+Calculation	tdvt/exprtests/standard	math.atan2	ATAN2	Required If Supported
+Calculation	tdvt/exprtests/standard	string.contains.empty	CONTAINS	Required
+Calculation	tdvt/exprtests/standard	string.contains.regex	CONTAINS	Required If Supported

--- a/tdvt/tdvt/metadata/test_metadata.csv
+++ b/tdvt/tdvt/metadata/test_metadata.csv
@@ -1,2563 +1,1088 @@
-Test Function	Test Category	Test Path Categorized	Test Name Categorized	Function Categorized	Priority
-SUM	Aggregation	tdvt/exprtests/standard	agg.avg	AVG	Required
-SUM	Aggregation	tdvt/exprtests/standard	agg.avg	COUNT	Required
-SUM	Calculation	tdvt/exprtests/standard	agg.avg	AVG	Required
-SUM	Calculation	tdvt/exprtests/standard	agg.avg	COUNT	Required
-TEMP_TABLES_AND_SUBQUERIES	Domain	tdvt/exprtests/standard	agg.avg	COUNT	Required
-TEMP_TABLES_AND_SUBQUERIES	Filters	tdvt/exprtests/standard	agg.avg	AVG	Required
-COUNT	Filters	tdvt/exprtests/standard	agg.avg	COUNT	Required
-COUNT	Reference Line	tdvt/exprtests/standard	agg.avg	AVG	Required
-COUNT	Reference Line	tdvt/exprtests/standard	agg.avg	COUNT	Required
-COUNT	Reference Line	tdvt/exprtests/standard	agg.count	COUNT	Required
-COUNT	Filters	tdvt/exprtests/standard	agg.count	COUNT	Required
-+	Domain	tdvt/exprtests/standard	agg.count	COUNT	Required
-+	Aggregation	tdvt/exprtests/standard	agg.count	COUNT	Required
-DATENAME	Calculation	tdvt/exprtests/standard	agg.count	COUNT	Required
-DATENAME	Aggregation	tdvt/exprtests/standard	agg.countd	COUNT	Required
-DATENAME	Aggregation	tdvt/exprtests/standard	agg.countd	COUNTD	Required
-SUM	Calculation	tdvt/exprtests/standard	agg.countd	COUNT	Required
-SUM	Calculation	tdvt/exprtests/standard	agg.countd	COUNTD	Required
-SUM	Column Metadata Nullability	tdvt/exprtests/standard	agg.countd	COLUMN_NULLABILITY	Required
-SUM	Domain	tdvt/exprtests/standard	agg.countd	COUNT	Required
-<=	Domain	tdvt/exprtests/standard	agg.countd	COUNTD	Required
-<=	Filters	tdvt/exprtests/standard	agg.countd	COUNT	Required
-<=	Filters	tdvt/exprtests/standard	agg.countd	COUNTD	Required
->=	Reference Line	tdvt/exprtests/standard	agg.countd	COUNT	Required
->=	Reference Line	tdvt/exprtests/standard	agg.countd	COUNTD	Required
->=	Reference Line	tdvt/exprtests/standard	agg.max	COUNT	Required
-	Filters	tdvt/exprtests/standard	agg.max	COUNT	Required
-DATE	Domain	tdvt/exprtests/standard	agg.max	COUNT	Required
-DATE	Aggregation	tdvt/exprtests/standard	agg.max	COUNT	Required
-YEAR	Calculation	tdvt/exprtests/standard	agg.max	COUNT	Required
-YEAR	Filters	tdvt/exprtests/standard	agg.max	MAX	Required
-YEAR	Domain	tdvt/exprtests/standard	agg.max	MAX	Required
-MONTH	Aggregation	tdvt/exprtests/standard	agg.max	MAX	Required
-MONTH	Calculation	tdvt/exprtests/standard	agg.max	MAX	Required
-MONTH	Aggregation	tdvt/exprtests/standard	agg.min	COUNT	Required
-DAY	Aggregation	tdvt/exprtests/standard	agg.min	MIN	Required
-DAY	Calculation	tdvt/exprtests/standard	agg.min	COUNT	Required
-DAY	Calculation	tdvt/exprtests/standard	agg.min	MIN	Required
-DATETIME	Domain	tdvt/exprtests/standard	agg.min	COUNT	Required
-DATETIME	Domain	tdvt/exprtests/standard	agg.min	MIN	Required
-DATETIME	Filters	tdvt/exprtests/standard	agg.min	COUNT	Required
-SUM	Filters	tdvt/exprtests/standard	agg.min	MIN	Required
-SUM	Reference Line	tdvt/exprtests/standard	agg.min	COUNT	Required
-SUM	Reference Line	tdvt/exprtests/standard	agg.stddev	COUNT	Required
-SUM	Filters	tdvt/exprtests/standard	agg.stddev	COUNT	Required
-AVG	Domain	tdvt/exprtests/standard	agg.stddev	COUNT	Required
-AVG	Aggregation	tdvt/exprtests/standard	agg.stddev	COUNT	Required
-AVG	Calculation	tdvt/exprtests/standard	agg.stddev	COUNT	Required
-AVG	Reference Line	tdvt/exprtests/standard	agg.stddev	STDEVP	Required
-<	Aggregation	tdvt/exprtests/standard	agg.stddev	STDEVP	Required
-<	Calculation	tdvt/exprtests/standard	agg.stddev	STDEVP	Required
-<	Reference Line	tdvt/exprtests/standard	agg.stddev	STDEV	Required
-DATEPARSE	Aggregation	tdvt/exprtests/standard	agg.stddev	STDEV	Required
-DATEPARSE	Calculation	tdvt/exprtests/standard	agg.stddev	STDEV	Required
-DATEPARSE	Aggregation	tdvt/exprtests/standard	agg.sum	COUNT	Required
-COUNT	Aggregation	tdvt/exprtests/standard	agg.sum	SUM	Required
-COUNT	Calculation	tdvt/exprtests/standard	agg.sum	COUNT	Required
-COUNT	Calculation	tdvt/exprtests/standard	agg.sum	SUM	Required
-COUNT	Domain	tdvt/exprtests/standard	agg.sum	COUNT	Required
-COUNT	Filters	tdvt/exprtests/standard	agg.sum	COUNT	Required
-SUM	Filters	tdvt/exprtests/standard	agg.sum	SUM	Required
-SUM	Reference Line	tdvt/exprtests/standard	agg.sum	COUNT	Required
-SUM	Reference Line	tdvt/exprtests/standard	agg.sum	SUM	Required
-SUM	Aggregation	tdvt/exprtests/standard	agg.var	COUNT	Required
-DATEPART	Aggregation	tdvt/exprtests/standard	agg.var	VAR	Required
-DATEPART	Aggregation	tdvt/exprtests/standard	agg.var	VARP	Required
-DATEPART	Calculation	tdvt/exprtests/standard	agg.var	COUNT	Required
-<=	Calculation	tdvt/exprtests/standard	agg.var	VAR	Required
-<=	Calculation	tdvt/exprtests/standard	agg.var	VARP	Required
-<=	Domain	tdvt/exprtests/standard	agg.var	COUNT	Required
-DATE	Filters	tdvt/exprtests/standard	agg.var	COUNT	Required
-DATE	Reference Line	tdvt/exprtests/standard	agg.var	COUNT	Required
-*	Reference Line	tdvt/exprtests/standard	agg.var	VAR	Required
-*	Reference Line	tdvt/exprtests/standard	agg.var	VARP	Required
-EXP		tdvt/logicaltests/staples	BUGS.B14080	$IN_SET$	Required
-EXP		tdvt/logicaltests/staples	BUGS.B14080	$SYS_NARY_AND$	Required
-DATEADD	Aggregation	tdvt/logicaltests/staples	BUGS.B14080	SUM	Required
-DATEADD	Calculation	tdvt/logicaltests/staples	BUGS.B14080	!	Required
-DATEADD	Calculation	tdvt/logicaltests/staples	BUGS.B14080	-	Required
-DATENAME	Calculation	tdvt/logicaltests/staples	BUGS.B14080	FLOAT	Required
-DATENAME	Calculation	tdvt/logicaltests/staples	BUGS.B14080	ISNULL	Required
-DATENAME	Calculation	tdvt/logicaltests/staples	BUGS.B14080	SUM	Required
-DATETRUNC	Cast	tdvt/logicaltests/staples	BUGS.B14080	FLOAT	Required
-DATETRUNC	Data Prep	tdvt/logicaltests/staples	BUGS.B14080	!	Required
-DATETRUNC	Data Prep	tdvt/logicaltests/staples	BUGS.B14080	FLOAT	Required
-COUNT	Filters	tdvt/logicaltests/staples	BUGS.B14080	SUM	Required
-COUNT	NULL Semantics	tdvt/logicaltests/staples	BUGS.B14080	ISNULL	Required
-COUNT	Operator	tdvt/logicaltests/staples	BUGS.B14080	!	Required
-COUNT	Operator	tdvt/logicaltests/staples	BUGS.B14080	-	Required
-COUNT	Reference Line	tdvt/logicaltests/staples	BUGS.B14080	SUM	Required
-DATEPART		tdvt/logicaltests/calcs	BUGS.B1713	$SYS_NARY_AND$	Required
-DATEPART		tdvt/logicaltests/calcs	BUGS.B1713	$SYS_NARY_OR$	Required
-DATEPART	Aggregation	tdvt/logicaltests/calcs	BUGS.B1713	COUNT	Required
-ROUND	Aggregation	tdvt/logicaltests/calcs	BUGS.B1713	SUM	Required
-COUNT	Calculation	tdvt/logicaltests/calcs	BUGS.B1713	<=	Required
-COUNT	Calculation	tdvt/logicaltests/calcs	BUGS.B1713	>=	Required
-COUNT	Calculation	tdvt/logicaltests/calcs	BUGS.B1713	COUNT	Required
-COUNT	Calculation	tdvt/logicaltests/calcs	BUGS.B1713	SUM	Required
-COUNT	Domain	tdvt/logicaltests/calcs	BUGS.B1713	COUNT	Required
-SPLIT	Filters	tdvt/logicaltests/calcs	BUGS.B1713	<=	Required
-SPLIT	Filters	tdvt/logicaltests/calcs	BUGS.B1713	>=	Required
-COUNT	Filters	tdvt/logicaltests/calcs	BUGS.B1713	COUNT	Required
-COUNT	Filters	tdvt/logicaltests/calcs	BUGS.B1713	SUM	Required
-COUNT	Filters	tdvt/logicaltests/calcs	BUGS.B1713	TEMP_TABLES_AND_SUBQUERIES	Required
-COUNT	Operator	tdvt/logicaltests/calcs	BUGS.B1713	<=	Required
-COUNT	Operator	tdvt/logicaltests/calcs	BUGS.B1713	>=	Required
-DATETRUNC	Reference Line	tdvt/logicaltests/calcs	BUGS.B1713	COUNT	Required
-DATETRUNC	Reference Line	tdvt/logicaltests/calcs	BUGS.B1713	SUM	Required
-DATETRUNC	Temp Tables and Subqueries	tdvt/logicaltests/calcs	BUGS.B1713	TEMP_TABLES_AND_SUBQUERIES	Required
-LEFT	Calculation	tdvt/logicaltests/staples	BUGS.B24394	<=	Required
-LEFT	Calculation	tdvt/logicaltests/staples	BUGS.B24394	DATEPART	Required
-LEFT	Calculation	tdvt/logicaltests/staples	BUGS.B24394	DATETRUNC	Required
-LEFT	Date Aggregation	tdvt/logicaltests/staples	BUGS.B24394	DATEPART	Required
-DATEDIFF	Date Aggregation	tdvt/logicaltests/staples	BUGS.B24394	DATETRUNC	Required
-DATEDIFF	Date Filters	tdvt/logicaltests/staples	BUGS.B24394	DATEPART	Required
-DATEDIFF	Date Filters	tdvt/logicaltests/staples	BUGS.B24394	DATETRUNC	Required
-DATETIME	Filters	tdvt/logicaltests/staples	BUGS.B24394	<=	Required
-DATETIME	Operator	tdvt/logicaltests/staples	BUGS.B24394	<=	Required
-DATETIME	Date Aggregation	tdvt/logicaltests/calcs	BUGS.B26728	DATEDIFF	Required
-RIGHT	Date Filters	tdvt/logicaltests/calcs	BUGS.B26728	DATEDIFF	Required
-RIGHT	Calculation	tdvt/logicaltests/calcs	BUGS.B26728	DATEDIFF	Required
-COLUMN_NULLABILITY		tdvt/logicaltests/calcs	BUGS.B26728	SYS_NUMBIN	Required
-SUM	Aggregation	tdvt/logicaltests/calcs	BUGS.B27875-asc-nulls-first	SUM	Recommended
-SUM	Calculation	tdvt/logicaltests/calcs	BUGS.B27875-asc-nulls-first	SUM	Recommended
-SUM	Filters	tdvt/logicaltests/calcs	BUGS.B27875-asc-nulls-first	SUM	Recommended
-SUM	Filters	tdvt/logicaltests/calcs	BUGS.B27875-asc-nulls-first	TEMP_TABLES_AND_SUBQUERIES	Recommended
-DATEPART	Reference Line	tdvt/logicaltests/calcs	BUGS.B27875-asc-nulls-first	SUM	Recommended
-DATEPART	Temp Tables and Subqueries	tdvt/logicaltests/calcs	BUGS.B27875-asc-nulls-first	TEMP_TABLES_AND_SUBQUERIES	Recommended
-DATEPART	Aggregation	tdvt/logicaltests/calcs	BUGS.B27875-desc-nulls-last	SUM	Recommended
-!	Calculation	tdvt/logicaltests/calcs	BUGS.B27875-desc-nulls-last	SUM	Recommended
-!	Filters	tdvt/logicaltests/calcs	BUGS.B27875-desc-nulls-last	SUM	Recommended
-!	Filters	tdvt/logicaltests/calcs	BUGS.B27875-desc-nulls-last	TEMP_TABLES_AND_SUBQUERIES	Recommended
-ISNULL	Reference Line	tdvt/logicaltests/calcs	BUGS.B27875-desc-nulls-last	SUM	Recommended
-ISNULL	Temp Tables and Subqueries	tdvt/logicaltests/calcs	BUGS.B27875-desc-nulls-last	TEMP_TABLES_AND_SUBQUERIES	Recommended
-	Reference Line	tdvt/logicaltests/staples	BUGS.B340	SUM	Recommended
-	Filters	tdvt/logicaltests/staples	BUGS.B340	SUM	Recommended
-RADIANS	Aggregation	tdvt/logicaltests/staples	BUGS.B340	SUM	Recommended
-RADIANS	Calculation	tdvt/logicaltests/staples	BUGS.B340	SUM	Recommended
-DATETRUNC	Temp Tables and Subqueries	tdvt/logicaltests/staples	BUGS.B340	TEMP_TABLES_AND_SUBQUERIES	Recommended
-DATETRUNC	Filters	tdvt/logicaltests/staples	BUGS.B340	TEMP_TABLES_AND_SUBQUERIES	Recommended
-DATETRUNC	Filters	tdvt/logicaltests/staples	BUGS.B340	<=	Recommended
-COUNT	Operator	tdvt/logicaltests/staples	BUGS.B340	<=	Recommended
-COUNT	Calculation	tdvt/logicaltests/staples	BUGS.B340	<=	Recommended
-COUNT	Filters	tdvt/logicaltests/staples	BUGS.B340	>=	Recommended
-COUNT	Operator	tdvt/logicaltests/staples	BUGS.B340	>=	Recommended
-COUNT	Calculation	tdvt/logicaltests/staples	BUGS.B340	>=	Recommended
-DATENAME		tdvt/logicaltests/staples	BUGS.B340	$SYS_NARY_AND$	Recommended
-DATENAME	Filters	tdvt/logicaltests/staples	BUGS.B340	MIN	Recommended
-DATENAME	Domain	tdvt/logicaltests/staples	BUGS.B340	MIN	Recommended
-DATENAME	Aggregation	tdvt/logicaltests/staples	BUGS.B340	MIN	Recommended
-DATENAME	Calculation	tdvt/logicaltests/staples	BUGS.B340	MIN	Recommended
-DATENAME	Reference Line	tdvt/logicaltests/staples	BUGS.B530764	COUNT	Recommended
-MAX	Filters	tdvt/logicaltests/staples	BUGS.B530764	COUNT	Recommended
-MAX	Domain	tdvt/logicaltests/staples	BUGS.B530764	COUNT	Recommended
-MAX	Aggregation	tdvt/logicaltests/staples	BUGS.B530764	COUNT	Recommended
-MAX	Calculation	tdvt/logicaltests/staples	BUGS.B530764	COUNT	Recommended
-<=	Reference Line	tdvt/logicaltests/staples	BUGS.B530764	SUM	Recommended
-<=	Filters	tdvt/logicaltests/staples	BUGS.B530764	SUM	Recommended
-<=	Aggregation	tdvt/logicaltests/staples	BUGS.B530764	SUM	Recommended
->=	Calculation	tdvt/logicaltests/staples	BUGS.B530764	SUM	Recommended
->=	Operator	tdvt/logicaltests/staples	BUGS.B530764	/	Recommended
->=	Calculation	tdvt/logicaltests/staples	BUGS.B530764	/	Recommended
-		tdvt/logicaltests/calcs	BUGS.B59740	$IN_SET$	Required
-COUNT	Filters	tdvt/logicaltests/calcs	BUGS.B59740	==	Required
-COUNT	Operator	tdvt/logicaltests/calcs	BUGS.B59740	==	Required
-COUNT	Calculation	tdvt/logicaltests/calcs	BUGS.B59740	==	Required
-COUNT		tdvt/logicaltests/calcs	BUGS.B641638	$IN_SET$	Recommended
-COUNT	Reference Line	tdvt/logicaltests/calcs	BUGS.B641638	SUM	Recommended
-PI	Filters	tdvt/logicaltests/calcs	BUGS.B641638	SUM	Recommended
-PI	Aggregation	tdvt/logicaltests/calcs	BUGS.B641638	SUM	Recommended
-*	Calculation	tdvt/logicaltests/calcs	BUGS.B641638	SUM	Recommended
-*	Aggregation	tdvt/logicaltests/staples	BUGS.B8888	COUNTD	Recommended
-COUNT	Calculation	tdvt/logicaltests/staples	BUGS.B8888	+	Recommended
-COUNT	Calculation	tdvt/logicaltests/staples	BUGS.B8888	-	Recommended
-COUNT	Calculation	tdvt/logicaltests/staples	BUGS.B8888	/	Recommended
-COUNT	Calculation	tdvt/logicaltests/staples	BUGS.B8888	<	Recommended
-COUNT	Calculation	tdvt/logicaltests/staples	BUGS.B8888	COUNTD	Recommended
-DATEPART	Calculation	tdvt/logicaltests/staples	BUGS.B8888	DATEADD	Recommended
-DATEPART	Calculation	tdvt/logicaltests/staples	BUGS.B8888	DATEPART	Recommended
-DATEPART	Calculation	tdvt/logicaltests/staples	BUGS.B8888	DATETRUNC	Recommended
-MIN	Calculation	tdvt/logicaltests/staples	BUGS.B8888	INT	Recommended
-MIN	Cast	tdvt/logicaltests/staples	BUGS.B8888	INT	Recommended
-MIN	Data Prep	tdvt/logicaltests/staples	BUGS.B8888	INT	Recommended
-MIN	Date Aggregation	tdvt/logicaltests/staples	BUGS.B8888	DATEADD	Recommended
-==	Date Aggregation	tdvt/logicaltests/staples	BUGS.B8888	DATEPART	Recommended
-==	Date Aggregation	tdvt/logicaltests/staples	BUGS.B8888	DATETRUNC	Recommended
-==	Date Filters	tdvt/logicaltests/staples	BUGS.B8888	DATEADD	Recommended
-MAX	Date Filters	tdvt/logicaltests/staples	BUGS.B8888	DATEPART	Recommended
-MAX	Date Filters	tdvt/logicaltests/staples	BUGS.B8888	DATETRUNC	Recommended
-MAX	Domain	tdvt/logicaltests/staples	BUGS.B8888	COUNTD	Recommended
-MAX	Filters	tdvt/logicaltests/staples	BUGS.B8888	<	Recommended
-DATEPART	Filters	tdvt/logicaltests/staples	BUGS.B8888	COUNTD	Recommended
-DATEPART	Operator	tdvt/logicaltests/staples	BUGS.B8888	+	Recommended
-DATEPART	Operator	tdvt/logicaltests/staples	BUGS.B8888	-	Recommended
-TODAY	Operator	tdvt/logicaltests/staples	BUGS.B8888	/	Recommended
-TODAY	Operator	tdvt/logicaltests/staples	BUGS.B8888	<	Recommended
-TODAY	Reference Line	tdvt/logicaltests/staples	BUGS.B8888	COUNTD	Recommended
-TODAY	Filters	tdvt/logicaltests/calcs	BUGS.TFS660780	==	Required
-DATENAME	Operator	tdvt/logicaltests/calcs	BUGS.TFS660780	==	Required
-DATENAME	Calculation	tdvt/logicaltests/calcs	BUGS.TFS660780	==	Required
-DATENAME	Reference Line	tdvt/logicaltests/calcs	BUGS.TFS660780	COUNT	Required
-SUM	Filters	tdvt/logicaltests/calcs	BUGS.TFS660780	COUNT	Required
-SUM	Domain	tdvt/logicaltests/calcs	BUGS.TFS660780	COUNT	Required
-SUM	Aggregation	tdvt/logicaltests/calcs	BUGS.TFS660780	COUNT	Required
-SUM	Calculation	tdvt/logicaltests/calcs	BUGS.TFS660780	COUNT	Required
-TEMP_TABLES_AND_SUBQUERIES	Reference Line	tdvt/logicaltests/calcs	BUGS.TFS660780	SUM	Required
-TEMP_TABLES_AND_SUBQUERIES	Filters	tdvt/logicaltests/calcs	BUGS.TFS660780	SUM	Required
-<=	Aggregation	tdvt/logicaltests/calcs	BUGS.TFS660780	SUM	Required
-<=	Calculation	tdvt/logicaltests/calcs	BUGS.TFS660780	SUM	Required
-<=	Filters	tdvt/logicaltests/union	calcs.union	TEMP_TABLES_AND_SUBQUERIES	Required If Supported
->=	Temp Tables and Subqueries	tdvt/logicaltests/union	calcs.union	TEMP_TABLES_AND_SUBQUERIES	Required If Supported
->=	Union	tdvt/logicaltests/union	calcs.union	UNION	Required If Supported
->=	Filters	tdvt/exprtests/standard	calcs_data	MAX	Required If Supported
-	Domain	tdvt/exprtests/standard	calcs_data	MAX	Required If Supported
-MIN	Aggregation	tdvt/exprtests/standard	calcs_data	MAX	Required If Supported
-MIN	Calculation	tdvt/exprtests/standard	calcs_data	MAX	Required If Supported
-MIN	CAP_QUERY_TIME_REQUIRES_CAST	tdvt/exprtests/standard	calcs_data	TIME1899	Required If Supported
-MIN	Time Values	tdvt/exprtests/standard	calcs_data	TIME1899	Required If Supported
-DATE	Filters	tdvt/exprtests/standard	calcs_data	MIN	Required If Supported
-DATE	Domain	tdvt/exprtests/standard	calcs_data	MIN	Required If Supported
-COUNT	Aggregation	tdvt/exprtests/standard	calcs_data	MIN	Required If Supported
-COUNT	Calculation	tdvt/exprtests/standard	calcs_data	MIN	Required If Supported
-COUNT	Calculation	tdvt/exprtests/standard	cast.float	FLOAT	Required
-COUNT	Cast	tdvt/exprtests/standard	cast.float	FLOAT	Required
-COUNT	Data Prep	tdvt/exprtests/standard	cast.float	FLOAT	Required
-DATEPART	Data Prep	tdvt/exprtests/standard	cast.float.string	FLOAT	Required
-DATEPART	Cast	tdvt/exprtests/standard	cast.float.string	FLOAT	Required
-DATEPART	Calculation	tdvt/exprtests/standard	cast.float.string	FLOAT	Required
-DATETIME	Operator	tdvt/exprtests/standard	cast.float.string	+	Required
-DATETIME	Calculation	tdvt/exprtests/standard	cast.float.string	+	Required
-DATETIME	Calculation	tdvt/exprtests/standard	cast.float.string	RIGHT	Required
-DATE	Data Prep	tdvt/exprtests/standard	cast.float.string	FLOAT	Required
-DATE	Cast	tdvt/exprtests/standard	cast.float.string	FLOAT	Required
-COUNT	Calculation	tdvt/exprtests/standard	cast.float.string	FLOAT	Required
-COUNT	Data Prep	tdvt/exprtests/standard	cast.int	INT	Required
-COUNT	Cast	tdvt/exprtests/standard	cast.int	INT	Required
-COUNT	Calculation	tdvt/exprtests/standard	cast.int	INT	Required
-COUNT	Calculation	tdvt/exprtests/standard	cast.int.nulls	+	Required
-DATEADD	Calculation	tdvt/exprtests/standard	cast.int.nulls	INT	Required
-DATEADD	Calculation	tdvt/exprtests/standard	cast.int.nulls	INT	Required
-DATEADD	Calculation	tdvt/exprtests/standard	cast.int.nulls	STR	Required
-DATETIME	Calculation	tdvt/exprtests/standard	cast.int.nulls	STR	Required
-DATETIME	Cast	tdvt/exprtests/standard	cast.int.nulls	INT	Required
-DATETIME	Cast	tdvt/exprtests/standard	cast.int.nulls	INT	Required
-COUNT	Cast	tdvt/exprtests/standard	cast.int.nulls	STR	Required
-COUNT	Cast	tdvt/exprtests/standard	cast.int.nulls	STR	Required
-COUNT	Data Prep	tdvt/exprtests/standard	cast.int.nulls	INT	Required
-COUNT	Data Prep	tdvt/exprtests/standard	cast.int.nulls	INT	Required
-COUNT	Filters	tdvt/exprtests/standard	cast.int.nulls	STR	Required
-DATEPART	Filters	tdvt/exprtests/standard	cast.int.nulls	STR	Required
-DATEPART	Operator	tdvt/exprtests/standard	cast.int.nulls	+	Required
-DATEPART	Filters	tdvt/exprtests/standard	cast.str	STR	Required
-DATETIME	Cast	tdvt/exprtests/standard	cast.str	STR	Required
-DATETIME	Calculation	tdvt/exprtests/standard	cast.str	STR	Required
-DATETIME	Calculation	tdvt/exprtests/standard	cast.str.date	DATE	Required
-DATE	Calculation	tdvt/exprtests/standard	cast.str.date	STR	Required
-DATE	Cast	tdvt/exprtests/standard	cast.str.date	DATE	Required
-COUNT	Cast	tdvt/exprtests/standard	cast.str.date	STR	Required
-COUNT	Filters	tdvt/exprtests/standard	cast.str.date	STR	Required
-COUNT	Calculation	tdvt/exprtests/standard	cast.str.str	STR	Required
-COUNT	Cast	tdvt/exprtests/standard	cast.str.str	STR	Required
-COUNT	Filters	tdvt/exprtests/standard	cast.str.str	STR	Required
-DATENAME	Aggregation	tdvt/exprtests/standard	date.B639952	COUNT	Required
-DATENAME	Aggregation	tdvt/exprtests/standard	date.B639952	SUM	Required
-DATENAME	Calculation	tdvt/exprtests/standard	date.B639952	+	Required
-DATETIME	Calculation	tdvt/exprtests/standard	date.B639952	-	Required
-DATETIME	Calculation	tdvt/exprtests/standard	date.B639952	COUNT	Required
-DATETIME	Calculation	tdvt/exprtests/standard	date.B639952	DATE	Required
-DATENAME	Calculation	tdvt/exprtests/standard	date.B639952	DATE	Required
-DATENAME	Calculation	tdvt/exprtests/standard	date.B639952	DATEADD	Required
-DATENAME	Calculation	tdvt/exprtests/standard	date.B639952	DATEADD	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.B639952	SUM	Required
-COUNT	Cast	tdvt/exprtests/standard	date.B639952	DATE	Required
-COUNT	Cast	tdvt/exprtests/standard	date.B639952	DATE	Required
-COUNT	Date Aggregation	tdvt/exprtests/standard	date.B639952	DATEADD	Required
-COUNT	Date Aggregation	tdvt/exprtests/standard	date.B639952	DATEADD	Required
-MIN	Date Filters	tdvt/exprtests/standard	date.B639952	DATEADD	Required
-MIN	Date Filters	tdvt/exprtests/standard	date.B639952	DATEADD	Required
-MIN	Domain	tdvt/exprtests/standard	date.B639952	COUNT	Required
-MIN	Filters	tdvt/exprtests/standard	date.B639952	COUNT	Required
-DATEPART	Filters	tdvt/exprtests/standard	date.B639952	SUM	Required
-DATEPART	Operator	tdvt/exprtests/standard	date.B639952	+	Required
-DATEPART	Operator	tdvt/exprtests/standard	date.B639952	-	Required
-TRIM	Reference Line	tdvt/exprtests/standard	date.B639952	COUNT	Required
-TRIM	Reference Line	tdvt/exprtests/standard	date.B639952	SUM	Required
-+	Cast	tdvt/exprtests/standard	date.cast.date	DATE	Required
-+	Calculation	tdvt/exprtests/standard	date.cast.date	DATE	Required
-DATETRUNC	Calculation	tdvt/exprtests/standard	date.cast.datetime	DATETIME	Required
-DATETRUNC	Date Aggregation	tdvt/exprtests/standard	date.cast.datetime	DATETIME	Required
-DATETRUNC	Date Filters	tdvt/exprtests/standard	date.cast.datetime	DATETIME	Required
-COUNT	Aggregation	tdvt/exprtests/standard	date.cast.datetime.630831	COUNT	Smoke
-COUNT	Calculation	tdvt/exprtests/standard	date.cast.datetime.630831	COUNT	Smoke
-COUNT	Calculation	tdvt/exprtests/standard	date.cast.datetime.630831	DATE	Smoke
-COUNT	Calculation	tdvt/exprtests/standard	date.cast.datetime.630831	DATE	Smoke
-COUNT	Cast	tdvt/exprtests/standard	date.cast.datetime.630831	DATE	Smoke
-UPPER	Cast	tdvt/exprtests/standard	date.cast.datetime.630831	DATE	Smoke
-UPPER	Domain	tdvt/exprtests/standard	date.cast.datetime.630831	COUNT	Smoke
-DATEPART	Filters	tdvt/exprtests/standard	date.cast.datetime.630831	COUNT	Smoke
-DATEPART	Reference Line	tdvt/exprtests/standard	date.cast.datetime.630831	COUNT	Smoke
-DATEPART	Data Prep	tdvt/exprtests/standard	date.cast.float	FLOAT	Recommended
-	Cast	tdvt/exprtests/standard	date.cast.float	FLOAT	Recommended
-SUM	Calculation	tdvt/exprtests/standard	date.cast.float	FLOAT	Recommended
-SUM	Aggregation	tdvt/exprtests/standard	date.cast.float.extended	COUNT	Recommended
-SUM	Calculation	tdvt/exprtests/standard	date.cast.float.extended	COUNT	Recommended
-SUM	Calculation	tdvt/exprtests/standard	date.cast.float.extended	FLOAT	Recommended
-	Calculation	tdvt/exprtests/standard	date.cast.float.extended	FLOAT	Recommended
-SUM	Cast	tdvt/exprtests/standard	date.cast.float.extended	FLOAT	Recommended
-SUM	Cast	tdvt/exprtests/standard	date.cast.float.extended	FLOAT	Recommended
-SUM	Data Prep	tdvt/exprtests/standard	date.cast.float.extended	FLOAT	Recommended
-SUM	Data Prep	tdvt/exprtests/standard	date.cast.float.extended	FLOAT	Recommended
-<=	Domain	tdvt/exprtests/standard	date.cast.float.extended	COUNT	Recommended
-<=	Filters	tdvt/exprtests/standard	date.cast.float.extended	COUNT	Recommended
-<=	Reference Line	tdvt/exprtests/standard	date.cast.float.extended	COUNT	Recommended
->=	Aggregation	tdvt/exprtests/standard	date.cast.int.extended	COUNT	Recommended
->=	Calculation	tdvt/exprtests/standard	date.cast.int.extended	COUNT	Recommended
->=	Calculation	tdvt/exprtests/standard	date.cast.int.extended	INT	Recommended
-	Calculation	tdvt/exprtests/standard	date.cast.int.extended	INT	Recommended
-LEFT	Cast	tdvt/exprtests/standard	date.cast.int.extended	INT	Recommended
-LEFT	Cast	tdvt/exprtests/standard	date.cast.int.extended	INT	Recommended
-CHAR	Data Prep	tdvt/exprtests/standard	date.cast.int.extended	INT	Recommended
-	Data Prep	tdvt/exprtests/standard	date.cast.int.extended	INT	Recommended
-COUNT	Domain	tdvt/exprtests/standard	date.cast.int.extended	COUNT	Recommended
-COUNT	Filters	tdvt/exprtests/standard	date.cast.int.extended	COUNT	Recommended
-COUNT	Reference Line	tdvt/exprtests/standard	date.cast.int.extended	COUNT	Recommended
-COUNT	Calculation	tdvt/exprtests/standard	date.cast.num_to_date	DATE	Recommended
-COUNT	Cast	tdvt/exprtests/standard	date.cast.num_to_date	DATE	Recommended
-SIGN	Calculation	tdvt/exprtests/standard	date.cast.str	STR	Required
-SIGN	Calculation	tdvt/exprtests/standard	date.cast.str	TRIM	Required
-SUM	Cast	tdvt/exprtests/standard	date.cast.str	STR	Required
-SUM	Data Prep	tdvt/exprtests/standard	date.cast.str	TRIM	Required
-SUM	Filters	tdvt/exprtests/standard	date.cast.str	STR	Required
-SUM	Calculation	tdvt/exprtests/standard	date.dateadd.day	DATEADD	Required
-	Date Aggregation	tdvt/exprtests/standard	date.dateadd.day	DATEADD	Required
-LOD_STYLE_JOIN	Date Filters	tdvt/exprtests/standard	date.dateadd.day	DATEADD	Required
-DATE	Calculation	tdvt/exprtests/standard	date.dateadd.dayofyear	DATEADD	Required
-DATE	Date Aggregation	tdvt/exprtests/standard	date.dateadd.dayofyear	DATEADD	Required
-COUNT	Date Filters	tdvt/exprtests/standard	date.dateadd.dayofyear	DATEADD	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.dateadd.hour	DATEADD	Required
-COUNT	Date Aggregation	tdvt/exprtests/standard	date.dateadd.hour	DATEADD	Required
-COUNT	Date Filters	tdvt/exprtests/standard	date.dateadd.hour	DATEADD	Required
-COUNT	Aggregation	tdvt/exprtests/iso8601week	date.dateadd.iso-week	COUNT	Recommended
-DATETIME	Calculation	tdvt/exprtests/iso8601week	date.dateadd.iso-week	COUNT	Recommended
-DATETIME	Calculation	tdvt/exprtests/iso8601week	date.dateadd.iso-week	DATEADD	Recommended
-DATETIME	Date Aggregation	tdvt/exprtests/iso8601week	date.dateadd.iso-week	DATEADD	Recommended
-DATETRUNC	Date Filters	tdvt/exprtests/iso8601week	date.dateadd.iso-week	DATEADD	Recommended
-DATETRUNC	Domain	tdvt/exprtests/iso8601week	date.dateadd.iso-week	COUNT	Recommended
-DATETRUNC	Filters	tdvt/exprtests/iso8601week	date.dateadd.iso-week	COUNT	Recommended
-COUNT	Reference Line	tdvt/exprtests/iso8601week	date.dateadd.iso-week	COUNT	Recommended
-COUNT	Aggregation	tdvt/exprtests/iso8601week	date.dateadd.iso-weekday	COUNT	Recommended
-COUNT	Calculation	tdvt/exprtests/iso8601week	date.dateadd.iso-weekday	COUNT	Recommended
-COUNT	Calculation	tdvt/exprtests/iso8601week	date.dateadd.iso-weekday	DATEADD	Recommended
-COUNT	Date Aggregation	tdvt/exprtests/iso8601week	date.dateadd.iso-weekday	DATEADD	Recommended
-SUM	Date Filters	tdvt/exprtests/iso8601week	date.dateadd.iso-weekday	DATEADD	Recommended
-SUM	Domain	tdvt/exprtests/iso8601week	date.dateadd.iso-weekday	COUNT	Recommended
-SUM	Filters	tdvt/exprtests/iso8601week	date.dateadd.iso-weekday	COUNT	Recommended
-SUM	Reference Line	tdvt/exprtests/iso8601week	date.dateadd.iso-weekday	COUNT	Recommended
-/	Calculation	tdvt/exprtests/standard	date.dateadd.minute	DATEADD	Required
-/	Date Aggregation	tdvt/exprtests/standard	date.dateadd.minute	DATEADD	Required
-SUM	Date Filters	tdvt/exprtests/standard	date.dateadd.minute	DATEADD	Required
-SUM	Calculation	tdvt/exprtests/standard	date.dateadd.month	DATEADD	Required
-SUM	Date Aggregation	tdvt/exprtests/standard	date.dateadd.month	DATEADD	Required
-SUM	Date Filters	tdvt/exprtests/standard	date.dateadd.month	DATEADD	Required
-LOD_STYLE_JOIN	Cast	tdvt/exprtests/standard	date.dateadd.nulls	DATE	Required If Supported
-FLOAT	Calculation	tdvt/exprtests/standard	date.dateadd.nulls	DATE	Required If Supported
-FLOAT	Reference Line	tdvt/exprtests/standard	date.dateadd.nulls	COUNT	Required If Supported
-FLOAT	Filters	tdvt/exprtests/standard	date.dateadd.nulls	COUNT	Required If Supported
-DATETRUNC	Domain	tdvt/exprtests/standard	date.dateadd.nulls	COUNT	Required If Supported
-DATETRUNC	Aggregation	tdvt/exprtests/standard	date.dateadd.nulls	COUNT	Required If Supported
-DATETRUNC	Calculation	tdvt/exprtests/standard	date.dateadd.nulls	COUNT	Required If Supported
-COUNT	Date Aggregation	tdvt/exprtests/standard	date.dateadd.nulls	DATEADD	Required If Supported
-COUNT	Date Filters	tdvt/exprtests/standard	date.dateadd.nulls	DATEADD	Required If Supported
-COUNT	Calculation	tdvt/exprtests/standard	date.dateadd.nulls	DATEADD	Required If Supported
-COUNT	Date Aggregation	tdvt/exprtests/standard	date.dateadd.nulls	DATETIME	Required If Supported
-COUNT	Date Filters	tdvt/exprtests/standard	date.dateadd.nulls	DATETIME	Required If Supported
-DATEPART	Calculation	tdvt/exprtests/standard	date.dateadd.nulls	DATETIME	Required If Supported
-DATEPART	Calculation	tdvt/exprtests/standard	date.dateadd.quarter	DATEADD	Required
-DATEPART	Date Aggregation	tdvt/exprtests/standard	date.dateadd.quarter	DATEADD	Required
-MIN	Date Filters	tdvt/exprtests/standard	date.dateadd.quarter	DATEADD	Required
-MIN	Calculation	tdvt/exprtests/standard	date.dateadd.second	DATEADD	Required
-MIN	Date Aggregation	tdvt/exprtests/standard	date.dateadd.second	DATEADD	Required
-MIN	Date Filters	tdvt/exprtests/standard	date.dateadd.second	DATEADD	Required
-==	Calculation	tdvt/exprtests/standard	date.dateadd.week	DATEADD	Required
-==	Date Aggregation	tdvt/exprtests/standard	date.dateadd.week	DATEADD	Required
-==	Date Filters	tdvt/exprtests/standard	date.dateadd.week	DATEADD	Required
-MAX	Calculation	tdvt/exprtests/standard	date.dateadd.weekday	DATEADD	Required
-MAX	Date Aggregation	tdvt/exprtests/standard	date.dateadd.weekday	DATEADD	Required
-MAX	Date Filters	tdvt/exprtests/standard	date.dateadd.weekday	DATEADD	Required
-MAX	Date Aggregation	tdvt/exprtests/standard	date.dateadd.year	DATEADD	Required
-DATEPART	Date Filters	tdvt/exprtests/standard	date.dateadd.year	DATEADD	Required
-DATEPART	Calculation	tdvt/exprtests/standard	date.dateadd.year	DATEADD	Required
-DATEPART	Calculation	tdvt/exprtests/standard	date.datediff.day	DATEDIFF	Required
-NOW	Calculation	tdvt/exprtests/standard	date.datediff.day	DATETIME	Required
-NOW	Date Aggregation	tdvt/exprtests/standard	date.datediff.day	DATEDIFF	Required
-NOW	Date Aggregation	tdvt/exprtests/standard	date.datediff.day	DATETIME	Required
-NOW	Date Filters	tdvt/exprtests/standard	date.datediff.day	DATEDIFF	Required
-FLOAT	Date Filters	tdvt/exprtests/standard	date.datediff.day	DATETIME	Required
-FLOAT	Calculation	tdvt/exprtests/standard	date.datediff.dayofyear	DATEDIFF	Required
-FLOAT	Calculation	tdvt/exprtests/standard	date.datediff.dayofyear	DATETIME	Required
-+	Date Aggregation	tdvt/exprtests/standard	date.datediff.dayofyear	DATEDIFF	Required
-+	Date Aggregation	tdvt/exprtests/standard	date.datediff.dayofyear	DATETIME	Required
-RIGHT	Date Filters	tdvt/exprtests/standard	date.datediff.dayofyear	DATEDIFF	Required
-FLOAT	Date Filters	tdvt/exprtests/standard	date.datediff.dayofyear	DATETIME	Required
-FLOAT	Calculation	tdvt/exprtests/standard	date.datediff.hour	DATEDIFF	Required
-FLOAT	Calculation	tdvt/exprtests/standard	date.datediff.hour	DATETIME	Required
-SPACE	Date Aggregation	tdvt/exprtests/standard	date.datediff.hour	DATEDIFF	Required
-DATEDIFF	Date Aggregation	tdvt/exprtests/standard	date.datediff.hour	DATETIME	Required
-DATEDIFF	Date Filters	tdvt/exprtests/standard	date.datediff.hour	DATEDIFF	Required
-DATEDIFF	Date Filters	tdvt/exprtests/standard	date.datediff.hour	DATETIME	Required
-	Aggregation	tdvt/exprtests/iso8601week	date.datediff.iso-week	COUNT	Recommended
-DATEPART	Calculation	tdvt/exprtests/iso8601week	date.datediff.iso-week	COUNT	Recommended
-DATEPART	Calculation	tdvt/exprtests/iso8601week	date.datediff.iso-week	DATEDIFF	Recommended
-DATEPART	Date Aggregation	tdvt/exprtests/iso8601week	date.datediff.iso-week	DATEDIFF	Recommended
-	Date Filters	tdvt/exprtests/iso8601week	date.datediff.iso-week	DATEDIFF	Recommended
-	Domain	tdvt/exprtests/iso8601week	date.datediff.iso-week	COUNT	Recommended
->=	Filters	tdvt/exprtests/iso8601week	date.datediff.iso-week	COUNT	Recommended
->=	Reference Line	tdvt/exprtests/iso8601week	date.datediff.iso-week	COUNT	Recommended
->=	Reference Line	tdvt/exprtests/iso8601week	date.datediff.iso-weekday	COUNT	Recommended
-	Filters	tdvt/exprtests/iso8601week	date.datediff.iso-weekday	COUNT	Recommended
-SUM	Domain	tdvt/exprtests/iso8601week	date.datediff.iso-weekday	COUNT	Recommended
-SUM	Aggregation	tdvt/exprtests/iso8601week	date.datediff.iso-weekday	COUNT	Recommended
-SUM	Calculation	tdvt/exprtests/iso8601week	date.datediff.iso-weekday	COUNT	Recommended
-SUM	Date Aggregation	tdvt/exprtests/iso8601week	date.datediff.iso-weekday	DATEDIFF	Recommended
-<=	Date Filters	tdvt/exprtests/iso8601week	date.datediff.iso-weekday	DATEDIFF	Recommended
-<=	Calculation	tdvt/exprtests/iso8601week	date.datediff.iso-weekday	DATEDIFF	Recommended
-<=	Calculation	tdvt/exprtests/standard	date.datediff.minute	DATEDIFF	Required
-SUM	Calculation	tdvt/exprtests/standard	date.datediff.minute	DATETIME	Required
-SUM	Date Aggregation	tdvt/exprtests/standard	date.datediff.minute	DATEDIFF	Required
-SUM	Date Aggregation	tdvt/exprtests/standard	date.datediff.minute	DATETIME	Required
-SUM	Date Filters	tdvt/exprtests/standard	date.datediff.minute	DATEDIFF	Required
-TEMP_TABLES_AND_SUBQUERIES	Date Filters	tdvt/exprtests/standard	date.datediff.minute	DATETIME	Required
-TEMP_TABLES_AND_SUBQUERIES	Date Aggregation	tdvt/exprtests/standard	date.datediff.month	DATEDIFF	Required
-DATETRUNC	Date Filters	tdvt/exprtests/standard	date.datediff.month	DATEDIFF	Required
-DATETRUNC	Calculation	tdvt/exprtests/standard	date.datediff.month	DATEDIFF	Required
-DATETRUNC	Date Aggregation	tdvt/exprtests/standard	date.datediff.month	DATETIME	Required
-POWER	Date Filters	tdvt/exprtests/standard	date.datediff.month	DATETIME	Required
-POWER	Calculation	tdvt/exprtests/standard	date.datediff.month	DATETIME	Required
-DEGREES	Aggregation	tdvt/exprtests/standard	date.datediff.nulls	COUNT	Required If Supported
-DEGREES	Calculation	tdvt/exprtests/standard	date.datediff.nulls	COUNT	Required If Supported
-DATEPART	Calculation	tdvt/exprtests/standard	date.datediff.nulls	DATE	Required If Supported
-DATEPART	Calculation	tdvt/exprtests/standard	date.datediff.nulls	DATEDIFF	Required If Supported
-DATEPART	Calculation	tdvt/exprtests/standard	date.datediff.nulls	DATETIME	Required If Supported
-DATE	Cast	tdvt/exprtests/standard	date.datediff.nulls	DATE	Required If Supported
-DATE	Date Aggregation	tdvt/exprtests/standard	date.datediff.nulls	DATEDIFF	Required If Supported
--	Date Aggregation	tdvt/exprtests/standard	date.datediff.nulls	DATETIME	Required If Supported
--	Date Filters	tdvt/exprtests/standard	date.datediff.nulls	DATEDIFF	Required If Supported
-SIN	Date Filters	tdvt/exprtests/standard	date.datediff.nulls	DATETIME	Required If Supported
-SIN	Domain	tdvt/exprtests/standard	date.datediff.nulls	COUNT	Required If Supported
-COUNT	Filters	tdvt/exprtests/standard	date.datediff.nulls	COUNT	Required If Supported
-COUNT	Reference Line	tdvt/exprtests/standard	date.datediff.nulls	COUNT	Required If Supported
-COUNT	Date Aggregation	tdvt/exprtests/standard	date.datediff.quarter	DATEDIFF	Required
-COUNT	Date Filters	tdvt/exprtests/standard	date.datediff.quarter	DATEDIFF	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.datediff.quarter	DATEDIFF	Required
-DATENAME	Date Aggregation	tdvt/exprtests/standard	date.datediff.quarter	DATETIME	Required
-DATENAME	Date Filters	tdvt/exprtests/standard	date.datediff.quarter	DATETIME	Required
-DATENAME	Calculation	tdvt/exprtests/standard	date.datediff.quarter	DATETIME	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.datediff.second	DATEDIFF	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.datediff.second	DATETIME	Required
-COUNT	Date Aggregation	tdvt/exprtests/standard	date.datediff.second	DATEDIFF	Required
-COUNT	Date Aggregation	tdvt/exprtests/standard	date.datediff.second	DATETIME	Required
-COUNT	Date Filters	tdvt/exprtests/standard	date.datediff.second	DATEDIFF	Required
-LOD_STYLE_JOIN	Date Filters	tdvt/exprtests/standard	date.datediff.second	DATETIME	Required
-DATEDIFF	Date Aggregation	tdvt/exprtests/standard	date.datediff.sow.day	DATEDIFF	Required
-DATEDIFF	Date Filters	tdvt/exprtests/standard	date.datediff.sow.day	DATEDIFF	Required
-DATEDIFF	Calculation	tdvt/exprtests/standard	date.datediff.sow.day	DATEDIFF	Required
-SUM	Date Aggregation	tdvt/exprtests/standard	date.datediff.sow.day	DATETIME	Required
-SUM	Date Filters	tdvt/exprtests/standard	date.datediff.sow.day	DATETIME	Required
-SUM	Calculation	tdvt/exprtests/standard	date.datediff.sow.day	DATETIME	Required
-SUM	Calculation	tdvt/exprtests/standard	date.datediff.sow.dayofyear	DATEDIFF	Required
-MIN	Calculation	tdvt/exprtests/standard	date.datediff.sow.dayofyear	DATETIME	Required
-MIN	Date Aggregation	tdvt/exprtests/standard	date.datediff.sow.dayofyear	DATEDIFF	Required
-MIN	Date Aggregation	tdvt/exprtests/standard	date.datediff.sow.dayofyear	DATETIME	Required
-MIN	Date Filters	tdvt/exprtests/standard	date.datediff.sow.dayofyear	DATEDIFF	Required
-COUNT	Date Filters	tdvt/exprtests/standard	date.datediff.sow.dayofyear	DATETIME	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.datediff.sow.hour	DATEDIFF	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.datediff.sow.hour	DATETIME	Required
-COUNT	Date Aggregation	tdvt/exprtests/standard	date.datediff.sow.hour	DATEDIFF	Required
-COUNT	Date Aggregation	tdvt/exprtests/standard	date.datediff.sow.hour	DATETIME	Required
-MIN	Date Filters	tdvt/exprtests/standard	date.datediff.sow.hour	DATEDIFF	Required
-MIN	Date Filters	tdvt/exprtests/standard	date.datediff.sow.hour	DATETIME	Required
-MIN	Calculation	tdvt/exprtests/standard	date.datediff.sow.minute	DATEDIFF	Required
-MIN	Calculation	tdvt/exprtests/standard	date.datediff.sow.minute	DATETIME	Required
-COUNT	Date Aggregation	tdvt/exprtests/standard	date.datediff.sow.minute	DATEDIFF	Required
-COUNT	Date Aggregation	tdvt/exprtests/standard	date.datediff.sow.minute	DATETIME	Required
-COUNT	Date Filters	tdvt/exprtests/standard	date.datediff.sow.minute	DATEDIFF	Required
-COUNT	Date Filters	tdvt/exprtests/standard	date.datediff.sow.minute	DATETIME	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.datediff.sow.month	DATEDIFF	Required
-MAX	Calculation	tdvt/exprtests/standard	date.datediff.sow.month	DATETIME	Required
-MAX	Date Aggregation	tdvt/exprtests/standard	date.datediff.sow.month	DATEDIFF	Required
-MAX	Date Aggregation	tdvt/exprtests/standard	date.datediff.sow.month	DATETIME	Required
-MAX	Date Filters	tdvt/exprtests/standard	date.datediff.sow.month	DATEDIFF	Required
-SUM	Date Filters	tdvt/exprtests/standard	date.datediff.sow.month	DATETIME	Required
-SUM	Aggregation	tdvt/exprtests/standard	date.datediff.sow.nulls	COUNT	Recommended
-SUM	Calculation	tdvt/exprtests/standard	date.datediff.sow.nulls	COUNT	Recommended
-SUM	Calculation	tdvt/exprtests/standard	date.datediff.sow.nulls	DATE	Recommended
-<=	Calculation	tdvt/exprtests/standard	date.datediff.sow.nulls	DATEDIFF	Recommended
-<=	Calculation	tdvt/exprtests/standard	date.datediff.sow.nulls	DATETIME	Recommended
-<=	Cast	tdvt/exprtests/standard	date.datediff.sow.nulls	DATE	Recommended
-	Date Aggregation	tdvt/exprtests/standard	date.datediff.sow.nulls	DATEDIFF	Recommended
-	Date Aggregation	tdvt/exprtests/standard	date.datediff.sow.nulls	DATETIME	Recommended
->=	Date Filters	tdvt/exprtests/standard	date.datediff.sow.nulls	DATEDIFF	Recommended
->=	Date Filters	tdvt/exprtests/standard	date.datediff.sow.nulls	DATETIME	Recommended
->=	Domain	tdvt/exprtests/standard	date.datediff.sow.nulls	COUNT	Recommended
-DATEDIFF	Filters	tdvt/exprtests/standard	date.datediff.sow.nulls	COUNT	Recommended
-DATEDIFF	Reference Line	tdvt/exprtests/standard	date.datediff.sow.nulls	COUNT	Recommended
-DATEDIFF	Date Aggregation	tdvt/exprtests/standard	date.datediff.sow.quarter	DATEDIFF	Required
-DATETIME	Date Filters	tdvt/exprtests/standard	date.datediff.sow.quarter	DATEDIFF	Required
-DATETIME	Calculation	tdvt/exprtests/standard	date.datediff.sow.quarter	DATEDIFF	Required
-DATETIME	Date Aggregation	tdvt/exprtests/standard	date.datediff.sow.quarter	DATETIME	Required
-	Date Filters	tdvt/exprtests/standard	date.datediff.sow.quarter	DATETIME	Required
-==	Calculation	tdvt/exprtests/standard	date.datediff.sow.quarter	DATETIME	Required
-==	Date Aggregation	tdvt/exprtests/standard	date.datediff.sow.second	DATEDIFF	Required
-==	Date Filters	tdvt/exprtests/standard	date.datediff.sow.second	DATEDIFF	Required
-==	Calculation	tdvt/exprtests/standard	date.datediff.sow.second	DATEDIFF	Required
-==	Date Aggregation	tdvt/exprtests/standard	date.datediff.sow.second	DATETIME	Required
-==	Date Filters	tdvt/exprtests/standard	date.datediff.sow.second	DATETIME	Required
-!	Calculation	tdvt/exprtests/standard	date.datediff.sow.second	DATETIME	Required
-!	Date Aggregation	tdvt/exprtests/standard	date.datediff.sow.week	DATEDIFF	Required
-!	Date Filters	tdvt/exprtests/standard	date.datediff.sow.week	DATEDIFF	Required
-SUM	Calculation	tdvt/exprtests/standard	date.datediff.sow.week	DATEDIFF	Required
-SUM	Date Aggregation	tdvt/exprtests/standard	date.datediff.sow.week	DATETIME	Required
-SUM	Date Filters	tdvt/exprtests/standard	date.datediff.sow.week	DATETIME	Required
-SUM	Calculation	tdvt/exprtests/standard	date.datediff.sow.week	DATETIME	Required
-	Date Aggregation	tdvt/exprtests/standard	date.datediff.sow.weekday	DATEDIFF	Required
-SUM	Date Filters	tdvt/exprtests/standard	date.datediff.sow.weekday	DATEDIFF	Required
-SUM	Calculation	tdvt/exprtests/standard	date.datediff.sow.weekday	DATEDIFF	Required
-SUM	Date Aggregation	tdvt/exprtests/standard	date.datediff.sow.weekday	DATETIME	Required
-SUM	Date Filters	tdvt/exprtests/standard	date.datediff.sow.weekday	DATETIME	Required
-AVG	Calculation	tdvt/exprtests/standard	date.datediff.sow.weekday	DATETIME	Required
-AVG	Date Aggregation	tdvt/exprtests/standard	date.datediff.sow.year	DATEDIFF	Required
-AVG	Date Filters	tdvt/exprtests/standard	date.datediff.sow.year	DATEDIFF	Required
-AVG	Calculation	tdvt/exprtests/standard	date.datediff.sow.year	DATEDIFF	Required
-<=	Date Aggregation	tdvt/exprtests/standard	date.datediff.sow.year	DATETIME	Required
-<=	Date Filters	tdvt/exprtests/standard	date.datediff.sow.year	DATETIME	Required
-<=	Calculation	tdvt/exprtests/standard	date.datediff.sow.year	DATETIME	Required
->=	Date Aggregation	tdvt/exprtests/standard	date.datediff.week	DATEDIFF	Required
->=	Date Filters	tdvt/exprtests/standard	date.datediff.week	DATEDIFF	Required
->=	Calculation	tdvt/exprtests/standard	date.datediff.week	DATEDIFF	Required
-	Date Aggregation	tdvt/exprtests/standard	date.datediff.week	DATETIME	Required
-	Date Filters	tdvt/exprtests/standard	date.datediff.week	DATETIME	Required
-ISNULL	Calculation	tdvt/exprtests/standard	date.datediff.week	DATETIME	Required
-ISNULL	Calculation	tdvt/exprtests/standard	date.datediff.week.extended	DATEDIFF	Required
-SUM	Date Aggregation	tdvt/exprtests/standard	date.datediff.week.extended	DATEDIFF	Required
-SUM	Date Filters	tdvt/exprtests/standard	date.datediff.week.extended	DATEDIFF	Required
-SUM	Date Aggregation	tdvt/exprtests/standard	date.datediff.weekday	DATEDIFF	Required
-SUM	Date Filters	tdvt/exprtests/standard	date.datediff.weekday	DATEDIFF	Required
-	Calculation	tdvt/exprtests/standard	date.datediff.weekday	DATEDIFF	Required
-SUM	Date Aggregation	tdvt/exprtests/standard	date.datediff.weekday	DATETIME	Required
-SUM	Date Filters	tdvt/exprtests/standard	date.datediff.weekday	DATETIME	Required
-SUM	Calculation	tdvt/exprtests/standard	date.datediff.weekday	DATETIME	Required
-SUM	Calculation	tdvt/exprtests/standard	date.datediff.year	DATEDIFF	Required
-AVG	Calculation	tdvt/exprtests/standard	date.datediff.year	DATETIME	Required
-AVG	Date Aggregation	tdvt/exprtests/standard	date.datediff.year	DATEDIFF	Required
-AVG	Date Aggregation	tdvt/exprtests/standard	date.datediff.year	DATETIME	Required
-AVG	Date Filters	tdvt/exprtests/standard	date.datediff.year	DATEDIFF	Required
-<=	Date Filters	tdvt/exprtests/standard	date.datediff.year	DATETIME	Required
-<=	Calculation	tdvt/exprtests/standard	date.datename.day	DATENAME	Required
-<=	Date Aggregation	tdvt/exprtests/standard	date.datename.day	DATENAME	Required
->=	Date Filters	tdvt/exprtests/standard	date.datename.day	DATENAME	Required
->=	Calculation	tdvt/exprtests/standard	date.datename.dayofyear	DATENAME	Required
->=	Date Aggregation	tdvt/exprtests/standard	date.datename.dayofyear	DATENAME	Required
-	Date Filters	tdvt/exprtests/standard	date.datename.dayofyear	DATENAME	Required
-DATEDIFF	Calculation	tdvt/exprtests/standard	date.datename.hour	DATENAME	Required
-DATEDIFF	Date Aggregation	tdvt/exprtests/standard	date.datename.hour	DATENAME	Required
-DATEDIFF	Date Filters	tdvt/exprtests/standard	date.datename.hour	DATENAME	Required
-DATETIME	Aggregation	tdvt/exprtests/iso8601week	date.datename.iso-quarter	COUNT	Recommended
-DATETIME	Calculation	tdvt/exprtests/iso8601week	date.datename.iso-quarter	COUNT	Recommended
-DATETIME	Calculation	tdvt/exprtests/iso8601week	date.datename.iso-quarter	DATENAME	Recommended
-	Date Aggregation	tdvt/exprtests/iso8601week	date.datename.iso-quarter	DATENAME	Recommended
-DATEPART	Date Filters	tdvt/exprtests/iso8601week	date.datename.iso-quarter	DATENAME	Recommended
-DATEPART	Domain	tdvt/exprtests/iso8601week	date.datename.iso-quarter	COUNT	Recommended
-DATEPART	Filters	tdvt/exprtests/iso8601week	date.datename.iso-quarter	COUNT	Recommended
->=	Reference Line	tdvt/exprtests/iso8601week	date.datename.iso-quarter	COUNT	Recommended
->=	Aggregation	tdvt/exprtests/iso8601week	date.datename.iso-week	COUNT	Recommended
->=	Calculation	tdvt/exprtests/iso8601week	date.datename.iso-week	COUNT	Recommended
-	Calculation	tdvt/exprtests/iso8601week	date.datename.iso-week	DATENAME	Recommended
-==	Date Aggregation	tdvt/exprtests/iso8601week	date.datename.iso-week	DATENAME	Recommended
-==	Date Filters	tdvt/exprtests/iso8601week	date.datename.iso-week	DATENAME	Recommended
-==	Domain	tdvt/exprtests/iso8601week	date.datename.iso-week	COUNT	Recommended
-SUM	Filters	tdvt/exprtests/iso8601week	date.datename.iso-week	COUNT	Recommended
-SUM	Reference Line	tdvt/exprtests/iso8601week	date.datename.iso-week	COUNT	Recommended
-SUM	Reference Line	tdvt/exprtests/iso8601week	date.datename.iso-weekday	COUNT	Recommended
-SUM	Filters	tdvt/exprtests/iso8601week	date.datename.iso-weekday	COUNT	Recommended
-<=	Domain	tdvt/exprtests/iso8601week	date.datename.iso-weekday	COUNT	Recommended
-<=	Aggregation	tdvt/exprtests/iso8601week	date.datename.iso-weekday	COUNT	Recommended
-<=	Calculation	tdvt/exprtests/iso8601week	date.datename.iso-weekday	COUNT	Recommended
-	Date Aggregation	tdvt/exprtests/iso8601week	date.datename.iso-weekday	DATENAME	Recommended
-AVG	Date Filters	tdvt/exprtests/iso8601week	date.datename.iso-weekday	DATENAME	Recommended
-AVG	Calculation	tdvt/exprtests/iso8601week	date.datename.iso-weekday	DATENAME	Recommended
-AVG	Aggregation	tdvt/exprtests/iso8601week	date.datename.iso-year	COUNT	Recommended
-AVG	Calculation	tdvt/exprtests/iso8601week	date.datename.iso-year	COUNT	Recommended
-LOD_STYLE_JOIN	Calculation	tdvt/exprtests/iso8601week	date.datename.iso-year	DATENAME	Recommended
-AVG	Date Aggregation	tdvt/exprtests/iso8601week	date.datename.iso-year	DATENAME	Recommended
-AVG	Date Filters	tdvt/exprtests/iso8601week	date.datename.iso-year	DATENAME	Recommended
-AVG	Domain	tdvt/exprtests/iso8601week	date.datename.iso-year	COUNT	Recommended
-AVG	Filters	tdvt/exprtests/iso8601week	date.datename.iso-year	COUNT	Recommended
-+	Reference Line	tdvt/exprtests/iso8601week	date.datename.iso-year	COUNT	Recommended
-+	Calculation	tdvt/exprtests/standard	date.datename.minute	DATENAME	Required
-/	Date Aggregation	tdvt/exprtests/standard	date.datename.minute	DATENAME	Required
-/	Date Filters	tdvt/exprtests/standard	date.datename.minute	DATENAME	Required
-FLOAT	Date Aggregation	tdvt/exprtests/standard	date.datename.month	DATENAME	Required
-FLOAT	Date Filters	tdvt/exprtests/standard	date.datename.month	DATENAME	Required
-FLOAT	Calculation	tdvt/exprtests/standard	date.datename.month	DATENAME	Required
-COUNT	Cast	tdvt/exprtests/standard	date.datename.nulls	DATE	Required If Supported
-COUNT	Calculation	tdvt/exprtests/standard	date.datename.nulls	DATE	Required If Supported
-COUNT	Reference Line	tdvt/exprtests/standard	date.datename.nulls	COUNT	Required If Supported
-COUNT	Filters	tdvt/exprtests/standard	date.datename.nulls	COUNT	Required If Supported
-COUNT	Domain	tdvt/exprtests/standard	date.datename.nulls	COUNT	Required If Supported
-MIN	Aggregation	tdvt/exprtests/standard	date.datename.nulls	COUNT	Required If Supported
-MIN	Calculation	tdvt/exprtests/standard	date.datename.nulls	COUNT	Required If Supported
-MIN	Date Aggregation	tdvt/exprtests/standard	date.datename.nulls	DATENAME	Required If Supported
-MIN	Date Filters	tdvt/exprtests/standard	date.datename.nulls	DATENAME	Required If Supported
-	Calculation	tdvt/exprtests/standard	date.datename.nulls	DATENAME	Required If Supported
-DATEPART	Date Aggregation	tdvt/exprtests/standard	date.datename.nulls	DATETIME	Required If Supported
-DATEPART	Date Filters	tdvt/exprtests/standard	date.datename.nulls	DATETIME	Required If Supported
-DATEPART	Calculation	tdvt/exprtests/standard	date.datename.nulls	DATETIME	Required If Supported
->=	Calculation	tdvt/exprtests/standard	date.datename.quarter	DATENAME	Required
->=	Date Aggregation	tdvt/exprtests/standard	date.datename.quarter	DATENAME	Required
->=	Date Filters	tdvt/exprtests/standard	date.datename.quarter	DATENAME	Required
-	Date Aggregation	tdvt/exprtests/standard	date.datename.second	DATENAME	Required
-<=	Date Filters	tdvt/exprtests/standard	date.datename.second	DATENAME	Required
-<=	Calculation	tdvt/exprtests/standard	date.datename.second	DATENAME	Required
-<=	Calculation	tdvt/exprtests/standard	date.datename.sow.day	DATENAME	Required
-	Date Aggregation	tdvt/exprtests/standard	date.datename.sow.day	DATENAME	Required
-COUNT	Date Filters	tdvt/exprtests/standard	date.datename.sow.day	DATENAME	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.datename.sow.dayofyear	DATENAME	Required
-COUNT	Date Aggregation	tdvt/exprtests/standard	date.datename.sow.dayofyear	DATENAME	Required
-COUNT	Date Filters	tdvt/exprtests/standard	date.datename.sow.dayofyear	DATENAME	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.datename.sow.hour	DATENAME	Required
-+	Date Aggregation	tdvt/exprtests/standard	date.datename.sow.hour	DATENAME	Required
-+	Date Filters	tdvt/exprtests/standard	date.datename.sow.hour	DATENAME	Required
-SPACE	Date Aggregation	tdvt/exprtests/standard	date.datename.sow.minute	DATENAME	Required
-INT	Date Filters	tdvt/exprtests/standard	date.datename.sow.minute	DATENAME	Required
-INT	Calculation	tdvt/exprtests/standard	date.datename.sow.minute	DATENAME	Required
-INT	Calculation	tdvt/exprtests/standard	date.datename.sow.month	DATENAME	Required
-INT	Date Aggregation	tdvt/exprtests/standard	date.datename.sow.month	DATENAME	Required
-INT	Date Filters	tdvt/exprtests/standard	date.datename.sow.month	DATENAME	Required
-INT	Aggregation	tdvt/exprtests/standard	date.datename.sow.nulls	COUNT	Recommended
-COUNT	Calculation	tdvt/exprtests/standard	date.datename.sow.nulls	COUNT	Recommended
-COUNT	Calculation	tdvt/exprtests/standard	date.datename.sow.nulls	DATE	Recommended
-COUNT	Calculation	tdvt/exprtests/standard	date.datename.sow.nulls	DATENAME	Recommended
-COUNT	Calculation	tdvt/exprtests/standard	date.datename.sow.nulls	DATETIME	Recommended
-COUNT	Cast	tdvt/exprtests/standard	date.datename.sow.nulls	DATE	Recommended
-SPACE	Date Aggregation	tdvt/exprtests/standard	date.datename.sow.nulls	DATENAME	Recommended
-COUNT	Date Aggregation	tdvt/exprtests/standard	date.datename.sow.nulls	DATETIME	Recommended
-COUNT	Date Filters	tdvt/exprtests/standard	date.datename.sow.nulls	DATENAME	Recommended
-COUNT	Date Filters	tdvt/exprtests/standard	date.datename.sow.nulls	DATETIME	Recommended
-COUNT	Domain	tdvt/exprtests/standard	date.datename.sow.nulls	COUNT	Recommended
-COUNT	Filters	tdvt/exprtests/standard	date.datename.sow.nulls	COUNT	Recommended
-STDEVP	Reference Line	tdvt/exprtests/standard	date.datename.sow.nulls	COUNT	Recommended
-STDEVP	Date Aggregation	tdvt/exprtests/standard	date.datename.sow.quarter	DATENAME	Required
-STDEVP	Date Filters	tdvt/exprtests/standard	date.datename.sow.quarter	DATENAME	Required
-STDEV	Calculation	tdvt/exprtests/standard	date.datename.sow.quarter	DATENAME	Required
-STDEV	Calculation	tdvt/exprtests/standard	date.datename.sow.second	DATENAME	Required
-STDEV	Date Aggregation	tdvt/exprtests/standard	date.datename.sow.second	DATENAME	Required
-DATETRUNC	Date Filters	tdvt/exprtests/standard	date.datename.sow.second	DATENAME	Required
-DATETRUNC	Date Aggregation	tdvt/exprtests/standard	date.datename.sow.week	DATENAME	Required
-DATETRUNC	Date Filters	tdvt/exprtests/standard	date.datename.sow.week	DATENAME	Required
-DATETRUNC	Calculation	tdvt/exprtests/standard	date.datename.sow.week	DATENAME	Required
-DATETRUNC	Date Aggregation	tdvt/exprtests/standard	date.datename.sow.weekday	DATENAME	Required
-DATETRUNC	Date Filters	tdvt/exprtests/standard	date.datename.sow.weekday	DATENAME	Required
-AVG	Calculation	tdvt/exprtests/standard	date.datename.sow.weekday	DATENAME	Required
-AVG	Calculation	tdvt/exprtests/standard	date.datename.sow.year	DATENAME	Required
-AVG	Date Aggregation	tdvt/exprtests/standard	date.datename.sow.year	DATENAME	Required
-AVG	Date Filters	tdvt/exprtests/standard	date.datename.sow.year	DATENAME	Required
-<=	Date Aggregation	tdvt/exprtests/standard	date.datename.week	DATENAME	Required
-<=	Date Filters	tdvt/exprtests/standard	date.datename.week	DATENAME	Required
-<=	Calculation	tdvt/exprtests/standard	date.datename.week	DATENAME	Required
->=	Calculation	tdvt/exprtests/standard	date.datename.weekday	DATENAME	Required
->=	Date Aggregation	tdvt/exprtests/standard	date.datename.weekday	DATENAME	Required
->=	Date Filters	tdvt/exprtests/standard	date.datename.weekday	DATENAME	Required
-	Date Aggregation	tdvt/exprtests/standard	date.datename.year	DATENAME	Required
-	Date Filters	tdvt/exprtests/standard	date.datename.year	DATENAME	Required
-LOD_STYLE_JOIN	Calculation	tdvt/exprtests/standard	date.datename.year	DATENAME	Required
-SUM	Aggregation	tdvt/exprtests/dateparse	date.dateparse.hour	COUNT	Recommended
-SUM	Calculation	tdvt/exprtests/dateparse	date.dateparse.hour	COUNT	Recommended
-SUM	Calculation	tdvt/exprtests/dateparse	date.dateparse.hour	DATEPARSE	Recommended
-SUM	Date Aggregation	tdvt/exprtests/dateparse	date.dateparse.hour	DATEPARSE	Recommended
-DATEPART	Date Filters	tdvt/exprtests/dateparse	date.dateparse.hour	DATEPARSE	Recommended
-DATEPART	Domain	tdvt/exprtests/dateparse	date.dateparse.hour	COUNT	Recommended
-DATEPART	Filters	tdvt/exprtests/dateparse	date.dateparse.hour	COUNT	Recommended
-DATETIME	Reference Line	tdvt/exprtests/dateparse	date.dateparse.hour	COUNT	Recommended
-DATETIME	Aggregation	tdvt/exprtests/dateparse	date.dateparse.month	COUNT	Recommended
-DATETIME	Calculation	tdvt/exprtests/dateparse	date.dateparse.month	COUNT	Recommended
-COUNT	Calculation	tdvt/exprtests/dateparse	date.dateparse.month	DATEPARSE	Recommended
-COUNT	Date Aggregation	tdvt/exprtests/dateparse	date.dateparse.month	DATEPARSE	Recommended
-COUNT	Date Filters	tdvt/exprtests/dateparse	date.dateparse.month	DATEPARSE	Recommended
-COUNT	Domain	tdvt/exprtests/dateparse	date.dateparse.month	COUNT	Recommended
-COUNT	Filters	tdvt/exprtests/dateparse	date.dateparse.month	COUNT	Recommended
-DATEDIFF	Reference Line	tdvt/exprtests/dateparse	date.dateparse.month	COUNT	Recommended
-DATEDIFF	Aggregation	tdvt/exprtests/dateparse	date.dateparse.weekday	COUNT	Recommended
-DATEDIFF	Calculation	tdvt/exprtests/dateparse	date.dateparse.weekday	COUNT	Recommended
-COUNT	Calculation	tdvt/exprtests/dateparse	date.dateparse.weekday	DATEPARSE	Recommended
-COUNT	Date Aggregation	tdvt/exprtests/dateparse	date.dateparse.weekday	DATEPARSE	Recommended
-COUNT	Date Filters	tdvt/exprtests/dateparse	date.dateparse.weekday	DATEPARSE	Recommended
-COUNT	Domain	tdvt/exprtests/dateparse	date.dateparse.weekday	COUNT	Recommended
-COUNT	Filters	tdvt/exprtests/dateparse	date.dateparse.weekday	COUNT	Recommended
-LEN	Reference Line	tdvt/exprtests/dateparse	date.dateparse.weekday	COUNT	Recommended
-LEN	Date Aggregation	tdvt/exprtests/dateparse	date.dateparse.year	DATEPARSE	Recommended
-LEN	Date Filters	tdvt/exprtests/dateparse	date.dateparse.year	DATEPARSE	Recommended
-LEN	Calculation	tdvt/exprtests/dateparse	date.dateparse.year	DATEPARSE	Recommended
-DATEPART	Reference Line	tdvt/exprtests/dateparse	date.dateparse.year	COUNT	Recommended
-DATEPART	Filters	tdvt/exprtests/dateparse	date.dateparse.year	COUNT	Recommended
-DATEPART	Domain	tdvt/exprtests/dateparse	date.dateparse.year	COUNT	Recommended
-COUNT	Aggregation	tdvt/exprtests/dateparse	date.dateparse.year	COUNT	Recommended
-COUNT	Calculation	tdvt/exprtests/dateparse	date.dateparse.year	COUNT	Recommended
-COUNT	Calculation	tdvt/exprtests/standard	date.datepart.dateadd.defect603107	+	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.datepart.dateadd.defect603107	-	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.datepart.dateadd.defect603107	DATEADD	Required
-DATEPART	Calculation	tdvt/exprtests/standard	date.datepart.dateadd.defect603107	DATEPART	Required
-DATEPART	Date Aggregation	tdvt/exprtests/standard	date.datepart.dateadd.defect603107	DATEADD	Required
-DATEPART	Date Aggregation	tdvt/exprtests/standard	date.datepart.dateadd.defect603107	DATEPART	Required
-	Date Filters	tdvt/exprtests/standard	date.datepart.dateadd.defect603107	DATEADD	Required
-LOD_STYLE_JOIN	Date Filters	tdvt/exprtests/standard	date.datepart.dateadd.defect603107	DATEPART	Required
-SUM	Operator	tdvt/exprtests/standard	date.datepart.dateadd.defect603107	+	Required
-SUM	Operator	tdvt/exprtests/standard	date.datepart.dateadd.defect603107	-	Required
-SUM	Date Aggregation	tdvt/exprtests/standard	date.datepart.day	DATEPART	Required
-SUM	Date Filters	tdvt/exprtests/standard	date.datepart.day	DATEPART	Required
-AVG	Calculation	tdvt/exprtests/standard	date.datepart.day	DATEPART	Required
-AVG	Calculation	tdvt/exprtests/standard	date.datepart.dayofyear	DATEPART	Required
-AVG	Date Aggregation	tdvt/exprtests/standard	date.datepart.dayofyear	DATEPART	Required
-AVG	Date Filters	tdvt/exprtests/standard	date.datepart.dayofyear	DATEPART	Required
-SUM	Calculation	tdvt/exprtests/standard	date.datepart.hour	DATEPART	Required
-SUM	Date Aggregation	tdvt/exprtests/standard	date.datepart.hour	DATEPART	Required
-SUM	Date Filters	tdvt/exprtests/standard	date.datepart.hour	DATEPART	Required
-SUM	Reference Line	tdvt/exprtests/iso8601week	date.datepart.iso-quarter	COUNT	Recommended
->	Filters	tdvt/exprtests/iso8601week	date.datepart.iso-quarter	COUNT	Recommended
->	Domain	tdvt/exprtests/iso8601week	date.datepart.iso-quarter	COUNT	Recommended
->	Aggregation	tdvt/exprtests/iso8601week	date.datepart.iso-quarter	COUNT	Recommended
-	Calculation	tdvt/exprtests/iso8601week	date.datepart.iso-quarter	COUNT	Recommended
-DATEPART	Date Aggregation	tdvt/exprtests/iso8601week	date.datepart.iso-quarter	DATEPART	Recommended
-DATEPART	Date Filters	tdvt/exprtests/iso8601week	date.datepart.iso-quarter	DATEPART	Recommended
-DATEPART	Calculation	tdvt/exprtests/iso8601week	date.datepart.iso-quarter	DATEPART	Recommended
->=	Aggregation	tdvt/exprtests/iso8601week	date.datepart.iso-week	COUNT	Recommended
->=	Calculation	tdvt/exprtests/iso8601week	date.datepart.iso-week	COUNT	Recommended
->=	Calculation	tdvt/exprtests/iso8601week	date.datepart.iso-week	DATEPART	Recommended
-	Date Aggregation	tdvt/exprtests/iso8601week	date.datepart.iso-week	DATEPART	Recommended
-MIN	Date Filters	tdvt/exprtests/iso8601week	date.datepart.iso-week	DATEPART	Recommended
-MIN	Domain	tdvt/exprtests/iso8601week	date.datepart.iso-week	COUNT	Recommended
-MIN	Filters	tdvt/exprtests/iso8601week	date.datepart.iso-week	COUNT	Recommended
-MIN	Reference Line	tdvt/exprtests/iso8601week	date.datepart.iso-week	COUNT	Recommended
-SUM	Reference Line	tdvt/exprtests/iso8601week	date.datepart.iso-weekday	COUNT	Recommended
-SUM	Filters	tdvt/exprtests/iso8601week	date.datepart.iso-weekday	COUNT	Recommended
-SUM	Domain	tdvt/exprtests/iso8601week	date.datepart.iso-weekday	COUNT	Recommended
-SUM	Aggregation	tdvt/exprtests/iso8601week	date.datepart.iso-weekday	COUNT	Recommended
-<=	Calculation	tdvt/exprtests/iso8601week	date.datepart.iso-weekday	COUNT	Recommended
-<=	Date Aggregation	tdvt/exprtests/iso8601week	date.datepart.iso-weekday	DATEPART	Recommended
-<=	Date Filters	tdvt/exprtests/iso8601week	date.datepart.iso-weekday	DATEPART	Recommended
-	Calculation	tdvt/exprtests/iso8601week	date.datepart.iso-weekday	DATEPART	Recommended
-	Aggregation	tdvt/exprtests/iso8601week	date.datepart.iso-year	COUNT	Recommended
-<	Calculation	tdvt/exprtests/iso8601week	date.datepart.iso-year	COUNT	Recommended
-<	Calculation	tdvt/exprtests/iso8601week	date.datepart.iso-year	DATEPART	Recommended
-<	Date Aggregation	tdvt/exprtests/iso8601week	date.datepart.iso-year	DATEPART	Recommended
-==	Date Filters	tdvt/exprtests/iso8601week	date.datepart.iso-year	DATEPART	Recommended
-==	Domain	tdvt/exprtests/iso8601week	date.datepart.iso-year	COUNT	Recommended
-==	Filters	tdvt/exprtests/iso8601week	date.datepart.iso-year	COUNT	Recommended
-	Reference Line	tdvt/exprtests/iso8601week	date.datepart.iso-year	COUNT	Recommended
-	Calculation	tdvt/exprtests/standard	date.datepart.minute	DATEPART	Required
-DATEPART	Date Aggregation	tdvt/exprtests/standard	date.datepart.minute	DATEPART	Required
-DATEPART	Date Filters	tdvt/exprtests/standard	date.datepart.minute	DATEPART	Required
-DATEPART	Date Aggregation	tdvt/exprtests/standard	date.datepart.month	DATEPART	Required
-DATEPART	Date Filters	tdvt/exprtests/standard	date.datepart.month	DATEPART	Required
-DATEPART	Calculation	tdvt/exprtests/standard	date.datepart.month	DATEPART	Required
-DATEPART	Aggregation	tdvt/exprtests/standard	date.datepart.nulls	COUNT	Required If Supported
-TAN	Calculation	tdvt/exprtests/standard	date.datepart.nulls	COUNT	Required If Supported
-DATEDIFF	Calculation	tdvt/exprtests/standard	date.datepart.nulls	DATE	Required If Supported
-DATEDIFF	Calculation	tdvt/exprtests/standard	date.datepart.nulls	DATEPART	Required If Supported
-DATEDIFF	Calculation	tdvt/exprtests/standard	date.datepart.nulls	DATETIME	Required If Supported
-DATETIME	Cast	tdvt/exprtests/standard	date.datepart.nulls	DATE	Required If Supported
-DATETIME	Date Aggregation	tdvt/exprtests/standard	date.datepart.nulls	DATEPART	Required If Supported
-DATETIME	Date Aggregation	tdvt/exprtests/standard	date.datepart.nulls	DATETIME	Required If Supported
-DATETRUNC	Date Filters	tdvt/exprtests/standard	date.datepart.nulls	DATEPART	Required If Supported
-DATETRUNC	Date Filters	tdvt/exprtests/standard	date.datepart.nulls	DATETIME	Required If Supported
-DATETRUNC	Domain	tdvt/exprtests/standard	date.datepart.nulls	COUNT	Required If Supported
-FLOAT	Filters	tdvt/exprtests/standard	date.datepart.nulls	COUNT	Required If Supported
-FLOAT	Reference Line	tdvt/exprtests/standard	date.datepart.nulls	COUNT	Required If Supported
-FLOAT	Date Aggregation	tdvt/exprtests/standard	date.datepart.quarter	DATEPART	Required
-DATENAME	Date Filters	tdvt/exprtests/standard	date.datepart.quarter	DATEPART	Required
-DATENAME	Calculation	tdvt/exprtests/standard	date.datepart.quarter	DATEPART	Required
-DATENAME	Calculation	tdvt/exprtests/standard	date.datepart.second	DATEPART	Required
-SUM	Date Aggregation	tdvt/exprtests/standard	date.datepart.second	DATEPART	Required
-SUM	Date Filters	tdvt/exprtests/standard	date.datepart.second	DATEPART	Required
-SUM	Reference Line	tdvt/exprtests/standard	date.datepart.second.ms	COUNT	Required
-SUM	Filters	tdvt/exprtests/standard	date.datepart.second.ms	COUNT	Required
-LOD_STYLE_JOIN	Domain	tdvt/exprtests/standard	date.datepart.second.ms	COUNT	Required
-==	Aggregation	tdvt/exprtests/standard	date.datepart.second.ms	COUNT	Required
-==	Calculation	tdvt/exprtests/standard	date.datepart.second.ms	COUNT	Required
-==	Date Aggregation	tdvt/exprtests/standard	date.datepart.second.ms	DATEPART	Required
-TEMP_TABLES_AND_SUBQUERIES	Date Filters	tdvt/exprtests/standard	date.datepart.second.ms	DATEPART	Required
-TEMP_TABLES_AND_SUBQUERIES	Calculation	tdvt/exprtests/standard	date.datepart.second.ms	DATEPART	Required
-DATETIME	Date Aggregation	tdvt/exprtests/standard	date.datepart.second.ms	DATETIME	Required
-DATETIME	Date Filters	tdvt/exprtests/standard	date.datepart.second.ms	DATETIME	Required
-DATETIME	Calculation	tdvt/exprtests/standard	date.datepart.second.ms	DATETIME	Required
-	Date Aggregation	tdvt/exprtests/standard	date.datepart.sow.day	DATEPART	Required
-ISNULL	Date Filters	tdvt/exprtests/standard	date.datepart.sow.day	DATEPART	Required
-ISNULL	Calculation	tdvt/exprtests/standard	date.datepart.sow.day	DATEPART	Required
-SUM	Calculation	tdvt/exprtests/standard	date.datepart.sow.dayofyear	DATEPART	Required
-SUM	Date Aggregation	tdvt/exprtests/standard	date.datepart.sow.dayofyear	DATEPART	Required
-SUM	Date Filters	tdvt/exprtests/standard	date.datepart.sow.dayofyear	DATEPART	Required
-SUM	Calculation	tdvt/exprtests/standard	date.datepart.sow.hour	DATEPART	Required
-<=	Date Aggregation	tdvt/exprtests/standard	date.datepart.sow.hour	DATEPART	Required
-<=	Date Filters	tdvt/exprtests/standard	date.datepart.sow.hour	DATEPART	Required
-<=	Calculation	tdvt/exprtests/standard	date.datepart.sow.minute	DATEPART	Required
-DATEPART	Date Aggregation	tdvt/exprtests/standard	date.datepart.sow.minute	DATEPART	Required
-DATEPART	Date Filters	tdvt/exprtests/standard	date.datepart.sow.minute	DATEPART	Required
-DATEPART	Date Aggregation	tdvt/exprtests/standard	date.datepart.sow.month	DATEPART	Required
-	Date Filters	tdvt/exprtests/standard	date.datepart.sow.month	DATEPART	Required
-MIN	Calculation	tdvt/exprtests/standard	date.datepart.sow.month	DATEPART	Required
-MIN	Cast	tdvt/exprtests/standard	date.datepart.sow.nulls	DATE	Recommended
-MIN	Calculation	tdvt/exprtests/standard	date.datepart.sow.nulls	DATE	Recommended
-MIN	Reference Line	tdvt/exprtests/standard	date.datepart.sow.nulls	COUNT	Recommended
-INT	Filters	tdvt/exprtests/standard	date.datepart.sow.nulls	COUNT	Recommended
-INT	Domain	tdvt/exprtests/standard	date.datepart.sow.nulls	COUNT	Recommended
-INT	Aggregation	tdvt/exprtests/standard	date.datepart.sow.nulls	COUNT	Recommended
-LOWER	Calculation	tdvt/exprtests/standard	date.datepart.sow.nulls	COUNT	Recommended
-LOWER	Date Aggregation	tdvt/exprtests/standard	date.datepart.sow.nulls	DATEPART	Recommended
-ISNULL	Date Filters	tdvt/exprtests/standard	date.datepart.sow.nulls	DATEPART	Recommended
-ISNULL	Calculation	tdvt/exprtests/standard	date.datepart.sow.nulls	DATEPART	Recommended
-DATEPART	Date Aggregation	tdvt/exprtests/standard	date.datepart.sow.nulls	DATETIME	Recommended
-DATEPART	Date Filters	tdvt/exprtests/standard	date.datepart.sow.nulls	DATETIME	Recommended
-DATEPART	Calculation	tdvt/exprtests/standard	date.datepart.sow.nulls	DATETIME	Recommended
-!=	Date Aggregation	tdvt/exprtests/standard	date.datepart.sow.quarter	DATEPART	Required
-!=	Date Filters	tdvt/exprtests/standard	date.datepart.sow.quarter	DATEPART	Required
-!	Calculation	tdvt/exprtests/standard	date.datepart.sow.quarter	DATEPART	Required
-!	Date Aggregation	tdvt/exprtests/standard	date.datepart.sow.second	DATEPART	Required
-!	Date Filters	tdvt/exprtests/standard	date.datepart.sow.second	DATEPART	Required
-MIN	Calculation	tdvt/exprtests/standard	date.datepart.sow.second	DATEPART	Required
-MIN	Date Aggregation	tdvt/exprtests/standard	date.datepart.sow.second	DATETIME	Required
-MIN	Date Filters	tdvt/exprtests/standard	date.datepart.sow.second	DATETIME	Required
-MIN	Calculation	tdvt/exprtests/standard	date.datepart.sow.second	DATETIME	Required
-IFNULL	Calculation	tdvt/exprtests/standard	date.datepart.sow.week	DATEPART	Required
-IIF	Date Aggregation	tdvt/exprtests/standard	date.datepart.sow.week	DATEPART	Required
->	Date Filters	tdvt/exprtests/standard	date.datepart.sow.week	DATEPART	Required
->	Date Aggregation	tdvt/exprtests/standard	date.datepart.sow.weekday	DATEPART	Required
->	Date Filters	tdvt/exprtests/standard	date.datepart.sow.weekday	DATEPART	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.datepart.sow.weekday	DATEPART	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.datepart.sow.year	DATEPART	Required
-COUNT	Date Aggregation	tdvt/exprtests/standard	date.datepart.sow.year	DATEPART	Required
-COUNT	Date Filters	tdvt/exprtests/standard	date.datepart.sow.year	DATEPART	Required
-COUNT	Cast	tdvt/exprtests/standard	date.datepart.week	DATE	Required
-DATEPART	Calculation	tdvt/exprtests/standard	date.datepart.week	DATE	Required
-DATEPART	Date Aggregation	tdvt/exprtests/standard	date.datepart.week	DATEPART	Required
-DATEPART	Date Filters	tdvt/exprtests/standard	date.datepart.week	DATEPART	Required
-==	Calculation	tdvt/exprtests/standard	date.datepart.week	DATEPART	Required
-==	Calculation	tdvt/exprtests/standard	date.datepart.weekday	DATEPART	Required
-==	Date Aggregation	tdvt/exprtests/standard	date.datepart.weekday	DATEPART	Required
-ISNULL	Date Filters	tdvt/exprtests/standard	date.datepart.weekday	DATEPART	Required
-ISNULL	Calculation	tdvt/exprtests/standard	date.datepart.year	DATEPART	Required
-IIF	Date Aggregation	tdvt/exprtests/standard	date.datepart.year	DATEPART	Required
-&&	Date Filters	tdvt/exprtests/standard	date.datepart.year	DATEPART	Required
-&&	Date Aggregation	tdvt/exprtests/standard	date.datetrunc.day	DATETRUNC	Required
-	Date Filters	tdvt/exprtests/standard	date.datetrunc.day	DATETRUNC	Required
-	Calculation	tdvt/exprtests/standard	date.datetrunc.day	DATETRUNC	Required
-LOWER	Date Aggregation	tdvt/exprtests/standard	date.datetrunc.dayofyear	DATETRUNC	Required
-LOWER	Date Filters	tdvt/exprtests/standard	date.datetrunc.dayofyear	DATETRUNC	Required
-INT	Calculation	tdvt/exprtests/standard	date.datetrunc.dayofyear	DATETRUNC	Required
-INT	Date Aggregation	tdvt/exprtests/standard	date.datetrunc.hour	DATETRUNC	Required
-INT	Date Filters	tdvt/exprtests/standard	date.datetrunc.hour	DATETRUNC	Required
-MAX	Calculation	tdvt/exprtests/standard	date.datetrunc.hour	DATETRUNC	Required
-MAX	Aggregation	tdvt/exprtests/iso8601week	date.datetrunc.iso-quarter	COUNT	Recommended
-MAX	Calculation	tdvt/exprtests/iso8601week	date.datetrunc.iso-quarter	COUNT	Recommended
-MAX	Calculation	tdvt/exprtests/iso8601week	date.datetrunc.iso-quarter	DATEPART	Recommended
-DIV	Calculation	tdvt/exprtests/iso8601week	date.datetrunc.iso-quarter	DATETRUNC	Recommended
-DIV	Date Aggregation	tdvt/exprtests/iso8601week	date.datetrunc.iso-quarter	DATEPART	Recommended
-DATEDIFF	Date Aggregation	tdvt/exprtests/iso8601week	date.datetrunc.iso-quarter	DATETRUNC	Recommended
-DATEDIFF	Date Filters	tdvt/exprtests/iso8601week	date.datetrunc.iso-quarter	DATEPART	Recommended
-DATEDIFF	Date Filters	tdvt/exprtests/iso8601week	date.datetrunc.iso-quarter	DATETRUNC	Recommended
-DATETIME	Domain	tdvt/exprtests/iso8601week	date.datetrunc.iso-quarter	COUNT	Recommended
-DATETIME	Filters	tdvt/exprtests/iso8601week	date.datetrunc.iso-quarter	COUNT	Recommended
-DATETIME	Reference Line	tdvt/exprtests/iso8601week	date.datetrunc.iso-quarter	COUNT	Recommended
-LOWER	Reference Line	tdvt/exprtests/iso8601week	date.datetrunc.iso-week	COUNT	Recommended
-LOWER	Filters	tdvt/exprtests/iso8601week	date.datetrunc.iso-week	COUNT	Recommended
-LOWER	Domain	tdvt/exprtests/iso8601week	date.datetrunc.iso-week	COUNT	Recommended
-LOWER	Aggregation	tdvt/exprtests/iso8601week	date.datetrunc.iso-week	COUNT	Recommended
-SUM	Calculation	tdvt/exprtests/iso8601week	date.datetrunc.iso-week	COUNT	Recommended
-SUM	Date Aggregation	tdvt/exprtests/iso8601week	date.datetrunc.iso-week	DATETRUNC	Recommended
-SUM	Date Filters	tdvt/exprtests/iso8601week	date.datetrunc.iso-week	DATETRUNC	Recommended
-SUM	Calculation	tdvt/exprtests/iso8601week	date.datetrunc.iso-week	DATETRUNC	Recommended
-LOD_STYLE_JOIN	Reference Line	tdvt/exprtests/iso8601week	date.datetrunc.iso-weekday	COUNT	Recommended
-FLOAT	Filters	tdvt/exprtests/iso8601week	date.datetrunc.iso-weekday	COUNT	Recommended
-FLOAT	Domain	tdvt/exprtests/iso8601week	date.datetrunc.iso-weekday	COUNT	Recommended
-FLOAT	Aggregation	tdvt/exprtests/iso8601week	date.datetrunc.iso-weekday	COUNT	Recommended
-INT	Calculation	tdvt/exprtests/iso8601week	date.datetrunc.iso-weekday	COUNT	Recommended
-INT	Date Aggregation	tdvt/exprtests/iso8601week	date.datetrunc.iso-weekday	DATETRUNC	Recommended
-INT	Date Filters	tdvt/exprtests/iso8601week	date.datetrunc.iso-weekday	DATETRUNC	Recommended
-DATEPART	Calculation	tdvt/exprtests/iso8601week	date.datetrunc.iso-weekday	DATETRUNC	Recommended
-DATEPART	Aggregation	tdvt/exprtests/iso8601week	date.datetrunc.iso-year	COUNT	Recommended
-DATEPART	Calculation	tdvt/exprtests/iso8601week	date.datetrunc.iso-year	COUNT	Recommended
-STR	Calculation	tdvt/exprtests/iso8601week	date.datetrunc.iso-year	DATEPART	Recommended
-STR	Calculation	tdvt/exprtests/iso8601week	date.datetrunc.iso-year	DATETRUNC	Recommended
-STR	Date Aggregation	tdvt/exprtests/iso8601week	date.datetrunc.iso-year	DATEPART	Recommended
-DATEDIFF	Date Aggregation	tdvt/exprtests/iso8601week	date.datetrunc.iso-year	DATETRUNC	Recommended
-DATEDIFF	Date Filters	tdvt/exprtests/iso8601week	date.datetrunc.iso-year	DATEPART	Recommended
-DATEDIFF	Date Filters	tdvt/exprtests/iso8601week	date.datetrunc.iso-year	DATETRUNC	Recommended
-DATETIME	Domain	tdvt/exprtests/iso8601week	date.datetrunc.iso-year	COUNT	Recommended
-DATETIME	Filters	tdvt/exprtests/iso8601week	date.datetrunc.iso-year	COUNT	Recommended
-DATETIME	Reference Line	tdvt/exprtests/iso8601week	date.datetrunc.iso-year	COUNT	Recommended
-DATENAME	Date Aggregation	tdvt/exprtests/standard	date.datetrunc.minute	DATETRUNC	Required
-DATENAME	Date Filters	tdvt/exprtests/standard	date.datetrunc.minute	DATETRUNC	Required
-DATENAME	Calculation	tdvt/exprtests/standard	date.datetrunc.minute	DATETRUNC	Required
-DATEDIFF	Calculation	tdvt/exprtests/standard	date.datetrunc.month	DATETRUNC	Required
-DATEDIFF	Date Aggregation	tdvt/exprtests/standard	date.datetrunc.month	DATETRUNC	Required
-DATEDIFF	Date Filters	tdvt/exprtests/standard	date.datetrunc.month	DATETRUNC	Required
-DATETIME	Cast	tdvt/exprtests/standard	date.datetrunc.nulls	DATE	Required If Supported
-DATETIME	Calculation	tdvt/exprtests/standard	date.datetrunc.nulls	DATE	Required If Supported
-DATETIME	Reference Line	tdvt/exprtests/standard	date.datetrunc.nulls	COUNT	Required If Supported
-DATE	Filters	tdvt/exprtests/standard	date.datetrunc.nulls	COUNT	Required If Supported
-DATE	Domain	tdvt/exprtests/standard	date.datetrunc.nulls	COUNT	Required If Supported
-DATEPART	Aggregation	tdvt/exprtests/standard	date.datetrunc.nulls	COUNT	Required If Supported
-DATEPART	Calculation	tdvt/exprtests/standard	date.datetrunc.nulls	COUNT	Required If Supported
-DATEPART	Date Aggregation	tdvt/exprtests/standard	date.datetrunc.nulls	DATETIME	Required If Supported
-MAX	Date Filters	tdvt/exprtests/standard	date.datetrunc.nulls	DATETIME	Required If Supported
-MAX	Calculation	tdvt/exprtests/standard	date.datetrunc.nulls	DATETIME	Required If Supported
-MAX	Date Aggregation	tdvt/exprtests/standard	date.datetrunc.nulls	DATETRUNC	Required If Supported
-MAX	Date Filters	tdvt/exprtests/standard	date.datetrunc.nulls	DATETRUNC	Required If Supported
-ENDSWITH	Calculation	tdvt/exprtests/standard	date.datetrunc.nulls	DATETRUNC	Required If Supported
-ENDSWITH	Calculation	tdvt/exprtests/standard	date.datetrunc.quarter	DATETRUNC	Required
-MIN	Date Aggregation	tdvt/exprtests/standard	date.datetrunc.quarter	DATETRUNC	Required
-MIN	Date Filters	tdvt/exprtests/standard	date.datetrunc.quarter	DATETRUNC	Required
-MIN	Calculation	tdvt/exprtests/standard	date.datetrunc.second	DATETRUNC	Required
-MIN	Date Aggregation	tdvt/exprtests/standard	date.datetrunc.second	DATETRUNC	Required
-SUM	Date Filters	tdvt/exprtests/standard	date.datetrunc.second	DATETRUNC	Required
-SUM	Calculation	tdvt/exprtests/standard	date.datetrunc.sow.day	DATETRUNC	Required
-SUM	Date Aggregation	tdvt/exprtests/standard	date.datetrunc.sow.day	DATETRUNC	Required
-SUM	Date Filters	tdvt/exprtests/standard	date.datetrunc.sow.day	DATETRUNC	Required
-LOD_STYLE_JOIN	Calculation	tdvt/exprtests/standard	date.datetrunc.sow.dayofyear	DATETRUNC	Required
-DATEDIFF	Date Aggregation	tdvt/exprtests/standard	date.datetrunc.sow.dayofyear	DATETRUNC	Required
-DATEDIFF	Date Filters	tdvt/exprtests/standard	date.datetrunc.sow.dayofyear	DATETRUNC	Required
-DATEDIFF	Date Aggregation	tdvt/exprtests/standard	date.datetrunc.sow.hour	DATETRUNC	Required
-DATETIME	Date Filters	tdvt/exprtests/standard	date.datetrunc.sow.hour	DATETRUNC	Required
-DATETIME	Calculation	tdvt/exprtests/standard	date.datetrunc.sow.hour	DATETRUNC	Required
-DATETIME	Calculation	tdvt/exprtests/standard	date.datetrunc.sow.minute	DATETRUNC	Required
-*	Date Aggregation	tdvt/exprtests/standard	date.datetrunc.sow.minute	DATETRUNC	Required
-*	Date Filters	tdvt/exprtests/standard	date.datetrunc.sow.minute	DATETRUNC	Required
-FIND	Calculation	tdvt/exprtests/standard	date.datetrunc.sow.month	DATETRUNC	Required
-FIND	Date Aggregation	tdvt/exprtests/standard	date.datetrunc.sow.month	DATETRUNC	Required
-FIND	Date Filters	tdvt/exprtests/standard	date.datetrunc.sow.month	DATETRUNC	Required
-FIND	Aggregation	tdvt/exprtests/standard	date.datetrunc.sow.nulls	COUNT	Recommended
-SUM	Calculation	tdvt/exprtests/standard	date.datetrunc.sow.nulls	COUNT	Recommended
-SUM	Calculation	tdvt/exprtests/standard	date.datetrunc.sow.nulls	DATE	Recommended
-SUM	Calculation	tdvt/exprtests/standard	date.datetrunc.sow.nulls	DATETIME	Recommended
-SUM	Calculation	tdvt/exprtests/standard	date.datetrunc.sow.nulls	DATETRUNC	Recommended
-LOD_STYLE_JOIN	Cast	tdvt/exprtests/standard	date.datetrunc.sow.nulls	DATE	Recommended
-DATEDIFF	Date Aggregation	tdvt/exprtests/standard	date.datetrunc.sow.nulls	DATETIME	Recommended
-DATEDIFF	Date Aggregation	tdvt/exprtests/standard	date.datetrunc.sow.nulls	DATETRUNC	Recommended
-DATEDIFF	Date Filters	tdvt/exprtests/standard	date.datetrunc.sow.nulls	DATETIME	Recommended
-DATETIME	Date Filters	tdvt/exprtests/standard	date.datetrunc.sow.nulls	DATETRUNC	Recommended
-DATETIME	Domain	tdvt/exprtests/standard	date.datetrunc.sow.nulls	COUNT	Recommended
-DATETIME	Filters	tdvt/exprtests/standard	date.datetrunc.sow.nulls	COUNT	Recommended
-==	Reference Line	tdvt/exprtests/standard	date.datetrunc.sow.nulls	COUNT	Recommended
-==	Calculation	tdvt/exprtests/standard	date.datetrunc.sow.quarter	DATETRUNC	Required
-==	Date Aggregation	tdvt/exprtests/standard	date.datetrunc.sow.quarter	DATETRUNC	Required
-COUNT	Date Filters	tdvt/exprtests/standard	date.datetrunc.sow.quarter	DATETRUNC	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.datetrunc.sow.second	DATETRUNC	Required
-COUNT	Date Aggregation	tdvt/exprtests/standard	date.datetrunc.sow.second	DATETRUNC	Required
-COUNT	Date Filters	tdvt/exprtests/standard	date.datetrunc.sow.second	DATETRUNC	Required
-COUNT	Date Aggregation	tdvt/exprtests/standard	date.datetrunc.sow.week	DATETRUNC	Required
-SUM	Date Filters	tdvt/exprtests/standard	date.datetrunc.sow.week	DATETRUNC	Required
-SUM	Calculation	tdvt/exprtests/standard	date.datetrunc.sow.week	DATETRUNC	Required
-SUM	Calculation	tdvt/exprtests/standard	date.datetrunc.sow.weekday	DATETRUNC	Required
-SUM	Date Aggregation	tdvt/exprtests/standard	date.datetrunc.sow.weekday	DATETRUNC	Required
-MAX	Date Filters	tdvt/exprtests/standard	date.datetrunc.sow.weekday	DATETRUNC	Required
-MAX	Date Aggregation	tdvt/exprtests/standard	date.datetrunc.sow.year	DATETRUNC	Required
-MAX	Date Filters	tdvt/exprtests/standard	date.datetrunc.sow.year	DATETRUNC	Required
-MAX	Calculation	tdvt/exprtests/standard	date.datetrunc.sow.year	DATETRUNC	Required
-TIME1899	Date Aggregation	tdvt/exprtests/standard	date.datetrunc.week	DATETRUNC	Required
-TIME1899	Date Filters	tdvt/exprtests/standard	date.datetrunc.week	DATETRUNC	Required
-MIN	Calculation	tdvt/exprtests/standard	date.datetrunc.week	DATETRUNC	Required
-MIN	Calculation	tdvt/exprtests/standard	date.datetrunc.weekday	DATETRUNC	Required
-MIN	Date Aggregation	tdvt/exprtests/standard	date.datetrunc.weekday	DATETRUNC	Required
-MIN	Date Filters	tdvt/exprtests/standard	date.datetrunc.weekday	DATETRUNC	Required
-DATETRUNC	Date Aggregation	tdvt/exprtests/standard	date.datetrunc.year	DATETRUNC	Required
-DATETRUNC	Date Filters	tdvt/exprtests/standard	date.datetrunc.year	DATETRUNC	Required
-DATETRUNC	Calculation	tdvt/exprtests/standard	date.datetrunc.year	DATETRUNC	Required
-COUNT	Aggregation	tdvt/exprtests/standard	date.math	COUNT	Recommended
-COUNT	Aggregation	tdvt/exprtests/standard	date.math	MAX	Recommended
-COUNT	Aggregation	tdvt/exprtests/standard	date.math	MIN	Recommended
-COUNT	Calculation	tdvt/exprtests/standard	date.math	!=	Recommended
-COUNT	Calculation	tdvt/exprtests/standard	date.math	+	Recommended
-DATETRUNC	Calculation	tdvt/exprtests/standard	date.math	-	Recommended
-DATETRUNC	Calculation	tdvt/exprtests/standard	date.math	<	Recommended
-DATETRUNC	Calculation	tdvt/exprtests/standard	date.math	<=	Recommended
-DATEDIFF	Calculation	tdvt/exprtests/standard	date.math	==	Recommended
-DATEDIFF	Calculation	tdvt/exprtests/standard	date.math	>	Recommended
-DATEDIFF	Calculation	tdvt/exprtests/standard	date.math	>=	Recommended
-DATETIME	Calculation	tdvt/exprtests/standard	date.math	COUNT	Recommended
-DATETIME	Calculation	tdvt/exprtests/standard	date.math	DATEDIFF	Recommended
-DATETIME	Calculation	tdvt/exprtests/standard	date.math	MAX	Recommended
-*	Calculation	tdvt/exprtests/standard	date.math	MIN	Recommended
-*	Calculation	tdvt/exprtests/standard	date.math	NOW	Recommended
->=	Calculation	tdvt/exprtests/standard	date.math	TODAY	Recommended
->=	Date Aggregation	tdvt/exprtests/standard	date.math	DATEDIFF	Recommended
->=	Date Filters	tdvt/exprtests/standard	date.math	DATEDIFF	Recommended
-^^	Date Filters	tdvt/exprtests/standard	date.math	NOW	Recommended
-^^	Date Filters	tdvt/exprtests/standard	date.math	TODAY	Recommended
-MIN	Domain	tdvt/exprtests/standard	date.math	COUNT	Recommended
-MIN	Domain	tdvt/exprtests/standard	date.math	MAX	Recommended
-MIN	Domain	tdvt/exprtests/standard	date.math	MIN	Recommended
-MIN	Filters	tdvt/exprtests/standard	date.math	<	Recommended
-==	Filters	tdvt/exprtests/standard	date.math	<=	Recommended
-==	Filters	tdvt/exprtests/standard	date.math	==	Recommended
-INCLUDE	Filters	tdvt/exprtests/standard	date.math	>	Recommended
-INCLUDE	Filters	tdvt/exprtests/standard	date.math	>=	Recommended
-COUNT	Filters	tdvt/exprtests/standard	date.math	COUNT	Recommended
-COUNT	Filters	tdvt/exprtests/standard	date.math	MAX	Recommended
-COUNT	Filters	tdvt/exprtests/standard	date.math	MIN	Recommended
-COUNT	Operator	tdvt/exprtests/standard	date.math	!=	Recommended
-COUNT	Operator	tdvt/exprtests/standard	date.math	+	Recommended
-COUNT	Operator	tdvt/exprtests/standard	date.math	-	Recommended
-DATEPARSE	Operator	tdvt/exprtests/standard	date.math	<	Recommended
-DATEPARSE	Operator	tdvt/exprtests/standard	date.math	<=	Recommended
-DATEPARSE	Operator	tdvt/exprtests/standard	date.math	==	Recommended
-DATEPARSE	Operator	tdvt/exprtests/standard	date.math	>	Recommended
-DATEPARSE	Operator	tdvt/exprtests/standard	date.math	>=	Recommended
-DATEPARSE	Reference Line	tdvt/exprtests/standard	date.math	COUNT	Recommended
-DATEPARSE	Operator	tdvt/exprtests/standard	date.math.date_minus_date	-	Recommended
-DATEPARSE	Calculation	tdvt/exprtests/standard	date.math.date_minus_date	-	Recommended
-DATEPARSE	Aggregation	tdvt/exprtests/standard	date.max	COUNT	Required
-COUNT	Aggregation	tdvt/exprtests/standard	date.max	MAX	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.max	COUNT	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.max	MAX	Required
-COUNT	Domain	tdvt/exprtests/standard	date.max	COUNT	Required
-COUNT	Domain	tdvt/exprtests/standard	date.max	MAX	Required
-COUNT	Filters	tdvt/exprtests/standard	date.max	COUNT	Required
-COUNT	Filters	tdvt/exprtests/standard	date.max	MAX	Required
-COUNT	Reference Line	tdvt/exprtests/standard	date.max	COUNT	Required
-COUNT	Reference Line	tdvt/exprtests/standard	date.min	COUNT	Required
-COUNT	Filters	tdvt/exprtests/standard	date.min	COUNT	Required
-COUNT	Domain	tdvt/exprtests/standard	date.min	COUNT	Required
-COUNT	Aggregation	tdvt/exprtests/standard	date.min	COUNT	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.min	COUNT	Required
-COUNT	Filters	tdvt/exprtests/standard	date.min	MIN	Required
-COUNT	Domain	tdvt/exprtests/standard	date.min	MIN	Required
-COUNT	Aggregation	tdvt/exprtests/standard	date.min	MIN	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.min	MIN	Required
-COUNT	Cast	tdvt/exprtests/standard	date.misc	DATE	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.misc	DATE	Required
-COUNT	Date Filters	tdvt/exprtests/standard	date.misc	YEAR	Required
-COUNT	Date Aggregation	tdvt/exprtests/standard	date.misc	YEAR	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.misc	YEAR	Required
-COUNT	Date Filters	tdvt/exprtests/standard	date.misc	MONTH	Required
-COUNT	Date Aggregation	tdvt/exprtests/standard	date.misc	MONTH	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.misc	MONTH	Required
-COUNT	Date Aggregation	tdvt/exprtests/standard	date.misc	DAY	Required
-COUNT	Date Filters	tdvt/exprtests/standard	date.misc	DAY	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.misc	DAY	Required
-COUNT	Date Aggregation	tdvt/exprtests/standard	date.misc	DATETIME	Required
-DATEADD	Date Filters	tdvt/exprtests/standard	date.misc	DATETIME	Required
-DATEADD	Calculation	tdvt/exprtests/standard	date.misc	DATETIME	Required
-DATEDIFF	Reference Line	tdvt/exprtests/standard	date.now	COUNT	Recommended
-DATENAME	Filters	tdvt/exprtests/standard	date.now	COUNT	Recommended
-DATENAME	Domain	tdvt/exprtests/standard	date.now	COUNT	Recommended
-DATENAME	Aggregation	tdvt/exprtests/standard	date.now	COUNT	Recommended
-DATEPART	Calculation	tdvt/exprtests/standard	date.now	COUNT	Recommended
-DATEPART	Date Aggregation	tdvt/exprtests/standard	date.now	DATEPART	Recommended
-DATEPART	Date Filters	tdvt/exprtests/standard	date.now	DATEPART	Recommended
-DATEPART	Calculation	tdvt/exprtests/standard	date.now	DATEPART	Recommended
-DATETRUNC	Filters	tdvt/exprtests/standard	date.now	MIN	Recommended
-DATETRUNC	Domain	tdvt/exprtests/standard	date.now	MIN	Recommended
-DATEADD	Aggregation	tdvt/exprtests/standard	date.now	MIN	Recommended
-DATEADD	Calculation	tdvt/exprtests/standard	date.now	MIN	Recommended
-DATEDIFF	Filters	tdvt/exprtests/standard	date.now	==	Recommended
-DATENAME	Operator	tdvt/exprtests/standard	date.now	==	Recommended
-DATENAME	Calculation	tdvt/exprtests/standard	date.now	==	Recommended
-DATENAME	Filters	tdvt/exprtests/standard	date.now	MAX	Recommended
-DATEPART	Domain	tdvt/exprtests/standard	date.now	MAX	Recommended
-DATEPART	Aggregation	tdvt/exprtests/standard	date.now	MAX	Recommended
-DATEPART	Calculation	tdvt/exprtests/standard	date.now	MAX	Recommended
-DATEPART	Date Aggregation	tdvt/exprtests/standard	date.now	DATEPART	Recommended
-DATETRUNC	Date Filters	tdvt/exprtests/standard	date.now	DATEPART	Recommended
-DATETRUNC	Calculation	tdvt/exprtests/standard	date.now	DATEPART	Recommended
-DATEADD	Date Filters	tdvt/exprtests/standard	date.now	NOW	Recommended
-DATEADD	Calculation	tdvt/exprtests/standard	date.now	NOW	Recommended
-DATEDIFF	Date Filters	tdvt/exprtests/standard	date.now	NOW	Recommended
-DATENAME	Calculation	tdvt/exprtests/standard	date.now	NOW	Recommended
-DATENAME	Reference Line	tdvt/exprtests/standard	date.today	COUNT	Required
-DATENAME	Filters	tdvt/exprtests/standard	date.today	COUNT	Required
-DATEPART	Domain	tdvt/exprtests/standard	date.today	COUNT	Required
-DATEPART	Aggregation	tdvt/exprtests/standard	date.today	COUNT	Required
-DATEPART	Calculation	tdvt/exprtests/standard	date.today	COUNT	Required
-DATEPART	Date Aggregation	tdvt/exprtests/standard	date.today	DATEPART	Required
-DATETRUNC	Date Filters	tdvt/exprtests/standard	date.today	DATEPART	Required
-DATETRUNC	Calculation	tdvt/exprtests/standard	date.today	DATEPART	Required
-COUNT	Filters	tdvt/exprtests/standard	date.today	MIN	Required
-COUNT	Domain	tdvt/exprtests/standard	date.today	MIN	Required
-COUNT	Aggregation	tdvt/exprtests/standard	date.today	MIN	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.today	MIN	Required
-COUNT	Filters	tdvt/exprtests/standard	date.today	==	Required
-COUNT	Operator	tdvt/exprtests/standard	date.today	==	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.today	==	Required
-COUNT	Filters	tdvt/exprtests/standard	date.today	MAX	Required
-COUNT	Domain	tdvt/exprtests/standard	date.today	MAX	Required
-COUNT	Aggregation	tdvt/exprtests/standard	date.today	MAX	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.today	MAX	Required
-COUNT	Date Aggregation	tdvt/exprtests/standard	date.today	DATEPART	Required
-COUNT	Date Filters	tdvt/exprtests/standard	date.today	DATEPART	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.today	DATEPART	Required
-COUNT	Date Filters	tdvt/exprtests/standard	date.today	TODAY	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.today	TODAY	Required
-COUNT	Date Filters	tdvt/exprtests/standard	date.today	TODAY	Required
-COUNT	Calculation	tdvt/exprtests/standard	date.today	TODAY	Required
-COUNT	Cast	tdvt/exprtests/standard	datetime.cast.date	DATE	Required
-COUNT	Calculation	tdvt/exprtests/standard	datetime.cast.date	DATE	Required
-COUNT	Data Prep	tdvt/exprtests/standard	datetime.cast.float	FLOAT	Required
-COUNT	Cast	tdvt/exprtests/standard	datetime.cast.float	FLOAT	Required
-COUNT	Calculation	tdvt/exprtests/standard	datetime.cast.float	FLOAT	Required
-COUNT	Calculation	tdvt/exprtests/standard	datetime.cast.str	STR	Required
-COUNT	Calculation	tdvt/exprtests/standard	datetime.cast.str	TRIM	Required
-COUNT	Cast	tdvt/exprtests/standard	datetime.cast.str	STR	Required
-COUNT	Data Prep	tdvt/exprtests/standard	datetime.cast.str	TRIM	Required
-COUNT	Filters	tdvt/exprtests/standard	datetime.cast.str	STR	Required
-COUNT	Filters	tdvt/logicaltests/staples	Filter.Add_to_context	==	Required
-COUNT	Operator	tdvt/logicaltests/staples	Filter.Add_to_context	==	Required
-	Calculation	tdvt/logicaltests/staples	Filter.Add_to_context	==	Required
-	Data Prep	tdvt/logicaltests/staples	Filter.Add_to_context	!	Required
-AVG	Operator	tdvt/logicaltests/staples	Filter.Add_to_context	!	Required
-COUNT	Calculation	tdvt/logicaltests/staples	Filter.Add_to_context	!	Required
-SUM	Reference Line	tdvt/logicaltests/staples	Filter.Add_to_context	SUM	Required
-/	Filters	tdvt/logicaltests/staples	Filter.Add_to_context	SUM	Required
-AVG	Aggregation	tdvt/logicaltests/staples	Filter.Add_to_context	SUM	Required
-COUNT	Calculation	tdvt/logicaltests/staples	Filter.Add_to_context	SUM	Required
-EXCLUDE		tdvt/logicaltests/staples	Filter.Add_to_context	$SYS_NARY_AND$	Required
-FIXED		tdvt/logicaltests/calcs	Filter.Date_In	$IN_SET$	Required
-SUM	Filters	tdvt/logicaltests/calcs	Filter.datetime_fractional	==	Recommended
-COUNT	Operator	tdvt/logicaltests/calcs	Filter.datetime_fractional	==	Recommended
-AVG	Calculation	tdvt/logicaltests/calcs	Filter.datetime_fractional	==	Recommended
-COUNT	Temp Tables and Subqueries	tdvt/logicaltests/calcs	Filter.datetime_fractional	TEMP_TABLES_AND_SUBQUERIES	Recommended
-SUM	Filters	tdvt/logicaltests/calcs	Filter.datetime_fractional	TEMP_TABLES_AND_SUBQUERIES	Recommended
-EXCLUDE	Date Aggregation	tdvt/logicaltests/calcs	Filter.datetime_fractional	DATETIME	Recommended
-FIXED	Date Filters	tdvt/logicaltests/calcs	Filter.datetime_fractional	DATETIME	Recommended
-/	Calculation	tdvt/logicaltests/calcs	Filter.datetime_fractional	DATETIME	Recommended
-AVG	Data Prep	tdvt/logicaltests/calcs	Filter.Exclude-list-not-null	!	Required
-COUNT	Operator	tdvt/logicaltests/calcs	Filter.Exclude-list-not-null	!	Required
-SUM	Calculation	tdvt/logicaltests/calcs	Filter.Exclude-list-not-null	!	Required
-	NULL Semantics	tdvt/logicaltests/calcs	Filter.Exclude-list-not-null	ISNULL	Required
-	Calculation	tdvt/logicaltests/calcs	Filter.Exclude-list-not-null	ISNULL	Required
-		tdvt/logicaltests/calcs	Filter.Exclude-list-not-null	$SYS_NARY_OR$	Required
-		tdvt/logicaltests/calcs	Filter.Exclude-list-not-null	$IN_SET$	Required
-		tdvt/logicaltests/calcs	Filter.Exclude-range-not-null	$SYS_NARY_AND$	Required
-AVG		tdvt/logicaltests/calcs	Filter.Exclude-range-not-null	$SYS_NARY_OR$	Required
-COUNT	Calculation	tdvt/logicaltests/calcs	Filter.Exclude-range-not-null	!	Required
-COUNT	Calculation	tdvt/logicaltests/calcs	Filter.Exclude-range-not-null	<=	Required
-COUNT	Calculation	tdvt/logicaltests/calcs	Filter.Exclude-range-not-null	>=	Required
-COUNT	Calculation	tdvt/logicaltests/calcs	Filter.Exclude-range-not-null	ISNULL	Required
-COUNT	Data Prep	tdvt/logicaltests/calcs	Filter.Exclude-range-not-null	!	Required
-COUNT	Filters	tdvt/logicaltests/calcs	Filter.Exclude-range-not-null	<=	Required
-COUNT	Filters	tdvt/logicaltests/calcs	Filter.Exclude-range-not-null	>=	Required
-COUNT	NULL Semantics	tdvt/logicaltests/calcs	Filter.Exclude-range-not-null	ISNULL	Required
-COUNT	Operator	tdvt/logicaltests/calcs	Filter.Exclude-range-not-null	!	Required
-COUNT	Operator	tdvt/logicaltests/calcs	Filter.Exclude-range-not-null	<=	Required
-COUNT	Operator	tdvt/logicaltests/calcs	Filter.Exclude-range-not-null	>=	Required
-COUNT	Reference Line	tdvt/logicaltests/calcs	Filter.FilterBy-to-no-results	SUM	Required
-COUNT	Filters	tdvt/logicaltests/calcs	Filter.FilterBy-to-no-results	SUM	Required
-COUNT	Aggregation	tdvt/logicaltests/calcs	Filter.FilterBy-to-no-results	SUM	Required
-COUNT	Calculation	tdvt/logicaltests/calcs	Filter.FilterBy-to-no-results	SUM	Required
-COUNT	Filters	tdvt/logicaltests/calcs	Filter.FilterBy-to-no-results	>	Required
-COUNT	Operator	tdvt/logicaltests/calcs	Filter.FilterBy-to-no-results	>	Required
-COUNT	Calculation	tdvt/logicaltests/calcs	Filter.FilterBy-to-no-results	>	Required
-COUNT		tdvt/logicaltests/staples	Filter.Q_date_instance_filter	$SYS_NARY_AND$	Required
-COUNT	Aggregation	tdvt/logicaltests/staples	Filter.Q_date_instance_filter	COUNT	Required
-COUNT	Calculation	tdvt/logicaltests/staples	Filter.Q_date_instance_filter	<=	Required
-COUNT	Calculation	tdvt/logicaltests/staples	Filter.Q_date_instance_filter	>=	Required
-COUNT	Calculation	tdvt/logicaltests/staples	Filter.Q_date_instance_filter	COUNT	Required
-COUNT	Domain	tdvt/logicaltests/staples	Filter.Q_date_instance_filter	COUNT	Required
-COUNT	Filters	tdvt/logicaltests/staples	Filter.Q_date_instance_filter	<=	Required
-COUNT	Filters	tdvt/logicaltests/staples	Filter.Q_date_instance_filter	>=	Required
-COUNT	Filters	tdvt/logicaltests/staples	Filter.Q_date_instance_filter	COUNT	Required
-COUNTD	Operator	tdvt/logicaltests/staples	Filter.Q_date_instance_filter	<=	Required
-COUNTD	Operator	tdvt/logicaltests/staples	Filter.Q_date_instance_filter	>=	Required
-MAX	Reference Line	tdvt/logicaltests/staples	Filter.Q_date_instance_filter	COUNT	Required
-MAX	Reference Line	tdvt/logicaltests/staples	Filter.Q_date_month_instance_filter	SUM	Required
-MAX	Filters	tdvt/logicaltests/staples	Filter.Q_date_month_instance_filter	SUM	Required
-MAX	Aggregation	tdvt/logicaltests/staples	Filter.Q_date_month_instance_filter	SUM	Required
-MAX	Calculation	tdvt/logicaltests/staples	Filter.Q_date_month_instance_filter	SUM	Required
-MAX	Date Aggregation	tdvt/logicaltests/staples	Filter.Q_date_month_instance_filter	DATEPART	Required
-MAX	Date Filters	tdvt/logicaltests/staples	Filter.Q_date_month_instance_filter	DATEPART	Required
-MAX	Calculation	tdvt/logicaltests/staples	Filter.Q_date_month_instance_filter	DATEPART	Required
-MAX	Filters	tdvt/logicaltests/staples	Filter.Q_date_month_instance_filter	<=	Required
-MAX	Operator	tdvt/logicaltests/staples	Filter.Q_date_month_instance_filter	<=	Required
-MAX	Calculation	tdvt/logicaltests/staples	Filter.Q_date_month_instance_filter	<=	Required
-MIN	Aggregation	tdvt/logicaltests/calcs	Filter.QFilter-max-NotNull	SUM	Required
-MIN	Calculation	tdvt/logicaltests/calcs	Filter.QFilter-max-NotNull	<=	Required
-MIN	Calculation	tdvt/logicaltests/calcs	Filter.QFilter-max-NotNull	SUM	Required
-MIN	Filters	tdvt/logicaltests/calcs	Filter.QFilter-max-NotNull	<=	Required
-MIN	Filters	tdvt/logicaltests/calcs	Filter.QFilter-max-NotNull	SUM	Required
-MIN	Operator	tdvt/logicaltests/calcs	Filter.QFilter-max-NotNull	<=	Required
-MIN	Reference Line	tdvt/logicaltests/calcs	Filter.QFilter-max-NotNull	SUM	Required
-MIN		tdvt/logicaltests/calcs	Filter.QFilter-max-Null	$SYS_NARY_OR$	Required
-SUM	NULL Semantics	tdvt/logicaltests/calcs	Filter.QFilter-max-Null	ISNULL	Required
-SUM	Calculation	tdvt/logicaltests/calcs	Filter.QFilter-max-Null	ISNULL	Required
-VAR	Reference Line	tdvt/logicaltests/calcs	Filter.QFilter-max-Null	SUM	Required
-VARP	Filters	tdvt/logicaltests/calcs	Filter.QFilter-max-Null	SUM	Required
-!	Aggregation	tdvt/logicaltests/calcs	Filter.QFilter-max-Null	SUM	Required
-!=	Calculation	tdvt/logicaltests/calcs	Filter.QFilter-max-Null	SUM	Required
-!=	Filters	tdvt/logicaltests/calcs	Filter.QFilter-max-Null	<=	Required
-!=	Operator	tdvt/logicaltests/calcs	Filter.QFilter-max-Null	<=	Required
-!=	Calculation	tdvt/logicaltests/calcs	Filter.QFilter-max-Null	<=	Required
-!=	Reference Line	tdvt/logicaltests/calcs	Filter.QFilter-minmax-NotNull	SUM	Required
-%	Filters	tdvt/logicaltests/calcs	Filter.QFilter-minmax-NotNull	SUM	Required
-&&	Aggregation	tdvt/logicaltests/calcs	Filter.QFilter-minmax-NotNull	SUM	Required
-*	Calculation	tdvt/logicaltests/calcs	Filter.QFilter-minmax-NotNull	SUM	Required
-*	Filters	tdvt/logicaltests/calcs	Filter.QFilter-minmax-NotNull	<=	Required
-+	Operator	tdvt/logicaltests/calcs	Filter.QFilter-minmax-NotNull	<=	Required
-+	Calculation	tdvt/logicaltests/calcs	Filter.QFilter-minmax-NotNull	<=	Required
-+	Filters	tdvt/logicaltests/calcs	Filter.QFilter-minmax-NotNull	>=	Required
-+	Operator	tdvt/logicaltests/calcs	Filter.QFilter-minmax-NotNull	>=	Required
-+	Calculation	tdvt/logicaltests/calcs	Filter.QFilter-minmax-NotNull	>=	Required
-+		tdvt/logicaltests/calcs	Filter.QFilter-minmax-NotNull	$SYS_NARY_AND$	Required
-+		tdvt/logicaltests/calcs	Filter.QFilter-minmax-Null	$SYS_NARY_AND$	Required
-+		tdvt/logicaltests/calcs	Filter.QFilter-minmax-Null	$SYS_NARY_OR$	Required
-+	Aggregation	tdvt/logicaltests/calcs	Filter.QFilter-minmax-Null	SUM	Required
-+	Calculation	tdvt/logicaltests/calcs	Filter.QFilter-minmax-Null	<=	Required
-+	Calculation	tdvt/logicaltests/calcs	Filter.QFilter-minmax-Null	>=	Required
-+	Calculation	tdvt/logicaltests/calcs	Filter.QFilter-minmax-Null	ISNULL	Required
--	Calculation	tdvt/logicaltests/calcs	Filter.QFilter-minmax-Null	SUM	Required
--	Filters	tdvt/logicaltests/calcs	Filter.QFilter-minmax-Null	<=	Required
--	Filters	tdvt/logicaltests/calcs	Filter.QFilter-minmax-Null	>=	Required
--	Filters	tdvt/logicaltests/calcs	Filter.QFilter-minmax-Null	SUM	Required
--	NULL Semantics	tdvt/logicaltests/calcs	Filter.QFilter-minmax-Null	ISNULL	Required
-/	Operator	tdvt/logicaltests/calcs	Filter.QFilter-minmax-Null	<=	Required
-/	Operator	tdvt/logicaltests/calcs	Filter.QFilter-minmax-Null	>=	Required
-/	Reference Line	tdvt/logicaltests/calcs	Filter.QFilter-minmax-Null	SUM	Required
-/	Aggregation	tdvt/logicaltests/calcs	Filter.QFilter-min-NotNull	SUM	Required
-<	Calculation	tdvt/logicaltests/calcs	Filter.QFilter-min-NotNull	>=	Required
-<	Calculation	tdvt/logicaltests/calcs	Filter.QFilter-min-NotNull	SUM	Required
-<	Filters	tdvt/logicaltests/calcs	Filter.QFilter-min-NotNull	>=	Required
-<	Filters	tdvt/logicaltests/calcs	Filter.QFilter-min-NotNull	SUM	Required
-<=	Operator	tdvt/logicaltests/calcs	Filter.QFilter-min-NotNull	>=	Required
-<=	Reference Line	tdvt/logicaltests/calcs	Filter.QFilter-min-NotNull	SUM	Required
-<=		tdvt/logicaltests/calcs	Filter.QFilter-min-Null	$SYS_NARY_OR$	Required
-<=	Aggregation	tdvt/logicaltests/calcs	Filter.QFilter-min-Null	SUM	Required
-==	Calculation	tdvt/logicaltests/calcs	Filter.QFilter-min-Null	>=	Required
-==	Calculation	tdvt/logicaltests/calcs	Filter.QFilter-min-Null	ISNULL	Required
-==	Calculation	tdvt/logicaltests/calcs	Filter.QFilter-min-Null	SUM	Required
-==	Filters	tdvt/logicaltests/calcs	Filter.QFilter-min-Null	>=	Required
-==	Filters	tdvt/logicaltests/calcs	Filter.QFilter-min-Null	SUM	Required
-==	NULL Semantics	tdvt/logicaltests/calcs	Filter.QFilter-min-Null	ISNULL	Required
-==	Operator	tdvt/logicaltests/calcs	Filter.QFilter-min-Null	>=	Required
->	Reference Line	tdvt/logicaltests/calcs	Filter.QFilter-min-Null	SUM	Required
->	Aggregation	tdvt/logicaltests/calcs	Filter.QFilter-NotNull	SUM	Required
->	Calculation	tdvt/logicaltests/calcs	Filter.QFilter-NotNull	!	Required
->	Calculation	tdvt/logicaltests/calcs	Filter.QFilter-NotNull	ISNULL	Required
->=	Calculation	tdvt/logicaltests/calcs	Filter.QFilter-NotNull	SUM	Required
->=	Data Prep	tdvt/logicaltests/calcs	Filter.QFilter-NotNull	!	Required
->=	Filters	tdvt/logicaltests/calcs	Filter.QFilter-NotNull	SUM	Required
-ABS	NULL Semantics	tdvt/logicaltests/calcs	Filter.QFilter-NotNull	ISNULL	Required
-ABS	Operator	tdvt/logicaltests/calcs	Filter.QFilter-NotNull	!	Required
-ABS	Reference Line	tdvt/logicaltests/calcs	Filter.QFilter-NotNull	SUM	Required
-ABS	Aggregation	tdvt/logicaltests/calcs	Filter.QFilter-Null	SUM	Required
-ACOS	Calculation	tdvt/logicaltests/calcs	Filter.QFilter-Null	ISNULL	Required
-ACOS	Calculation	tdvt/logicaltests/calcs	Filter.QFilter-Null	SUM	Required
-ASCII	Filters	tdvt/logicaltests/calcs	Filter.QFilter-Null	SUM	Required
-ASCII	NULL Semantics	tdvt/logicaltests/calcs	Filter.QFilter-Null	ISNULL	Required
-ASIN	Reference Line	tdvt/logicaltests/calcs	Filter.QFilter-Null	SUM	Required
-ASIN		tdvt/logicaltests/staples	Filter.slicing_Q_date_instance_filter	$SYS_NARY_AND$	Required
-ATAN	Aggregation	tdvt/logicaltests/staples	Filter.slicing_Q_date_instance_filter	SUM	Required
-ATAN	Calculation	tdvt/logicaltests/staples	Filter.slicing_Q_date_instance_filter	<=	Required
-ATAN2	Calculation	tdvt/logicaltests/staples	Filter.slicing_Q_date_instance_filter	>=	Required
-ATAN2	Calculation	tdvt/logicaltests/staples	Filter.slicing_Q_date_instance_filter	SUM	Required
-AVG	Filters	tdvt/logicaltests/staples	Filter.slicing_Q_date_instance_filter	<=	Required
-CEILING	Filters	tdvt/logicaltests/staples	Filter.slicing_Q_date_instance_filter	>=	Required
-CONTAINS	Filters	tdvt/logicaltests/staples	Filter.slicing_Q_date_instance_filter	SUM	Required
-COS	Operator	tdvt/logicaltests/staples	Filter.slicing_Q_date_instance_filter	<=	Required
-COS	Operator	tdvt/logicaltests/staples	Filter.slicing_Q_date_instance_filter	>=	Required
-COT	Reference Line	tdvt/logicaltests/staples	Filter.slicing_Q_date_instance_filter	SUM	Required
-COT	Date Aggregation	tdvt/logicaltests/staples	Filter.slicing_Q_date_month_instance_filter	DATEPART	Required
-COUNT	Date Filters	tdvt/logicaltests/staples	Filter.slicing_Q_date_month_instance_filter	DATEPART	Required
-COUNT	Calculation	tdvt/logicaltests/staples	Filter.slicing_Q_date_month_instance_filter	DATEPART	Required
-COUNT		tdvt/logicaltests/calcs	Filter.TopN-context	$SYS_NARY_AND$	Required
-COUNT		tdvt/logicaltests/calcs	Filter.TopN-context	$SYS_NARY_OR$	Required
-COUNT	Aggregation	tdvt/logicaltests/calcs	Filter.TopN-context	COUNT	Required
-COUNT	Aggregation	tdvt/logicaltests/calcs	Filter.TopN-context	SUM	Required
-COUNT	Calculation	tdvt/logicaltests/calcs	Filter.TopN-context	<=	Required
-COUNT	Calculation	tdvt/logicaltests/calcs	Filter.TopN-context	>=	Required
-COUNT	Calculation	tdvt/logicaltests/calcs	Filter.TopN-context	COUNT	Required
-COUNT	Calculation	tdvt/logicaltests/calcs	Filter.TopN-context	SUM	Required
-COUNT	Domain	tdvt/logicaltests/calcs	Filter.TopN-context	COUNT	Required
-COUNT	Filters	tdvt/logicaltests/calcs	Filter.TopN-context	<=	Required
-COUNT	Filters	tdvt/logicaltests/calcs	Filter.TopN-context	>=	Required
-COUNT	Filters	tdvt/logicaltests/calcs	Filter.TopN-context	COUNT	Required
-COUNT	Filters	tdvt/logicaltests/calcs	Filter.TopN-context	SUM	Required
-COUNT	Filters	tdvt/logicaltests/calcs	Filter.TopN-context	TEMP_TABLES_AND_SUBQUERIES	Required
-COUNT	Operator	tdvt/logicaltests/calcs	Filter.TopN-context	<=	Required
-COUNT	Operator	tdvt/logicaltests/calcs	Filter.TopN-context	>=	Required
-COUNT	Reference Line	tdvt/logicaltests/calcs	Filter.TopN-context	COUNT	Required
-COUNT	Reference Line	tdvt/logicaltests/calcs	Filter.TopN-context	SUM	Required
-COUNT	Temp Tables and Subqueries	tdvt/logicaltests/calcs	Filter.TopN-context	TEMP_TABLES_AND_SUBQUERIES	Required
-COUNT		tdvt/logicaltests/staples	Filter.Trademark	$IN_SET$	Smoke
-COUNT		tdvt/logicaltests/staples	Filter.Trademark	$SYS_NARY_OR$	Smoke
-COUNT	Filters	tdvt/logicaltests/staples	Filter.Trademark	>=	Smoke
-COUNT	Operator	tdvt/logicaltests/staples	Filter.Trademark	>=	Smoke
-COUNT	Calculation	tdvt/logicaltests/staples	Filter.Trademark	>=	Smoke
-COUNT		tdvt/logicaltests/staples	Filter.Trademark	$SYS_NARY_AND$	Smoke
-COUNTD	Reference Line	tdvt/logicaltests/staples	Filter.Trademark	SUM	Smoke
-COUNTD	Filters	tdvt/logicaltests/staples	Filter.Trademark	SUM	Smoke
-DATE	Aggregation	tdvt/logicaltests/staples	Filter.Trademark	SUM	Smoke
-DATE	Calculation	tdvt/logicaltests/staples	Filter.Trademark	SUM	Smoke
-DATE	Filters	tdvt/logicaltests/staples	Filter.Trademark	<=	Smoke
-DATE	Operator	tdvt/logicaltests/staples	Filter.Trademark	<=	Smoke
-DATE	Calculation	tdvt/logicaltests/staples	Filter.Trademark	<=	Smoke
-DATE	Aggregation	tdvt/logicaltests/calcs	join.null.bool	SUM	Required If Supported
-DATE	Calculation	tdvt/logicaltests/calcs	join.null.bool	SUM	Required If Supported
-DATE	Column Metadata Nullability	tdvt/logicaltests/calcs	join.null.bool	COLUMN_NULLABILITY	Required If Supported
-DATE	Filters	tdvt/logicaltests/calcs	join.null.bool	SUM	Required If Supported
-DATE	Reference Line	tdvt/logicaltests/calcs	join.null.bool	SUM	Required If Supported
-DATE	Aggregation	tdvt/logicaltests/calcs	join.null.date	SUM	Required If Supported
-DATEADD	Calculation	tdvt/logicaltests/calcs	join.null.date	SUM	Required If Supported
-DATEADD	Column Metadata Nullability	tdvt/logicaltests/calcs	join.null.date	COLUMN_NULLABILITY	Required If Supported
-DATEADD	Filters	tdvt/logicaltests/calcs	join.null.date	SUM	Required If Supported
-DATEADD	Reference Line	tdvt/logicaltests/calcs	join.null.date	SUM	Required If Supported
-DATEADD	Aggregation	tdvt/logicaltests/calcs	join.null.datetime	SUM	Required If Supported
-DATEADD	Calculation	tdvt/logicaltests/calcs	join.null.datetime	DATETIME	Required If Supported
-DATEADD	Calculation	tdvt/logicaltests/calcs	join.null.datetime	SUM	Required If Supported
-DATEADD	Column Metadata Nullability	tdvt/logicaltests/calcs	join.null.datetime	COLUMN_NULLABILITY	Required If Supported
-DATEADD	Date Aggregation	tdvt/logicaltests/calcs	join.null.datetime	DATETIME	Required If Supported
-DATEADD	Date Filters	tdvt/logicaltests/calcs	join.null.datetime	DATETIME	Required If Supported
-DATEADD	Filters	tdvt/logicaltests/calcs	join.null.datetime	SUM	Required If Supported
-DATEADD	Reference Line	tdvt/logicaltests/calcs	join.null.datetime	SUM	Required If Supported
-DATEDIFF	Aggregation	tdvt/logicaltests/calcs	join.null.int	SUM	Required If Supported
-DATEDIFF	Calculation	tdvt/logicaltests/calcs	join.null.int	SUM	Required If Supported
-DATEDIFF	Column Metadata Nullability	tdvt/logicaltests/calcs	join.null.int	COLUMN_NULLABILITY	Required If Supported
-DATEDIFF	Filters	tdvt/logicaltests/calcs	join.null.int	SUM	Required If Supported
-DATEDIFF	Reference Line	tdvt/logicaltests/calcs	join.null.int	SUM	Required If Supported
-DATEDIFF	Aggregation	tdvt/logicaltests/calcs	join.null.real	SUM	Required If Supported
-DATEDIFF	Calculation	tdvt/logicaltests/calcs	join.null.real	SUM	Required If Supported
-DATEDIFF	Column Metadata Nullability	tdvt/logicaltests/calcs	join.null.real	COLUMN_NULLABILITY	Required If Supported
-DATEDIFF	Filters	tdvt/logicaltests/calcs	join.null.real	SUM	Required If Supported
-DATEDIFF	Reference Line	tdvt/logicaltests/calcs	join.null.real	SUM	Required If Supported
-DATEDIFF	Column Metadata Nullability	tdvt/logicaltests/calcs	join.null.str	COLUMN_NULLABILITY	Required If Supported
-DATEDIFF	Reference Line	tdvt/logicaltests/calcs	join.null.str	SUM	Required If Supported
-DATEDIFF	Filters	tdvt/logicaltests/calcs	join.null.str	SUM	Required If Supported
-DATEDIFF	Aggregation	tdvt/logicaltests/calcs	join.null.str	SUM	Required If Supported
-DATENAME	Calculation	tdvt/logicaltests/calcs	join.null.str	SUM	Required If Supported
-DATENAME	Reference Line	tdvt/logicaltests/lod	lod.1_Difference From with Cross Join	COUNT	Required If Supported
-DATENAME	Filters	tdvt/logicaltests/lod	lod.1_Difference From with Cross Join	COUNT	Required If Supported
-DATENAME	Domain	tdvt/logicaltests/lod	lod.1_Difference From with Cross Join	COUNT	Required If Supported
-DATENAME	Aggregation	tdvt/logicaltests/lod	lod.1_Difference From with Cross Join	COUNT	Required If Supported
-DATENAME	Calculation	tdvt/logicaltests/lod	lod.1_Difference From with Cross Join	COUNT	Required If Supported
-DATENAME	Level of Detail	tdvt/logicaltests/lod	lod.1_Difference From with Cross Join	LOD_STYLE_JOIN	Required If Supported
-DATENAME	Date Aggregation	tdvt/logicaltests/lod	lod.1_Difference From with Cross Join	DATEDIFF	Required If Supported
-DATENAME	Date Filters	tdvt/logicaltests/lod	lod.1_Difference From with Cross Join	DATEDIFF	Required If Supported
-DATENAME	Calculation	tdvt/logicaltests/lod	lod.1_Difference From with Cross Join	DATEDIFF	Required If Supported
-DATENAME	Reference Line	tdvt/logicaltests/lod	lod.1_Difference From with Cross Join	SUM	Required If Supported
-DATENAME	Filters	tdvt/logicaltests/lod	lod.1_Difference From with Cross Join	SUM	Required If Supported
-DATENAME	Aggregation	tdvt/logicaltests/lod	lod.1_Difference From with Cross Join	SUM	Required If Supported
-DATEPART	Calculation	tdvt/logicaltests/lod	lod.1_Difference From with Cross Join	SUM	Required If Supported
-DATEPART	Filters	tdvt/logicaltests/lod	lod.1_Difference From with Cross Join	MIN	Required If Supported
-DATEPART	Domain	tdvt/logicaltests/lod	lod.1_Difference From with Cross Join	MIN	Required If Supported
-DATEPART	Aggregation	tdvt/logicaltests/lod	lod.1_Difference From with Cross Join	MIN	Required If Supported
-DATEPART	Calculation	tdvt/logicaltests/lod	lod.1_Difference From with Cross Join	MIN	Required If Supported
-DATEPART	Aggregation	tdvt/logicaltests/lod	lod.10_As in-out Set	MIN	Required If Supported
-DATEPART	Calculation	tdvt/logicaltests/lod	lod.10_As in-out Set	MIN	Required If Supported
-DATEPART	Domain	tdvt/logicaltests/lod	lod.10_As in-out Set	MIN	Required If Supported
-DATEPART	Filters	tdvt/logicaltests/lod	lod.10_As in-out Set	MIN	Required If Supported
-DATEPART	Level of Detail	tdvt/logicaltests/lod	lod.10_As in-out Set	LOD_STYLE_JOIN	Required If Supported
-DATEPART	Aggregation	tdvt/logicaltests/lod	lod.11_As in-out Set	MIN	Required If Supported
-DATEPART	Calculation	tdvt/logicaltests/lod	lod.11_As in-out Set	ISNULL	Required If Supported
-DATEPART	Calculation	tdvt/logicaltests/lod	lod.11_As in-out Set	MIN	Required If Supported
-DATETIME	Domain	tdvt/logicaltests/lod	lod.11_As in-out Set	MIN	Required If Supported
-DATETIME	Filters	tdvt/logicaltests/lod	lod.11_As in-out Set	MIN	Required If Supported
-DATETIME	Filters	tdvt/logicaltests/lod	lod.11_As in-out Set	TEMP_TABLES_AND_SUBQUERIES	Required If Supported
-DATETIME	Level of Detail	tdvt/logicaltests/lod	lod.11_As in-out Set	LOD_STYLE_JOIN	Required If Supported
-DATETIME	NULL Semantics	tdvt/logicaltests/lod	lod.11_As in-out Set	ISNULL	Required If Supported
-DATETIME	Temp Tables and Subqueries	tdvt/logicaltests/lod	lod.11_As in-out Set	TEMP_TABLES_AND_SUBQUERIES	Required If Supported
-DATETIME	Aggregation	tdvt/logicaltests/lod	lod.12_As in-out Set	MIN	Required If Supported
-DATETIME	Calculation	tdvt/logicaltests/lod	lod.12_As in-out Set	MIN	Required If Supported
-DATETIME	Domain	tdvt/logicaltests/lod	lod.12_As in-out Set	MIN	Required If Supported
-DATETIME	Filters	tdvt/logicaltests/lod	lod.12_As in-out Set	MIN	Required If Supported
-DATETIME	Level of Detail	tdvt/logicaltests/lod	lod.12_As in-out Set	LOD_STYLE_JOIN	Required If Supported
-DATETIME	Aggregation	tdvt/logicaltests/lod	lod.13_As in-out Set	MIN	Required If Supported
-DATETIME	Calculation	tdvt/logicaltests/lod	lod.13_As in-out Set	ISNULL	Required If Supported
-DATETIME	Calculation	tdvt/logicaltests/lod	lod.13_As in-out Set	MIN	Required If Supported
-DATETIME	Domain	tdvt/logicaltests/lod	lod.13_As in-out Set	MIN	Required If Supported
-DATETIME	Filters	tdvt/logicaltests/lod	lod.13_As in-out Set	MIN	Required If Supported
-DATETRUNC	Filters	tdvt/logicaltests/lod	lod.13_As in-out Set	TEMP_TABLES_AND_SUBQUERIES	Required If Supported
-DATETRUNC	Level of Detail	tdvt/logicaltests/lod	lod.13_As in-out Set	LOD_STYLE_JOIN	Required If Supported
-DATETRUNC	NULL Semantics	tdvt/logicaltests/lod	lod.13_As in-out Set	ISNULL	Required If Supported
-DATETRUNC	Temp Tables and Subqueries	tdvt/logicaltests/lod	lod.13_As in-out Set	TEMP_TABLES_AND_SUBQUERIES	Required If Supported
-DATETRUNC		tdvt/logicaltests/lod	lod.14_As in-out Set	$IN_SET$	Required If Supported
-DATETRUNC	Aggregation	tdvt/logicaltests/lod	lod.14_As in-out Set	AVG	Required If Supported
-DATETRUNC	Aggregation	tdvt/logicaltests/lod	lod.14_As in-out Set	COUNT	Required If Supported
-DATETRUNC	Aggregation	tdvt/logicaltests/lod	lod.14_As in-out Set	MAX	Required If Supported
-DATETRUNC	Aggregation	tdvt/logicaltests/lod	lod.14_As in-out Set	MIN	Required If Supported
-DATETRUNC	Aggregation	tdvt/logicaltests/lod	lod.14_As in-out Set	SUM	Required If Supported
-DATETRUNC	Calculation	tdvt/logicaltests/lod	lod.14_As in-out Set	!	Required If Supported
-DATETRUNC	Calculation	tdvt/logicaltests/lod	lod.14_As in-out Set	AVG	Required If Supported
-FIND	Calculation	tdvt/logicaltests/lod	lod.14_As in-out Set	COUNT	Required If Supported
-FLOAT	Calculation	tdvt/logicaltests/lod	lod.14_As in-out Set	ISNULL	Required If Supported
-FLOAT	Calculation	tdvt/logicaltests/lod	lod.14_As in-out Set	MAX	Required If Supported
-FLOAT	Calculation	tdvt/logicaltests/lod	lod.14_As in-out Set	MIN	Required If Supported
-FLOOR	Calculation	tdvt/logicaltests/lod	lod.14_As in-out Set	SUM	Required If Supported
-HEXBINX	Data Prep	tdvt/logicaltests/lod	lod.14_As in-out Set	!	Required If Supported
-HEXBINY	Domain	tdvt/logicaltests/lod	lod.14_As in-out Set	COUNT	Required If Supported
-IFNULL	Domain	tdvt/logicaltests/lod	lod.14_As in-out Set	MAX	Required If Supported
-IIF	Domain	tdvt/logicaltests/lod	lod.14_As in-out Set	MIN	Required If Supported
-IIF	Filters	tdvt/logicaltests/lod	lod.14_As in-out Set	AVG	Required If Supported
-IIF	Filters	tdvt/logicaltests/lod	lod.14_As in-out Set	COUNT	Required If Supported
-IIF	Filters	tdvt/logicaltests/lod	lod.14_As in-out Set	MAX	Required If Supported
-INT	Filters	tdvt/logicaltests/lod	lod.14_As in-out Set	MIN	Required If Supported
-INT	Filters	tdvt/logicaltests/lod	lod.14_As in-out Set	SUM	Required If Supported
-INT	Level of Detail	tdvt/logicaltests/lod	lod.14_As in-out Set	LOD_STYLE_JOIN	Required If Supported
-INT	NULL Semantics	tdvt/logicaltests/lod	lod.14_As in-out Set	ISNULL	Required If Supported
-INT	Operator	tdvt/logicaltests/lod	lod.14_As in-out Set	!	Required If Supported
-INT	Reference Line	tdvt/logicaltests/lod	lod.14_As in-out Set	AVG	Required If Supported
-INT	Reference Line	tdvt/logicaltests/lod	lod.14_As in-out Set	COUNT	Required If Supported
-INT	Reference Line	tdvt/logicaltests/lod	lod.14_As in-out Set	SUM	Required If Supported
-ISNULL	Reference Line	tdvt/logicaltests/lod	lod.15_As Bin	SUM	Required If Supported
-ISNULL	Filters	tdvt/logicaltests/lod	lod.15_As Bin	SUM	Required If Supported
-LEFT	Aggregation	tdvt/logicaltests/lod	lod.15_As Bin	SUM	Required If Supported
-LEFT	Calculation	tdvt/logicaltests/lod	lod.15_As Bin	SUM	Required If Supported
-LN		tdvt/logicaltests/lod	lod.15_As Bin	SYS_NUMBIN	Required If Supported
-LN	Level of Detail	tdvt/logicaltests/lod	lod.15_As Bin	LOD_STYLE_JOIN	Required If Supported
-LOG		tdvt/logicaltests/lod	lod.16_As Group	$IN_SET$	Required If Supported
-LOG	Aggregation	tdvt/logicaltests/lod	lod.16_As Group	AVG	Required If Supported
-LOWER	Aggregation	tdvt/logicaltests/lod	lod.16_As Group	COUNT	Required If Supported
-LOWER	Aggregation	tdvt/logicaltests/lod	lod.16_As Group	MIN	Required If Supported
-LTRIM	Aggregation	tdvt/logicaltests/lod	lod.16_As Group	SUM	Required If Supported
-MAX	Calculation	tdvt/logicaltests/lod	lod.16_As Group	==	Required If Supported
-MAX	Calculation	tdvt/logicaltests/lod	lod.16_As Group	AVG	Required If Supported
-MAX	Calculation	tdvt/logicaltests/lod	lod.16_As Group	COUNT	Required If Supported
-MAX	Calculation	tdvt/logicaltests/lod	lod.16_As Group	DATEDIFF	Required If Supported
-MAX	Calculation	tdvt/logicaltests/lod	lod.16_As Group	DATEPART	Required If Supported
-MAX	Calculation	tdvt/logicaltests/lod	lod.16_As Group	FLOAT	Required If Supported
-MAX	Calculation	tdvt/logicaltests/lod	lod.16_As Group	MIN	Required If Supported
-MAX	Calculation	tdvt/logicaltests/lod	lod.16_As Group	SUM	Required If Supported
-MAX	Cast	tdvt/logicaltests/lod	lod.16_As Group	FLOAT	Required If Supported
-MAX	Data Prep	tdvt/logicaltests/lod	lod.16_As Group	FLOAT	Required If Supported
-MAX	Date Aggregation	tdvt/logicaltests/lod	lod.16_As Group	DATEDIFF	Required If Supported
-MID	Date Aggregation	tdvt/logicaltests/lod	lod.16_As Group	DATEPART	Required If Supported
-MID	Date Filters	tdvt/logicaltests/lod	lod.16_As Group	DATEDIFF	Required If Supported
-MID	Date Filters	tdvt/logicaltests/lod	lod.16_As Group	DATEPART	Required If Supported
-MID	Domain	tdvt/logicaltests/lod	lod.16_As Group	COUNT	Required If Supported
-MIN	Domain	tdvt/logicaltests/lod	lod.16_As Group	MIN	Required If Supported
-MIN	Filters	tdvt/logicaltests/lod	lod.16_As Group	==	Required If Supported
-MIN	Filters	tdvt/logicaltests/lod	lod.16_As Group	AVG	Required If Supported
-MIN	Filters	tdvt/logicaltests/lod	lod.16_As Group	COUNT	Required If Supported
-MIN	Filters	tdvt/logicaltests/lod	lod.16_As Group	MIN	Required If Supported
-MIN	Filters	tdvt/logicaltests/lod	lod.16_As Group	SUM	Required If Supported
-MIN	Level of Detail	tdvt/logicaltests/lod	lod.16_As Group	LOD_STYLE_JOIN	Required If Supported
-MIN	Operator	tdvt/logicaltests/lod	lod.16_As Group	==	Required If Supported
-NOW	Reference Line	tdvt/logicaltests/lod	lod.16_As Group	AVG	Required If Supported
-POWER	Reference Line	tdvt/logicaltests/lod	lod.16_As Group	COUNT	Required If Supported
-POWER	Reference Line	tdvt/logicaltests/lod	lod.16_As Group	SUM	Required If Supported
-REPLACE	Level of Detail	tdvt/logicaltests/lod	lod.17_Nesting	LOD_STYLE_JOIN	Required If Supported
-REPLACE	Reference Line	tdvt/logicaltests/lod	lod.17_Nesting	AVG	Required If Supported
-RIGHT	Filters	tdvt/logicaltests/lod	lod.17_Nesting	AVG	Required If Supported
-RIGHT	Aggregation	tdvt/logicaltests/lod	lod.17_Nesting	AVG	Required If Supported
-ROUND	Calculation	tdvt/logicaltests/lod	lod.17_Nesting	AVG	Required If Supported
-ROUND	Operator	tdvt/logicaltests/lod	lod.17_Nesting	+	Required If Supported
-RTRIM	Calculation	tdvt/logicaltests/lod	lod.17_Nesting	+	Required If Supported
-SPLIT	Operator	tdvt/logicaltests/lod	lod.17_Nesting	/	Required If Supported
-SQRT	Calculation	tdvt/logicaltests/lod	lod.17_Nesting	/	Required If Supported
-SQRT	Data Prep	tdvt/logicaltests/lod	lod.17_Nesting	FLOAT	Required If Supported
-SQUARE	Cast	tdvt/logicaltests/lod	lod.17_Nesting	FLOAT	Required If Supported
-SQUARE	Calculation	tdvt/logicaltests/lod	lod.17_Nesting	FLOAT	Required If Supported
-STARTSWITH		tdvt/logicaltests/lod	lod.2_Cross Join	$AGGREGATE$	Required If Supported
-STR	Aggregation	tdvt/logicaltests/lod	lod.2_Cross Join	SUM	Required If Supported
-STR	Calculation	tdvt/logicaltests/lod	lod.2_Cross Join	SUM	Required If Supported
-STR	Filters	tdvt/logicaltests/lod	lod.2_Cross Join	SUM	Required If Supported
-STR	Level of Detail	tdvt/logicaltests/lod	lod.2_Cross Join	LOD_STYLE_JOIN	Required If Supported
-STR	Reference Line	tdvt/logicaltests/lod	lod.2_Cross Join	SUM	Required If Supported
-STR		tdvt/logicaltests/lod	lod.3_Disjoint LOD	$AGGREGATE$	Required If Supported
-STR	Aggregation	tdvt/logicaltests/lod	lod.3_Disjoint LOD	SUM	Required If Supported
-STR	Calculation	tdvt/logicaltests/lod	lod.3_Disjoint LOD	SUM	Required If Supported
-SUM	Filters	tdvt/logicaltests/lod	lod.3_Disjoint LOD	SUM	Required If Supported
-SUM	Level of Detail	tdvt/logicaltests/lod	lod.3_Disjoint LOD	LOD_STYLE_JOIN	Required If Supported
-TODAY	Reference Line	tdvt/logicaltests/lod	lod.3_Disjoint LOD	SUM	Required If Supported
-TRIM	Aggregation	tdvt/logicaltests/lod	lod.4_Subset Fixed	SUM	Required If Supported
-TRIM	Calculation	tdvt/logicaltests/lod	lod.4_Subset Fixed	SUM	Required If Supported
-VAR	Filters	tdvt/logicaltests/lod	lod.4_Subset Fixed	SUM	Required If Supported
-VARP	Level of Detail	tdvt/logicaltests/lod	lod.4_Subset Fixed	LOD_STYLE_JOIN	Required If Supported
-ZN	Reference Line	tdvt/logicaltests/lod	lod.4_Subset Fixed	SUM	Required If Supported
-^^	Aggregation	tdvt/logicaltests/lod	lod.5_Subset Fixed - 2	SUM	Required If Supported
-||	Calculation	tdvt/logicaltests/lod	lod.5_Subset Fixed - 2	FLOAT	Required If Supported
-DATE	Calculation	tdvt/logicaltests/lod	lod.5_Subset Fixed - 2	SUM	Required If Supported
-DATE	Cast	tdvt/logicaltests/lod	lod.5_Subset Fixed - 2	FLOAT	Required If Supported
-DATE	Data Prep	tdvt/logicaltests/lod	lod.5_Subset Fixed - 2	FLOAT	Required If Supported
-DATE	Filters	tdvt/logicaltests/lod	lod.5_Subset Fixed - 2	SUM	Required If Supported
-DATE	Level of Detail	tdvt/logicaltests/lod	lod.5_Subset Fixed - 2	LOD_STYLE_JOIN	Required If Supported
-DATE	Reference Line	tdvt/logicaltests/lod	lod.5_Subset Fixed - 2	SUM	Required If Supported
-DATE	Reference Line	tdvt/logicaltests/lod	lod.6_Include - 1	SUM	Required If Supported
-DATE	Filters	tdvt/logicaltests/lod	lod.6_Include - 1	SUM	Required If Supported
-DATE	Aggregation	tdvt/logicaltests/lod	lod.6_Include - 1	SUM	Required If Supported
-DATE	Calculation	tdvt/logicaltests/lod	lod.6_Include - 1	SUM	Required If Supported
-DATE	Level of Detail	tdvt/logicaltests/lod	lod.6_Include - 1	LOD_STYLE_JOIN	Required If Supported
-FLOAT	Reference Line	tdvt/logicaltests/lod	lod.7_Percent of Total 1	SUM	Required If Supported
-FLOAT	Filters	tdvt/logicaltests/lod	lod.7_Percent of Total 1	SUM	Required If Supported
-FLOAT	Aggregation	tdvt/logicaltests/lod	lod.7_Percent of Total 1	SUM	Required If Supported
-INT	Calculation	tdvt/logicaltests/lod	lod.7_Percent of Total 1	SUM	Required If Supported
-INT	Level of Detail	tdvt/logicaltests/lod	lod.7_Percent of Total 1	LOD_STYLE_JOIN	Required If Supported
-INT	Reference Line	tdvt/logicaltests/lod	lod.8_Precent of Total 2	SUM	Required If Supported
-INT	Filters	tdvt/logicaltests/lod	lod.8_Precent of Total 2	SUM	Required If Supported
-INT	Aggregation	tdvt/logicaltests/lod	lod.8_Precent of Total 2	SUM	Required If Supported
-INT	Calculation	tdvt/logicaltests/lod	lod.8_Precent of Total 2	SUM	Required If Supported
-INT	Level of Detail	tdvt/logicaltests/lod	lod.8_Precent of Total 2	LOD_STYLE_JOIN	Required If Supported
-INT	Aggregation	tdvt/logicaltests/lod	lod.9_Fixed as Dimension	MIN	Required If Supported
-STR	Aggregation	tdvt/logicaltests/lod	lod.9_Fixed as Dimension	SUM	Required If Supported
-STR	Calculation	tdvt/logicaltests/lod	lod.9_Fixed as Dimension	DATEPART	Required If Supported
-STR	Calculation	tdvt/logicaltests/lod	lod.9_Fixed as Dimension	FLOOR	Required If Supported
-STR	Calculation	tdvt/logicaltests/lod	lod.9_Fixed as Dimension	MIN	Required If Supported
-STR	Calculation	tdvt/logicaltests/lod	lod.9_Fixed as Dimension	SUM	Required If Supported
-STR	Date Aggregation	tdvt/logicaltests/lod	lod.9_Fixed as Dimension	DATEPART	Required If Supported
-STR	Date Filters	tdvt/logicaltests/lod	lod.9_Fixed as Dimension	DATEPART	Required If Supported
-STR	Domain	tdvt/logicaltests/lod	lod.9_Fixed as Dimension	MIN	Required If Supported
-COLUMN_NULLABILITY	Filters	tdvt/logicaltests/lod	lod.9_Fixed as Dimension	MIN	Required If Supported
-COLUMN_NULLABILITY	Filters	tdvt/logicaltests/lod	lod.9_Fixed as Dimension	SUM	Required If Supported
-!	Level of Detail	tdvt/logicaltests/lod	lod.9_Fixed as Dimension	LOD_STYLE_JOIN	Required If Supported
-FIND	Reference Line	tdvt/logicaltests/lod	lod.9_Fixed as Dimension	SUM	Required If Supported
-FLOAT	Aggregation	tdvt/logicaltests/lod	lod.calc.1.TopN	MIN	Required If Supported
-FLOAT	Aggregation	tdvt/logicaltests/lod	lod.calc.1.TopN	SUM	Required If Supported
-FLOAT	Calculation	tdvt/logicaltests/lod	lod.calc.1.TopN	FLOOR	Required If Supported
-INT	Calculation	tdvt/logicaltests/lod	lod.calc.1.TopN	MIN	Required If Supported
-INT	Calculation	tdvt/logicaltests/lod	lod.calc.1.TopN	SUM	Required If Supported
-INT	Domain	tdvt/logicaltests/lod	lod.calc.1.TopN	MIN	Required If Supported
-INT	Filters	tdvt/logicaltests/lod	lod.calc.1.TopN	MIN	Required If Supported
-INT	Filters	tdvt/logicaltests/lod	lod.calc.1.TopN	SUM	Required If Supported
-INT	Filters	tdvt/logicaltests/lod	lod.calc.1.TopN	TEMP_TABLES_AND_SUBQUERIES	Required If Supported
-INT	Level of Detail	tdvt/logicaltests/lod	lod.calc.1.TopN	LOD_STYLE_JOIN	Required If Supported
-INT	Reference Line	tdvt/logicaltests/lod	lod.calc.1.TopN	SUM	Required If Supported
-LEFT	Temp Tables and Subqueries	tdvt/logicaltests/lod	lod.calc.1.TopN	TEMP_TABLES_AND_SUBQUERIES	Required If Supported
-LEFT	Aggregation	tdvt/logicaltests/lod	lod.calc.11.Exclude	COUNT	Required If Supported
-MID	Aggregation	tdvt/logicaltests/lod	lod.calc.11.Exclude	SUM	Required If Supported
-MID	Calculation	tdvt/logicaltests/lod	lod.calc.11.Exclude	COUNT	Required If Supported
-MID	Calculation	tdvt/logicaltests/lod	lod.calc.11.Exclude	SUM	Required If Supported
-MID	Domain	tdvt/logicaltests/lod	lod.calc.11.Exclude	COUNT	Required If Supported
-SPLIT	Filters	tdvt/logicaltests/lod	lod.calc.11.Exclude	COUNT	Required If Supported
-TRIM	Filters	tdvt/logicaltests/lod	lod.calc.11.Exclude	SUM	Required If Supported
-TRIM	Level of Detail	tdvt/logicaltests/lod	lod.calc.11.Exclude	LOD_STYLE_JOIN	Required If Supported
-DATEADD	Reference Line	tdvt/logicaltests/lod	lod.calc.11.Exclude	COUNT	Required If Supported
-DATEADD	Reference Line	tdvt/logicaltests/lod	lod.calc.11.Exclude	SUM	Required If Supported
-DATEADD		tdvt/logicaltests/lod	lod.calc.2.Two-level Agg	$AGGREGATE$	Required If Supported
-DATEADD	Level of Detail	tdvt/logicaltests/lod	lod.calc.2.Two-level Agg	LOD_STYLE_JOIN	Required If Supported
-DATEADD	Reference Line	tdvt/logicaltests/lod	lod.calc.2.Two-level Agg	SUM	Required If Supported
-DATEADD	Filters	tdvt/logicaltests/lod	lod.calc.2.Two-level Agg	SUM	Required If Supported
-DATEADD	Aggregation	tdvt/logicaltests/lod	lod.calc.2.Two-level Agg	SUM	Required If Supported
-DATEADD	Calculation	tdvt/logicaltests/lod	lod.calc.2.Two-level Agg	SUM	Required If Supported
-DATEADD	Reference Line	tdvt/logicaltests/lod	lod.calc.2.Two-level Agg	AVG	Required If Supported
-DATEADD	Filters	tdvt/logicaltests/lod	lod.calc.2.Two-level Agg	AVG	Required If Supported
-DATEADD	Aggregation	tdvt/logicaltests/lod	lod.calc.2.Two-level Agg	AVG	Required If Supported
-DATEADD	Calculation	tdvt/logicaltests/lod	lod.calc.2.Two-level Agg	AVG	Required If Supported
-DATEDIFF	Aggregation	tdvt/logicaltests/lod	lod.calc.3.LOD Metadata	SUM	Required If Supported
-DATEDIFF	Calculation	tdvt/logicaltests/lod	lod.calc.3.LOD Metadata	SUM	Required If Supported
-DATEDIFF	Filters	tdvt/logicaltests/lod	lod.calc.3.LOD Metadata	SUM	Required If Supported
-DATEDIFF	Level of Detail	tdvt/logicaltests/lod	lod.calc.3.LOD Metadata	LOD_STYLE_JOIN	Required If Supported
-DATEDIFF	Reference Line	tdvt/logicaltests/lod	lod.calc.3.LOD Metadata	SUM	Required If Supported
-DATEDIFF	Reference Line	tdvt/logicaltests/lod	lod.calc.4.Lookup	SUM	Required If Supported
-DATEDIFF	Filters	tdvt/logicaltests/lod	lod.calc.4.Lookup	SUM	Required If Supported
-DATEDIFF	Aggregation	tdvt/logicaltests/lod	lod.calc.4.Lookup	SUM	Required If Supported
-DATEDIFF	Calculation	tdvt/logicaltests/lod	lod.calc.4.Lookup	SUM	Required If Supported
-DATEDIFF	Level of Detail	tdvt/logicaltests/lod	lod.calc.4.Lookup	LOD_STYLE_JOIN	Required If Supported
-DATEDIFF	Data Prep	tdvt/logicaltests/lod	lod.calc.4.Lookup	FLOAT	Required If Supported
-DATEDIFF	Cast	tdvt/logicaltests/lod	lod.calc.4.Lookup	FLOAT	Required If Supported
-DATEDIFF	Calculation	tdvt/logicaltests/lod	lod.calc.4.Lookup	FLOAT	Required If Supported
-DATEDIFF	Aggregation	tdvt/logicaltests/lod	lod.calc.5.LOD Set	SUM	Required If Supported
-DATENAME	Calculation	tdvt/logicaltests/lod	lod.calc.5.LOD Set	SUM	Required If Supported
-DATENAME	Filters	tdvt/logicaltests/lod	lod.calc.5.LOD Set	SUM	Required If Supported
-DATENAME	Level of Detail	tdvt/logicaltests/lod	lod.calc.5.LOD Set	LOD_STYLE_JOIN	Required If Supported
-DATENAME	Reference Line	tdvt/logicaltests/lod	lod.calc.5.LOD Set	SUM	Required If Supported
-DATENAME	Aggregation	tdvt/logicaltests/lod	lod.calc.6. LOD Dimension	SUM	Required If Supported
-DATENAME	Calculation	tdvt/logicaltests/lod	lod.calc.6. LOD Dimension	SUM	Required If Supported
-DATENAME	Filters	tdvt/logicaltests/lod	lod.calc.6. LOD Dimension	SUM	Required If Supported
-DATENAME	Level of Detail	tdvt/logicaltests/lod	lod.calc.6. LOD Dimension	LOD_STYLE_JOIN	Required If Supported
-DATENAME	Reference Line	tdvt/logicaltests/lod	lod.calc.6. LOD Dimension	SUM	Required If Supported
-DATENAME		tdvt/logicaltests/lod	lod.calc.7. LOD Bins	$AGGREGATE$	Required If Supported
-DATENAME		tdvt/logicaltests/lod	lod.calc.7. LOD Bins	SYS_NUMBIN	Required If Supported
-DATENAME	Aggregation	tdvt/logicaltests/lod	lod.calc.7. LOD Bins	SUM	Required If Supported
-DATENAME	Calculation	tdvt/logicaltests/lod	lod.calc.7. LOD Bins	SUM	Required If Supported
-DATEPART	Filters	tdvt/logicaltests/lod	lod.calc.7. LOD Bins	SUM	Required If Supported
-DATEPART	Level of Detail	tdvt/logicaltests/lod	lod.calc.7. LOD Bins	LOD_STYLE_JOIN	Required If Supported
-DATEPART	Reference Line	tdvt/logicaltests/lod	lod.calc.7. LOD Bins	SUM	Required If Supported
-DATEPART	Reference Line	tdvt/logicaltests/lod	lod.calc.8. Include	SUM	Required If Supported
-DATEPART	Filters	tdvt/logicaltests/lod	lod.calc.8. Include	SUM	Required If Supported
-DATEPART	Aggregation	tdvt/logicaltests/lod	lod.calc.8. Include	SUM	Required If Supported
-DATEPART	Calculation	tdvt/logicaltests/lod	lod.calc.8. Include	SUM	Required If Supported
-DATEPART	Level of Detail	tdvt/logicaltests/lod	lod.calc.8. Include	LOD_STYLE_JOIN	Required If Supported
-DATEPART		tdvt/logicaltests/lod	lod.calc.9.Fixed	$AGGREGATE$	Required If Supported
-DATEPART	Level of Detail	tdvt/logicaltests/lod	lod.calc.9.Fixed	LOD_STYLE_JOIN	Required If Supported
-DATEPART	Reference Line	tdvt/logicaltests/lod	lod.calc.9.Fixed	SUM	Required If Supported
-DATEPART	Filters	tdvt/logicaltests/lod	lod.calc.9.Fixed	SUM	Required If Supported
-DATEPART	Aggregation	tdvt/logicaltests/lod	lod.calc.9.Fixed	SUM	Required If Supported
-DATETIME	Calculation	tdvt/logicaltests/lod	lod.calc.9.Fixed	SUM	Required If Supported
-DATETIME		tdvt/exprtests/lodcalcs	lod.calcs	$AGGREGATE$	Required If Supported
-DATETIME		tdvt/exprtests/lodcalcs	lod.calcs	INDEX	Required If Supported
-DATETIME	Aggregation	tdvt/exprtests/lodcalcs	lod.calcs	AVG	Required If Supported
-DATETIME	Aggregation	tdvt/exprtests/lodcalcs	lod.calcs	COUNT	Required If Supported
-DATETIME	Aggregation	tdvt/exprtests/lodcalcs	lod.calcs	SUM	Required If Supported
-DATETIME	Calculation	tdvt/exprtests/lodcalcs	lod.calcs	/	Required If Supported
-DATETIME	Calculation	tdvt/exprtests/lodcalcs	lod.calcs	AVG	Required If Supported
-DATETIME	Calculation	tdvt/exprtests/lodcalcs	lod.calcs	COUNT	Required If Supported
-DATETIME	Calculation	tdvt/exprtests/lodcalcs	lod.calcs	EXCLUDE	Required If Supported
-DATETIME	Calculation	tdvt/exprtests/lodcalcs	lod.calcs	FIXED	Required If Supported
-DATETIME	Calculation	tdvt/exprtests/lodcalcs	lod.calcs	SUM	Required If Supported
-DATETIME	Domain	tdvt/exprtests/lodcalcs	lod.calcs	COUNT	Required If Supported
-DATETIME	Filters	tdvt/exprtests/lodcalcs	lod.calcs	AVG	Required If Supported
-DATETIME	Filters	tdvt/exprtests/lodcalcs	lod.calcs	COUNT	Required If Supported
-DATETIME	Filters	tdvt/exprtests/lodcalcs	lod.calcs	SUM	Required If Supported
-DATETRUNC	Level of Detail	tdvt/exprtests/lodcalcs	lod.calcs	EXCLUDE	Required If Supported
-DATETRUNC	Level of Detail	tdvt/exprtests/lodcalcs	lod.calcs	FIXED	Required If Supported
-DATETRUNC	Operator	tdvt/exprtests/lodcalcs	lod.calcs	/	Required If Supported
-DATETRUNC	Reference Line	tdvt/exprtests/lodcalcs	lod.calcs	AVG	Required If Supported
-DATETRUNC	Reference Line	tdvt/exprtests/lodcalcs	lod.calcs	COUNT	Required If Supported
-DATETRUNC	Reference Line	tdvt/exprtests/lodcalcs	lod.calcs	SUM	Required If Supported
-DATETRUNC		tdvt/exprtests/standard	logical	$CASE$	Required
-DATETRUNC	Filters	tdvt/exprtests/standard	logical	MIN	Required
-DATETRUNC	Domain	tdvt/exprtests/standard	logical	MIN	Required
-DATETRUNC	Aggregation	tdvt/exprtests/standard	logical	MIN	Required
-DATETRUNC	Calculation	tdvt/exprtests/standard	logical	MIN	Required
-DATETRUNC	Data Prep	tdvt/exprtests/standard	logical	INT	Required
-DATEADD	Cast	tdvt/exprtests/standard	logical	INT	Required
-DATEADD	Calculation	tdvt/exprtests/standard	logical	INT	Required
-DATEADD	Filters	tdvt/exprtests/standard	logical	LOWER	Required
-DATEADD	Calculation	tdvt/exprtests/standard	logical	LOWER	Required
-DATEADD	NULL Semantics	tdvt/exprtests/standard	logical	ISNULL	Required
-DATEADD	Calculation	tdvt/exprtests/standard	logical	ISNULL	Required
-DATEADD	Date Aggregation	tdvt/exprtests/standard	logical	DATEPART	Required
-DATEADD	Date Filters	tdvt/exprtests/standard	logical	DATEPART	Required
-DATEADD	Calculation	tdvt/exprtests/standard	logical	DATEPART	Required
-DATEADD	Operator	tdvt/exprtests/standard	logical	!=	Required
-DATEADD	Calculation	tdvt/exprtests/standard	logical	!=	Required
-DATEADD	Data Prep	tdvt/exprtests/standard	logical	!	Required
-DATEDIFF	Operator	tdvt/exprtests/standard	logical	!	Required
-DATEDIFF	Calculation	tdvt/exprtests/standard	logical	!	Required
-DATEDIFF	Filters	tdvt/exprtests/standard	logical	MIN	Required
-DATEDIFF	Domain	tdvt/exprtests/standard	logical	MIN	Required
-DATEDIFF	Aggregation	tdvt/exprtests/standard	logical	MIN	Required
-DATEDIFF	Calculation	tdvt/exprtests/standard	logical	MIN	Required
-DATEDIFF	Calculation	tdvt/exprtests/standard	logical	IFNULL	Required
-DATEDIFF	Calculation	tdvt/exprtests/standard	logical	IIF	Required
-DATEDIFF	Filters	tdvt/exprtests/standard	logical	>	Required
-DATEDIFF	Operator	tdvt/exprtests/standard	logical	>	Required
-DATEDIFF	Calculation	tdvt/exprtests/standard	logical	>	Required
-DATEDIFF	Reference Line	tdvt/exprtests/standard	logical	COUNT	Required
-DATEDIFF	Filters	tdvt/exprtests/standard	logical	COUNT	Required
-DATEDIFF	Domain	tdvt/exprtests/standard	logical	COUNT	Required
-DATENAME	Aggregation	tdvt/exprtests/standard	logical	COUNT	Required
-DATENAME	Calculation	tdvt/exprtests/standard	logical	COUNT	Required
-DATENAME	Date Aggregation	tdvt/exprtests/standard	logical	DATEPART	Required
-DATENAME	Date Filters	tdvt/exprtests/standard	logical	DATEPART	Required
-DATENAME	Calculation	tdvt/exprtests/standard	logical	DATEPART	Required
-DATENAME	Filters	tdvt/exprtests/standard	logical	==	Required
-DATENAME	Operator	tdvt/exprtests/standard	logical	==	Required
-DATENAME	Calculation	tdvt/exprtests/standard	logical	==	Required
-DATENAME	NULL Semantics	tdvt/exprtests/standard	logical	ISNULL	Required
-DATENAME	Calculation	tdvt/exprtests/standard	logical	ISNULL	Required
-DATENAME	Calculation	tdvt/exprtests/standard	logical	IIF	Required
-DATENAME	Operator	tdvt/exprtests/standard	logical	&&	Required
-DATENAME	Calculation	tdvt/exprtests/standard	logical	&&	Required
-DATEPART		tdvt/exprtests/standard	logical	$IF$	Required
-DATEPART		tdvt/exprtests/standard	logical	$IN_SET$	Required
-DATEPART	Filters	tdvt/exprtests/standard	logical	LOWER	Required
-DATEPART	Calculation	tdvt/exprtests/standard	logical	LOWER	Required
-DATEPART	Data Prep	tdvt/exprtests/standard	logical	INT	Required
-DATEPART	Cast	tdvt/exprtests/standard	logical	INT	Required
-DATEPART	Calculation	tdvt/exprtests/standard	logical	INT	Required
-DATEPART	Filters	tdvt/exprtests/standard	logical	MAX	Required
-DATEPART	Domain	tdvt/exprtests/standard	logical	MAX	Required
-DATEPART	Aggregation	tdvt/exprtests/standard	logical	MAX	Required
-DATEPART	Calculation	tdvt/exprtests/standard	logical	MAX	Required
-DATEPART		tdvt/exprtests/standard	logical.bool	$IF$	Required
-DATEPART	Aggregation	tdvt/exprtests/standard	logical.bool	MAX	Required
-DATETIME	Aggregation	tdvt/exprtests/standard	logical.bool	MIN	Required
-DATETIME	Calculation	tdvt/exprtests/standard	logical.bool	==	Required
-DATETIME	Calculation	tdvt/exprtests/standard	logical.bool	IIF	Required
-DATETIME	Calculation	tdvt/exprtests/standard	logical.bool	IIF	Required
-DATETIME	Calculation	tdvt/exprtests/standard	logical.bool	INT	Required
-DATETIME	Calculation	tdvt/exprtests/standard	logical.bool	INT	Required
-DATETIME	Calculation	tdvt/exprtests/standard	logical.bool	ISNULL	Required
-DATETIME	Calculation	tdvt/exprtests/standard	logical.bool	ISNULL	Required
-DATETIME	Calculation	tdvt/exprtests/standard	logical.bool	MAX	Required
-DATETIME	Calculation	tdvt/exprtests/standard	logical.bool	MIN	Required
-DATETIME	Cast	tdvt/exprtests/standard	logical.bool	INT	Required
-DATETIME	Cast	tdvt/exprtests/standard	logical.bool	INT	Required
-DATETIME	Data Prep	tdvt/exprtests/standard	logical.bool	INT	Required
-DATETIME	Data Prep	tdvt/exprtests/standard	logical.bool	INT	Required
-DATETIME	Domain	tdvt/exprtests/standard	logical.bool	MAX	Required
-DATETIME	Domain	tdvt/exprtests/standard	logical.bool	MIN	Required
-DATETRUNC	Filters	tdvt/exprtests/standard	logical.bool	==	Required
-DATETRUNC	Filters	tdvt/exprtests/standard	logical.bool	MAX	Required
-DATETRUNC	Filters	tdvt/exprtests/standard	logical.bool	MIN	Required
-DATETRUNC	NULL Semantics	tdvt/exprtests/standard	logical.bool	ISNULL	Required
-DATETRUNC	NULL Semantics	tdvt/exprtests/standard	logical.bool	ISNULL	Required
-DATETRUNC	Operator	tdvt/exprtests/standard	logical.bool	==	Required
-DATETRUNC	Filters	tdvt/exprtests/standard	logical.case.null	==	Required
-DATETRUNC	Operator	tdvt/exprtests/standard	logical.case.null	==	Required
-DATETRUNC	Calculation	tdvt/exprtests/standard	logical.case.null	==	Required
-DATETRUNC		tdvt/exprtests/standard	logical.case.null	$IN_SET$	Required
-DATETRUNC		tdvt/exprtests/standard	logical.case.null	$CASE$	Required
-DATETRUNC	Date Aggregation	tdvt/exprtests/standard	logical.case.null	DATEPART	Required
-NOW	Date Filters	tdvt/exprtests/standard	logical.case.null	DATEPART	Required
-TODAY	Calculation	tdvt/exprtests/standard	logical.case.null	DATEPART	Required
-COUNT	Date Aggregation	tdvt/exprtests/standard	logical.case.null	DATEPART	Required
-COUNT	Date Filters	tdvt/exprtests/standard	logical.case.null	DATEPART	Required
-COUNT	Calculation	tdvt/exprtests/standard	logical.case.null	DATEPART	Required
-COUNT		tdvt/exprtests/standard	logical.case.str	$CASE$	Required
-COUNT		tdvt/exprtests/standard	logical.case.str	$IN_SET$	Required
-COUNT	Calculation	tdvt/exprtests/standard	logical.case.str	==	Required
-COUNT	Filters	tdvt/exprtests/standard	logical.case.str	==	Required
-COUNT	Operator	tdvt/exprtests/standard	logical.case.str	==	Required
-COUNT	Aggregation	tdvt/exprtests/standard	logical.ifnull	COUNT	Required
-COUNT	Aggregation	tdvt/exprtests/standard	logical.ifnull	COUNTD	Required
-COUNT	Calculation	tdvt/exprtests/standard	logical.ifnull	COUNT	Required
-COUNT	Calculation	tdvt/exprtests/standard	logical.ifnull	COUNTD	Required
-COUNT	Calculation	tdvt/exprtests/standard	logical.ifnull	IFNULL	Required
-COUNT	Domain	tdvt/exprtests/standard	logical.ifnull	COUNT	Required
-COUNT	Domain	tdvt/exprtests/standard	logical.ifnull	COUNTD	Required
-COUNT	Filters	tdvt/exprtests/standard	logical.ifnull	COUNT	Required
-COUNT	Filters	tdvt/exprtests/standard	logical.ifnull	COUNTD	Required
-COUNT	Reference Line	tdvt/exprtests/standard	logical.ifnull	COUNT	Required
-COUNT	Reference Line	tdvt/exprtests/standard	logical.ifnull	COUNTD	Required
-COUNT	Calculation	tdvt/exprtests/standard	math.abs	ABS	Required
-COUNT	Calculation	tdvt/exprtests/standard	math.abs	ABS	Required
-COUNT	Calculation	tdvt/exprtests/standard	math.acos	/	Recommended
-COUNT	Calculation	tdvt/exprtests/standard	math.acos	ACOS	Recommended
-COUNT	Calculation	tdvt/exprtests/standard	math.acos	ACOS	Recommended
-COUNT	Operator	tdvt/exprtests/standard	math.acos	/	Recommended
-COUNT	Calculation	tdvt/exprtests/standard	math.asin	/	Recommended
-COUNT	Calculation	tdvt/exprtests/standard	math.asin	ASIN	Recommended
-COUNTD	Calculation	tdvt/exprtests/standard	math.asin	ASIN	Recommended
-COUNTD	Operator	tdvt/exprtests/standard	math.asin	/	Recommended
-MAX	Calculation	tdvt/exprtests/standard	math.atan	ATAN	Recommended
-MAX	Calculation	tdvt/exprtests/standard	math.atan	ATAN	Recommended
-MAX	Calculation	tdvt/exprtests/standard	math.atan	ATAN2	Recommended
-MAX	Calculation	tdvt/exprtests/standard	math.atan	ATAN2	Recommended
-MAX	Calculation	tdvt/exprtests/standard	math.ceilfloor	+	Required
-MAX	Calculation	tdvt/exprtests/standard	math.ceilfloor	CEILING	Required
-MAX	Calculation	tdvt/exprtests/standard	math.ceilfloor	FLOOR	Required
-MAX	Operator	tdvt/exprtests/standard	math.ceilfloor	+	Required
-MAX	Calculation	tdvt/exprtests/standard	math.cos	COS	Required
-MAX	Calculation	tdvt/exprtests/standard	math.cos	COS	Required
-MAX	Calculation	tdvt/exprtests/standard	math.cot	COT	Required
-MIN	Calculation	tdvt/exprtests/standard	math.cot	COT	Required
-MIN	Calculation	tdvt/exprtests/standard	math.degree	DEGREES	Required
-MIN	Calculation	tdvt/exprtests/standard	math.degree	DEGREES	Required
-MIN	Calculation	tdvt/exprtests/standard	math.div	DIV	Required
-MIN	Calculation	tdvt/exprtests/standard	math.div	DIV	Required
-MIN	Operator	tdvt/exprtests/standard	math.exp	*	Required
-MIN	Calculation	tdvt/exprtests/standard	math.exp	*	Required
-MIN	Calculation	tdvt/exprtests/standard	math.exp	EXP	Required
-<	Calculation	tdvt/exprtests/standard	math.exp	EXP	Required
-<	Calculation	tdvt/exprtests/standard	math.hexbin	HEXBINX	Recommended
-<	Calculation	tdvt/exprtests/standard	math.hexbin	HEXBINY	Recommended
-<	Calculation	tdvt/exprtests/standard	math.ln	LN	Required
-<=	Calculation	tdvt/exprtests/standard	math.ln	LN	Required
-<=	Calculation	tdvt/exprtests/standard	math.log	LOG	Required
-<=	Calculation	tdvt/exprtests/standard	math.log	LOG	Required
-<=	Aggregation	tdvt/exprtests/standard	math.max	COUNT	Required
-==	Aggregation	tdvt/exprtests/standard	math.max	MAX	Required
-==	Calculation	tdvt/exprtests/standard	math.max	COUNT	Required
-==	Calculation	tdvt/exprtests/standard	math.max	MAX	Required
-==	Domain	tdvt/exprtests/standard	math.max	COUNT	Required
-==	Domain	tdvt/exprtests/standard	math.max	MAX	Required
-==	Filters	tdvt/exprtests/standard	math.max	COUNT	Required
->	Filters	tdvt/exprtests/standard	math.max	MAX	Required
->	Reference Line	tdvt/exprtests/standard	math.max	COUNT	Required
->	Reference Line	tdvt/exprtests/standard	math.min	COUNT	Required
->	Filters	tdvt/exprtests/standard	math.min	COUNT	Required
->=	Domain	tdvt/exprtests/standard	math.min	COUNT	Required
->=	Aggregation	tdvt/exprtests/standard	math.min	COUNT	Required
->=	Calculation	tdvt/exprtests/standard	math.min	COUNT	Required
-AVG	Filters	tdvt/exprtests/standard	math.min	MIN	Required
-COUNT	Domain	tdvt/exprtests/standard	math.min	MIN	Required
-COUNT	Aggregation	tdvt/exprtests/standard	math.min	MIN	Required
-COUNT	Calculation	tdvt/exprtests/standard	math.min	MIN	Required
-COUNT	Reference Line	tdvt/exprtests/standard	math.pi	COUNT	Required
-COUNT	Filters	tdvt/exprtests/standard	math.pi	COUNT	Required
-COUNT	Domain	tdvt/exprtests/standard	math.pi	COUNT	Required
-COUNT	Aggregation	tdvt/exprtests/standard	math.pi	COUNT	Required
-COUNT	Calculation	tdvt/exprtests/standard	math.pi	COUNT	Required
-COUNT	Calculation	tdvt/exprtests/standard	math.pi	PI	Required
-COUNT	Calculation	tdvt/exprtests/standard	math.pi	PI	Required
-COUNT	Operator	tdvt/exprtests/standard	math.pi	*	Required
-COUNT	Calculation	tdvt/exprtests/standard	math.pi	*	Required
-COUNT	Table Calc	tdvt/exprtests/standard	math.power	POWER	Required
-COUNT	Calculation	tdvt/exprtests/standard	math.power	POWER	Required
-COUNT	Calculation	tdvt/exprtests/standard	math.power.real	*	Recommended
-COUNT	Calculation	tdvt/exprtests/standard	math.power.real	POWER	Recommended
-COUNT	Calculation	tdvt/exprtests/standard	math.power.real	POWER	Recommended
-COUNT	Operator	tdvt/exprtests/standard	math.power.real	*	Recommended
-COUNT	Table Calc	tdvt/exprtests/standard	math.power.real	POWER	Recommended
-COUNT	Table Calc	tdvt/exprtests/standard	math.power.real	POWER	Recommended
-COUNT	Calculation	tdvt/exprtests/standard	math.radians	RADIANS	Required
-COUNT	Calculation	tdvt/exprtests/standard	math.radians	RADIANS	Required
-COUNT	Calculation	tdvt/exprtests/standard	math.round	ROUND	Required
-COUNT	Calculation	tdvt/exprtests/standard	math.round	ROUND	Required
-COUNT	Calculation	tdvt/exprtests/standard	math.round.B584401	ROUND	Recommended
-COUNT	Calculation	tdvt/exprtests/standard	math.sign	SIGN	Required
-COUNT	Calculation	tdvt/exprtests/standard	math.sign	SIGN	Required
-COUNTD	Calculation	tdvt/exprtests/standard	math.sin	SIN	Required
-COUNTD	Calculation	tdvt/exprtests/standard	math.sin	SIN	Required
-LOWER	Calculation	tdvt/exprtests/standard	math.sqrt	SQRT	Required
-LOWER	Calculation	tdvt/exprtests/standard	math.sqrt	SQRT	Required
-MAX	Calculation	tdvt/exprtests/standard	math.square	SQUARE	Required
-MAX	Calculation	tdvt/exprtests/standard	math.square	SQUARE	Required
-MAX	Calculation	tdvt/exprtests/standard	math.tan	TAN	Required
-MAX	Calculation	tdvt/exprtests/standard	math.zn	ZN	Required
-MAX	Column Metadata Nullability	tdvt/exprtests/standard	math.zn	COLUMN_NULLABILITY	Required
-MAX	Table Calc	tdvt/exprtests/standard	math.zn	ZN	Required
-MAX		tdvt/exprtests/standard	operator.bool	$SYS_NARY_AND$	Required
-MAX		tdvt/exprtests/standard	operator.bool	$SYS_NARY_OR$	Required
-MAX	Aggregation	tdvt/exprtests/standard	operator.bool	COUNT	Required
-MAX	Aggregation	tdvt/exprtests/standard	operator.bool	MAX	Required
-MAX	Aggregation	tdvt/exprtests/standard	operator.bool	MIN	Required
-MIN	Calculation	tdvt/exprtests/standard	operator.bool	!	Required
-MIN	Calculation	tdvt/exprtests/standard	operator.bool	!=	Required
-MIN	Calculation	tdvt/exprtests/standard	operator.bool	&&	Required
-MIN	Calculation	tdvt/exprtests/standard	operator.bool	==	Required
-MIN	Calculation	tdvt/exprtests/standard	operator.bool	COUNT	Required
-MIN	Calculation	tdvt/exprtests/standard	operator.bool	MAX	Required
-MIN	Calculation	tdvt/exprtests/standard	operator.bool	MIN	Required
-MIN	Calculation	tdvt/exprtests/standard	operator.bool	||	Required
-STARTSWITH	Data Prep	tdvt/exprtests/standard	operator.bool	!	Required
-STR	Domain	tdvt/exprtests/standard	operator.bool	COUNT	Required
-STR	Domain	tdvt/exprtests/standard	operator.bool	MAX	Required
-STR	Domain	tdvt/exprtests/standard	operator.bool	MIN	Required
-STR	Filters	tdvt/exprtests/standard	operator.bool	==	Required
-STR	Filters	tdvt/exprtests/standard	operator.bool	COUNT	Required
-STR	Filters	tdvt/exprtests/standard	operator.bool	MAX	Required
-STR	Filters	tdvt/exprtests/standard	operator.bool	MIN	Required
-STR	Operator	tdvt/exprtests/standard	operator.bool	!	Required
-SUM	Operator	tdvt/exprtests/standard	operator.bool	!=	Required
-SUM	Operator	tdvt/exprtests/standard	operator.bool	&&	Required
-ISNULL	Operator	tdvt/exprtests/standard	operator.bool	==	Required
-ISNULL	Operator	tdvt/exprtests/standard	operator.bool	||	Required
-!	Reference Line	tdvt/exprtests/standard	operator.bool	COUNT	Required
-!=	Aggregation	tdvt/exprtests/standard	operator.date	MAX	Required
-!=	Aggregation	tdvt/exprtests/standard	operator.date	MIN	Required
-!=	Calculation	tdvt/exprtests/standard	operator.date	!=	Required
-!=	Calculation	tdvt/exprtests/standard	operator.date	+	Required
-!=	Calculation	tdvt/exprtests/standard	operator.date	-	Required
-%	Calculation	tdvt/exprtests/standard	operator.date	<	Required
-&&	Calculation	tdvt/exprtests/standard	operator.date	<=	Required
-*	Calculation	tdvt/exprtests/standard	operator.date	==	Required
-*	Calculation	tdvt/exprtests/standard	operator.date	>	Required
-+	Calculation	tdvt/exprtests/standard	operator.date	>=	Required
-+	Calculation	tdvt/exprtests/standard	operator.date	MAX	Required
-+	Calculation	tdvt/exprtests/standard	operator.date	MIN	Required
-+	Domain	tdvt/exprtests/standard	operator.date	MAX	Required
-+	Domain	tdvt/exprtests/standard	operator.date	MIN	Required
-+	Filters	tdvt/exprtests/standard	operator.date	<	Required
-+	Filters	tdvt/exprtests/standard	operator.date	<=	Required
-+	Filters	tdvt/exprtests/standard	operator.date	==	Required
-+	Filters	tdvt/exprtests/standard	operator.date	>	Required
-+	Filters	tdvt/exprtests/standard	operator.date	>=	Required
-+	Filters	tdvt/exprtests/standard	operator.date	MAX	Required
-+	Filters	tdvt/exprtests/standard	operator.date	MIN	Required
--	Operator	tdvt/exprtests/standard	operator.date	!=	Required
--	Operator	tdvt/exprtests/standard	operator.date	+	Required
--	Operator	tdvt/exprtests/standard	operator.date	-	Required
--	Operator	tdvt/exprtests/standard	operator.date	<	Required
--	Operator	tdvt/exprtests/standard	operator.date	<=	Required
-/	Operator	tdvt/exprtests/standard	operator.date	==	Required
-/	Operator	tdvt/exprtests/standard	operator.date	>	Required
-/	Operator	tdvt/exprtests/standard	operator.date	>=	Required
-/	Calculation	tdvt/exprtests/standard	operator.int	%	Required
-<	Calculation	tdvt/exprtests/standard	operator.int	/	Required
-<	Calculation	tdvt/exprtests/standard	operator.int	^^	Required
-<	Operator	tdvt/exprtests/standard	operator.int	%	Required
-<	Operator	tdvt/exprtests/standard	operator.int	/	Required
-<=	Operator	tdvt/exprtests/standard	operator.int	^^	Required
-<=	Operator	tdvt/exprtests/standard	operator.num	*	Required
-<=	Calculation	tdvt/exprtests/standard	operator.num	*	Required
-<=	Filters	tdvt/exprtests/standard	operator.num	>=	Required
-==	Operator	tdvt/exprtests/standard	operator.num	>=	Required
-==	Calculation	tdvt/exprtests/standard	operator.num	>=	Required
-==	Operator	tdvt/exprtests/standard	operator.num	^^	Required
-==	Calculation	tdvt/exprtests/standard	operator.num	^^	Required
-==	Filters	tdvt/exprtests/standard	operator.num	MIN	Required
-==	Domain	tdvt/exprtests/standard	operator.num	MIN	Required
->	Aggregation	tdvt/exprtests/standard	operator.num	MIN	Required
->	Calculation	tdvt/exprtests/standard	operator.num	MIN	Required
->	Filters	tdvt/exprtests/standard	operator.num	==	Required
->	Operator	tdvt/exprtests/standard	operator.num	==	Required
->=	Aggregation	tdvt/exprtests/standard	operator.num	MAX	Required
->=	Calculation	tdvt/exprtests/standard	operator.num	!=	Required
->=	Calculation	tdvt/exprtests/standard	operator.num	+	Required
-^^	Calculation	tdvt/exprtests/standard	operator.num	-	Required
-||	Calculation	tdvt/exprtests/standard	operator.num	/	Required
-AVG	Calculation	tdvt/exprtests/standard	operator.num	<	Required
-COUNT	Calculation	tdvt/exprtests/standard	operator.num	<=	Required
-COUNT	Calculation	tdvt/exprtests/standard	operator.num	==	Required
-COUNT	Calculation	tdvt/exprtests/standard	operator.num	>	Required
-COUNT	Calculation	tdvt/exprtests/standard	operator.num	ABS	Required
-COUNT	Calculation	tdvt/exprtests/standard	operator.num	ABS	Required
-COUNT	Calculation	tdvt/exprtests/standard	operator.num	MAX	Required
-COUNT	Domain	tdvt/exprtests/standard	operator.num	MAX	Required
-COUNT	Filters	tdvt/exprtests/standard	operator.num	<	Required
-COUNT	Filters	tdvt/exprtests/standard	operator.num	<=	Required
-COUNT	Filters	tdvt/exprtests/standard	operator.num	>	Required
-COUNT	Filters	tdvt/exprtests/standard	operator.num	MAX	Required
-COUNT	Operator	tdvt/exprtests/standard	operator.num	!=	Required
-COUNT	Operator	tdvt/exprtests/standard	operator.num	+	Required
-COUNT	Operator	tdvt/exprtests/standard	operator.num	-	Required
-COUNT	Operator	tdvt/exprtests/standard	operator.num	/	Required
-COUNT	Operator	tdvt/exprtests/standard	operator.num	<	Required
-COUNT	Operator	tdvt/exprtests/standard	operator.num	<=	Required
-COUNT	Operator	tdvt/exprtests/standard	operator.num	>	Required
-COUNT	Aggregation	tdvt/exprtests/standard	operator.str	COUNT	Required
-COUNT	Aggregation	tdvt/exprtests/standard	operator.str	MAX	Required
-COUNT	Aggregation	tdvt/exprtests/standard	operator.str	MIN	Required
-COUNT	Calculation	tdvt/exprtests/standard	operator.str	!=	Required
-COUNT	Calculation	tdvt/exprtests/standard	operator.str	+	Required
-COUNT	Calculation	tdvt/exprtests/standard	operator.str	<	Required
-COUNT	Calculation	tdvt/exprtests/standard	operator.str	<=	Required
-COUNT	Calculation	tdvt/exprtests/standard	operator.str	==	Required
-COUNT	Calculation	tdvt/exprtests/standard	operator.str	>	Required
-COUNTD	Calculation	tdvt/exprtests/standard	operator.str	>=	Required
-COUNTD	Calculation	tdvt/exprtests/standard	operator.str	COUNT	Required
-SUM	Calculation	tdvt/exprtests/standard	operator.str	IIF	Required
-SUM	Calculation	tdvt/exprtests/standard	operator.str	IIF	Required
-VAR	Calculation	tdvt/exprtests/standard	operator.str	LOWER	Required
-VARP	Calculation	tdvt/exprtests/standard	operator.str	LOWER	Required
-POWER	Calculation	tdvt/exprtests/standard	operator.str	MAX	Required
-POWER	Calculation	tdvt/exprtests/standard	operator.str	MIN	Required
-ZN	Domain	tdvt/exprtests/standard	operator.str	COUNT	Required
-CONTAINS	Domain	tdvt/exprtests/standard	operator.str	MAX	Required
-	Domain	tdvt/exprtests/standard	operator.str	MIN	Required
-	Filters	tdvt/exprtests/standard	operator.str	<	Required
-	Filters	tdvt/exprtests/standard	operator.str	<=	Required
-	Filters	tdvt/exprtests/standard	operator.str	==	Required
-	Filters	tdvt/exprtests/standard	operator.str	>	Required
-	Filters	tdvt/exprtests/standard	operator.str	>=	Required
-	Filters	tdvt/exprtests/standard	operator.str	COUNT	Required
-	Filters	tdvt/exprtests/standard	operator.str	LOWER	Required
-	Filters	tdvt/exprtests/standard	operator.str	LOWER	Required
-	Filters	tdvt/exprtests/standard	operator.str	MAX	Required
-	Filters	tdvt/exprtests/standard	operator.str	MIN	Required
-COUNT	Operator	tdvt/exprtests/standard	operator.str	!=	Required
-COUNT	Operator	tdvt/exprtests/standard	operator.str	+	Required
-SUM	Operator	tdvt/exprtests/standard	operator.str	<	Required
-SUM	Operator	tdvt/exprtests/standard	operator.str	<=	Required
-SUM	Operator	tdvt/exprtests/standard	operator.str	==	Required
-SUM	Operator	tdvt/exprtests/standard	operator.str	>	Required
-SUM	Operator	tdvt/exprtests/standard	operator.str	>=	Required
-SUM	Reference Line	tdvt/exprtests/standard	operator.str	COUNT	Required
-SUM	Aggregation	tdvt/logicaltests/staples	Query.Dates_MDY	SUM	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Dates_MDY	*	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Dates_MDY	+	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Dates_MDY	DATEPART	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Dates_MDY	SUM	Required
-SUM	Date Aggregation	tdvt/logicaltests/staples	Query.Dates_MDY	DATEPART	Required
-SUM	Date Filters	tdvt/logicaltests/staples	Query.Dates_MDY	DATEPART	Required
-SUM	Filters	tdvt/logicaltests/staples	Query.Dates_MDY	SUM	Required
-SUM	Operator	tdvt/logicaltests/staples	Query.Dates_MDY	*	Required
-SUM	Operator	tdvt/logicaltests/staples	Query.Dates_MDY	+	Required
-SUM	Reference Line	tdvt/logicaltests/staples	Query.Dates_MDY	SUM	Required
-!		tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	$SYS_NARY_AND$	Required
-!		tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	$SYS_NARY_OR$	Required
-<=	Aggregation	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	SUM	Required
-<=	Calculation	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	*	Required
-<=	Calculation	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	+	Required
-<=	Calculation	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	<=	Required
-<=	Calculation	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	>=	Required
-<=	Calculation	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	DATEPART	Required
->=	Calculation	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	SUM	Required
->=	Date Aggregation	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	DATEPART	Required
->=	Date Filters	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	DATEPART	Required
->=	Filters	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	<=	Required
->=	Filters	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	>=	Required
->=	Filters	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	SUM	Required
->=	Operator	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	*	Required
-COUNT	Operator	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	+	Required
-COUNT	Operator	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	<=	Required
-DATETIME	Operator	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	>=	Required
-ISNULL	Reference Line	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	SUM	Required
-ISNULL		tdvt/logicaltests/calcs	Query.Filter.IsNOTNULL	$SYS_NARY_AND$	Required
-ISNULL	Aggregation	tdvt/logicaltests/calcs	Query.Filter.IsNOTNULL	SUM	Required
-ISNULL	Calculation	tdvt/logicaltests/calcs	Query.Filter.IsNOTNULL	<=	Required
-ISNULL	Calculation	tdvt/logicaltests/calcs	Query.Filter.IsNOTNULL	>=	Required
-ISNULL	Calculation	tdvt/logicaltests/calcs	Query.Filter.IsNOTNULL	SUM	Required
-SUM	Filters	tdvt/logicaltests/calcs	Query.Filter.IsNOTNULL	<=	Required
-SUM	Filters	tdvt/logicaltests/calcs	Query.Filter.IsNOTNULL	>=	Required
-SUM	Filters	tdvt/logicaltests/calcs	Query.Filter.IsNOTNULL	SUM	Required
-SUM	Operator	tdvt/logicaltests/calcs	Query.Filter.IsNOTNULL	<=	Required
-SUM	Operator	tdvt/logicaltests/calcs	Query.Filter.IsNOTNULL	>=	Required
-SUM	Reference Line	tdvt/logicaltests/calcs	Query.Filter.IsNOTNULL	SUM	Required
-SUM	Aggregation	tdvt/logicaltests/calcs	Query.Filter.IsNULL	SUM	Required
-SUM	Calculation	tdvt/logicaltests/calcs	Query.Filter.IsNULL	ISNULL	Required
-SUM	Calculation	tdvt/logicaltests/calcs	Query.Filter.IsNULL	SUM	Required
-SUM	Filters	tdvt/logicaltests/calcs	Query.Filter.IsNULL	SUM	Required
-SUM	NULL Semantics	tdvt/logicaltests/calcs	Query.Filter.IsNULL	ISNULL	Required
-SUM	Reference Line	tdvt/logicaltests/calcs	Query.Filter.IsNULL	SUM	Required
-SUM		tdvt/logicaltests/calcs	Query.Filter.NullAndOne	$IN_SET$	Required
-SUM	NULL Semantics	tdvt/logicaltests/calcs	Query.Filter.NullAndOne	ISNULL	Required
-SUM	Calculation	tdvt/logicaltests/calcs	Query.Filter.NullAndOne	ISNULL	Required
-SUM	Reference Line	tdvt/logicaltests/calcs	Query.Filter.NullAndOne	SUM	Required
-SUM	Filters	tdvt/logicaltests/calcs	Query.Filter.NullAndOne	SUM	Required
-COLUMN_NULLABILITY	Aggregation	tdvt/logicaltests/calcs	Query.Filter.NullAndOne	SUM	Required
-COLUMN_NULLABILITY	Calculation	tdvt/logicaltests/calcs	Query.Filter.NullAndOne	SUM	Required
-COLUMN_NULLABILITY		tdvt/logicaltests/calcs	Query.Filter.NullAndOne	$SYS_NARY_OR$	Required
-COLUMN_NULLABILITY	Reference Line	tdvt/logicaltests/staples	Query.Filter_AVG	AVG	Required
-COLUMN_NULLABILITY	Filters	tdvt/logicaltests/staples	Query.Filter_AVG	AVG	Required
-!	Aggregation	tdvt/logicaltests/staples	Query.Filter_AVG	AVG	Required
-!	Calculation	tdvt/logicaltests/staples	Query.Filter_AVG	AVG	Required
-DATETIME	Filters	tdvt/logicaltests/staples	Query.Filter_AVG	<=	Required
-DATETIME	Operator	tdvt/logicaltests/staples	Query.Filter_AVG	<=	Required
-COUNT	Calculation	tdvt/logicaltests/staples	Query.Filter_AVG	<=	Required
-COUNT	Filters	tdvt/logicaltests/staples	Query.Filter_AVG	>=	Required
-<=	Operator	tdvt/logicaltests/staples	Query.Filter_AVG	>=	Required
-<=	Calculation	tdvt/logicaltests/staples	Query.Filter_AVG	>=	Required
-<=		tdvt/logicaltests/staples	Query.Filter_AVG	$SYS_NARY_AND$	Required
-<=		tdvt/logicaltests/staples	Query.Filter_CNT	$SYS_NARY_AND$	Required
-<=	Aggregation	tdvt/logicaltests/staples	Query.Filter_CNT	SUM	Required
-<=	Calculation	tdvt/logicaltests/staples	Query.Filter_CNT	<=	Required
->=	Calculation	tdvt/logicaltests/staples	Query.Filter_CNT	>=	Required
->=	Calculation	tdvt/logicaltests/staples	Query.Filter_CNT	SUM	Required
->=	Filters	tdvt/logicaltests/staples	Query.Filter_CNT	<=	Required
->=	Filters	tdvt/logicaltests/staples	Query.Filter_CNT	>=	Required
->=	Filters	tdvt/logicaltests/staples	Query.Filter_CNT	SUM	Required
->=	Operator	tdvt/logicaltests/staples	Query.Filter_CNT	<=	Required
->=	Operator	tdvt/logicaltests/staples	Query.Filter_CNT	>=	Required
-COUNT	Reference Line	tdvt/logicaltests/staples	Query.Filter_CNT	SUM	Required
-COUNT		tdvt/logicaltests/staples	Query.Filter_Exclude1	$SYS_NARY_OR$	Required
-SUM	Reference Line	tdvt/logicaltests/staples	Query.Filter_Exclude1	SUM	Required
-SUM	Filters	tdvt/logicaltests/staples	Query.Filter_Exclude1	SUM	Required
-SUM	Aggregation	tdvt/logicaltests/staples	Query.Filter_Exclude1	SUM	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Filter_Exclude1	SUM	Required
-SUM	Filters	tdvt/logicaltests/staples	Query.Filter_Exclude1	<=	Required
-SUM	Operator	tdvt/logicaltests/staples	Query.Filter_Exclude1	<=	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Filter_Exclude1	<=	Required
-SUM	Filters	tdvt/logicaltests/staples	Query.Filter_Exclude1	>=	Required
-SUM	Operator	tdvt/logicaltests/staples	Query.Filter_Exclude1	>=	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Filter_Exclude1	>=	Required
-SUM		tdvt/logicaltests/staples	Query.Filter_Exclude1	$SYS_NARY_AND$	Required
-SUM	Aggregation	tdvt/logicaltests/staples	Query.Filter_Include1	SUM	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Filter_Include1	==	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Filter_Include1	SUM	Required
-SUM	Filters	tdvt/logicaltests/staples	Query.Filter_Include1	==	Required
-SUM	Filters	tdvt/logicaltests/staples	Query.Filter_Include1	SUM	Required
-SUM	Operator	tdvt/logicaltests/staples	Query.Filter_Include1	==	Required
-TEMP_TABLES_AND_SUBQUERIES	Reference Line	tdvt/logicaltests/staples	Query.Filter_Include1	SUM	Required
-TEMP_TABLES_AND_SUBQUERIES	Filters	tdvt/logicaltests/staples	Query.Filter_MAX	MAX	Required
-TEMP_TABLES_AND_SUBQUERIES	Domain	tdvt/logicaltests/staples	Query.Filter_MAX	MAX	Required
-TEMP_TABLES_AND_SUBQUERIES	Aggregation	tdvt/logicaltests/staples	Query.Filter_MAX	MAX	Required
-ISNULL	Calculation	tdvt/logicaltests/staples	Query.Filter_MAX	MAX	Required
-ISNULL	Filters	tdvt/logicaltests/staples	Query.Filter_MAX	<=	Required
-ISNULL	Operator	tdvt/logicaltests/staples	Query.Filter_MAX	<=	Required
-ISNULL	Calculation	tdvt/logicaltests/staples	Query.Filter_MAX	<=	Required
-ISNULL	Filters	tdvt/logicaltests/staples	Query.Filter_MAX	>=	Required
-ISNULL	Operator	tdvt/logicaltests/staples	Query.Filter_MAX	>=	Required
-!	Calculation	tdvt/logicaltests/staples	Query.Filter_MAX	>=	Required
-!		tdvt/logicaltests/staples	Query.Filter_MAX	$SYS_NARY_AND$	Required
-<=		tdvt/logicaltests/staples	Query.Filter_MIN	$SYS_NARY_AND$	Required
-<=	Aggregation	tdvt/logicaltests/staples	Query.Filter_MIN	MIN	Required
-<=	Calculation	tdvt/logicaltests/staples	Query.Filter_MIN	<=	Required
-<=	Calculation	tdvt/logicaltests/staples	Query.Filter_MIN	>=	Required
-<=	Calculation	tdvt/logicaltests/staples	Query.Filter_MIN	MIN	Required
-<=	Domain	tdvt/logicaltests/staples	Query.Filter_MIN	MIN	Required
->=	Filters	tdvt/logicaltests/staples	Query.Filter_MIN	<=	Required
->=	Filters	tdvt/logicaltests/staples	Query.Filter_MIN	>=	Required
->=	Filters	tdvt/logicaltests/staples	Query.Filter_MIN	MIN	Required
->=	Operator	tdvt/logicaltests/staples	Query.Filter_MIN	<=	Required
->=	Operator	tdvt/logicaltests/staples	Query.Filter_MIN	>=	Required
->=	Reference Line	tdvt/logicaltests/staples	Query.Filter_SliceAggQ	SUM	Required
->=	Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQ	SUM	Required
-COUNT	Aggregation	tdvt/logicaltests/staples	Query.Filter_SliceAggQ	SUM	Required
-COUNT	Calculation	tdvt/logicaltests/staples	Query.Filter_SliceAggQ	SUM	Required
-SUM	Reference Line	tdvt/logicaltests/staples	Query.Filter_SliceAggQ	AVG	Required
-SUM	Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQ	AVG	Required
-SUM	Aggregation	tdvt/logicaltests/staples	Query.Filter_SliceAggQ	AVG	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Filter_SliceAggQ	AVG	Required
-SUM	Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQ	<=	Required
-SUM	Operator	tdvt/logicaltests/staples	Query.Filter_SliceAggQ	<=	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Filter_SliceAggQ	<=	Required
-SUM	Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQ	>=	Required
-SUM	Operator	tdvt/logicaltests/staples	Query.Filter_SliceAggQ	>=	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Filter_SliceAggQ	>=	Required
-SUM		tdvt/logicaltests/staples	Query.Filter_SliceAggQ	$SYS_NARY_AND$	Required
-SUM		tdvt/logicaltests/staples	Query.Filter_SliceAggQ_AxisQ	$SYS_NARY_AND$	Required
-SUM	Aggregation	tdvt/logicaltests/staples	Query.Filter_SliceAggQ_AxisQ	SUM	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Filter_SliceAggQ_AxisQ	<=	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Filter_SliceAggQ_AxisQ	>=	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Filter_SliceAggQ_AxisQ	SUM	Required
-SUM	Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQ_AxisQ	<=	Required
-TEMP_TABLES_AND_SUBQUERIES	Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQ_AxisQ	>=	Required
-TEMP_TABLES_AND_SUBQUERIES	Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQ_AxisQ	SUM	Required
-TEMP_TABLES_AND_SUBQUERIES	Operator	tdvt/logicaltests/staples	Query.Filter_SliceAggQ_AxisQ	<=	Required
-TEMP_TABLES_AND_SUBQUERIES	Operator	tdvt/logicaltests/staples	Query.Filter_SliceAggQ_AxisQ	>=	Required
-	Reference Line	tdvt/logicaltests/staples	Query.Filter_SliceAggQ_AxisQ	SUM	Required
-		tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQ	$SYS_NARY_AND$	Required
-	Aggregation	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQ	SUM	Required
-	Calculation	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQ	<=	Required
-	Calculation	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQ	>=	Required
-	Calculation	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQ	SUM	Required
-AVG	Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQ	<=	Required
-AVG	Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQ	>=	Required
-COUNT	Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQ	SUM	Required
-COUNT	Operator	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQ	<=	Required
-COUNT	Operator	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQ	>=	Required
-MAX	Reference Line	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQ	SUM	Required
-MIN	Reference Line	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQO	SUM	Required
-MIN	Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQO	SUM	Required
-MIN	Aggregation	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQO	SUM	Required
-MIN	Calculation	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQO	SUM	Required
-MIN	Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQO	<=	Required
-MIN	Operator	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQO	<=	Required
-MIN	Calculation	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQO	<=	Required
-MIN		tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQO	$NOT_IN_SET$	Required
-SUM		tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQO	$SYS_NARY_AND$	Required
-SUM	Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQO	>=	Required
-SUM	Operator	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQO	>=	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQO	>=	Required
-SUM		tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQOYear	$IN_SET$	Required
-SUM		tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQOYear	$NOT_IN_SET$	Required
-SUM		tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQOYear	$SYS_NARY_AND$	Required
-SUM	Aggregation	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQOYear	SUM	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQOYear	<=	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQOYear	>=	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQOYear	DATEPART	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQOYear	SUM	Required
-SUM	Date Aggregation	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQOYear	DATEPART	Required
-!	Date Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQOYear	DATEPART	Required
-==	Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQOYear	<=	Required
-AVG	Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQOYear	>=	Required
-AVG	Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQOYear	SUM	Required
-COUNT	Operator	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQOYear	<=	Required
-COUNT	Operator	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQOYear	>=	Required
-COUNT	Reference Line	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQOYear	SUM	Required
-DATEDIFF		tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear	$IN_SET$	Required
-DATEPART		tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear	$NOT_IN_SET$	Required
-DATEPART		tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear	$SYS_NARY_AND$	Required
-FLOAT	Aggregation	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear	SUM	Required
-FLOAT	Calculation	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear	<=	Required
-FLOOR	Calculation	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear	>=	Required
-FLOOR	Calculation	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear	DATEPART	Required
-ISNULL	Calculation	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear	SUM	Required
-ISNULL	Date Aggregation	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear	DATEPART	Required
-ISNULL	Date Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear	DATEPART	Required
-MAX	Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear	<=	Required
-MIN	Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear	>=	Required
-MIN	Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear	SUM	Required
-MIN	Operator	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear	<=	Required
-MIN	Operator	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear	>=	Required
-MIN	Reference Line	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear	SUM	Required
-MIN		tdvt/logicaltests/staples	Query.Filter_SUM	$SYS_NARY_AND$	Required
-MIN	Aggregation	tdvt/logicaltests/staples	Query.Filter_SUM	SUM	Required
-MIN	Calculation	tdvt/logicaltests/staples	Query.Filter_SUM	<=	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Filter_SUM	>=	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Filter_SUM	SUM	Required
-SUM	Filters	tdvt/logicaltests/staples	Query.Filter_SUM	<=	Required
-SUM	Filters	tdvt/logicaltests/staples	Query.Filter_SUM	>=	Required
-SUM	Filters	tdvt/logicaltests/staples	Query.Filter_SUM	SUM	Required
-SUM	Operator	tdvt/logicaltests/staples	Query.Filter_SUM	<=	Required
-SUM	Operator	tdvt/logicaltests/staples	Query.Filter_SUM	>=	Required
-SUM	Reference Line	tdvt/logicaltests/staples	Query.Filter_SUM	SUM	Required
-SUM		tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	$IN_SET$	Required
-SUM	Date Aggregation	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	DATEPART	Required
-SUM	Date Filters	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	DATEPART	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	DATEPART	Required
-SUM	Filters	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	>=	Required
-FLOAT	Operator	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	>=	Required
-FLOAT	Calculation	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	>=	Required
-!		tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	$SYS_NARY_AND$	Required
-FLOAT	Filters	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	MIN	Required
-FLOAT	Domain	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	MIN	Required
-DATEDIFF	Aggregation	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	MIN	Required
-DATEPART	Calculation	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	MIN	Required
-DATEPART	Reference Line	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	SUM	Required
-DATEDIFF	Filters	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	SUM	Required
-DATEPART	Aggregation	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	SUM	Required
-DATEPART	Calculation	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	SUM	Required
-COUNT	Filters	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	<=	Required
-COUNT	Operator	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	<=	Required
-COUNT	Calculation	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	<=	Required
-MAX		tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	$SYS_NARY_OR$	Required
-MIN		tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	$NOT_IN_SET$	Required
-MIN	Filters	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	<	Required
-MIN	Operator	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	<	Required
-MIN	Calculation	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	<	Required
-MIN	Reference Line	tdvt/logicaltests/staples	Query.FilterBy_Q	SUM	Required
-MIN	Filters	tdvt/logicaltests/staples	Query.FilterBy_Q	SUM	Required
-MIN	Aggregation	tdvt/logicaltests/staples	Query.FilterBy_Q	SUM	Required
-MIN	Calculation	tdvt/logicaltests/staples	Query.FilterBy_Q	SUM	Required
-==	Reference Line	tdvt/logicaltests/staples	Query.FilterBy_Q	AVG	Required
-AVG	Filters	tdvt/logicaltests/staples	Query.FilterBy_Q	AVG	Required
-AVG	Aggregation	tdvt/logicaltests/staples	Query.FilterBy_Q	AVG	Required
-COUNT	Calculation	tdvt/logicaltests/staples	Query.FilterBy_Q	AVG	Required
-COUNT	Filters	tdvt/logicaltests/staples	Query.FilterBy_Q	<	Required
-COUNT	Operator	tdvt/logicaltests/staples	Query.FilterBy_Q	<	Required
-MAX	Calculation	tdvt/logicaltests/staples	Query.FilterBy_Q	<	Required
-MIN		tdvt/logicaltests/staples	Query.HideEmptyRows	$SYS_NARY_AND$	Required
-MIN	Aggregation	tdvt/logicaltests/staples	Query.HideEmptyRows	AVG	Required
-MIN	Aggregation	tdvt/logicaltests/staples	Query.HideEmptyRows	MIN	Required
-MIN	Calculation	tdvt/logicaltests/staples	Query.HideEmptyRows	<=	Required
-MIN	Calculation	tdvt/logicaltests/staples	Query.HideEmptyRows	>=	Required
-MIN	Calculation	tdvt/logicaltests/staples	Query.HideEmptyRows	AVG	Required
-MIN	Calculation	tdvt/logicaltests/staples	Query.HideEmptyRows	MIN	Required
-MIN	Domain	tdvt/logicaltests/staples	Query.HideEmptyRows	MIN	Required
-SUM	Filters	tdvt/logicaltests/staples	Query.HideEmptyRows	<=	Required
-SUM	Filters	tdvt/logicaltests/staples	Query.HideEmptyRows	>=	Required
-SUM	Filters	tdvt/logicaltests/staples	Query.HideEmptyRows	AVG	Required
-SUM	Filters	tdvt/logicaltests/staples	Query.HideEmptyRows	MIN	Required
-SUM	Operator	tdvt/logicaltests/staples	Query.HideEmptyRows	<=	Required
-SUM	Operator	tdvt/logicaltests/staples	Query.HideEmptyRows	>=	Required
-SUM	Reference Line	tdvt/logicaltests/staples	Query.HideEmptyRows	AVG	Required
-SUM		tdvt/logicaltests/staples	Query.MultipleFilters	$IN_SET$	Required
-SUM	Date Aggregation	tdvt/logicaltests/staples	Query.MultipleFilters	DATEPART	Required
-SUM	Date Filters	tdvt/logicaltests/staples	Query.MultipleFilters	DATEPART	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.MultipleFilters	DATEPART	Required
-SUM	Filters	tdvt/logicaltests/staples	Query.MultipleFilters	>=	Required
-SUM	Operator	tdvt/logicaltests/staples	Query.MultipleFilters	>=	Required
-TEMP_TABLES_AND_SUBQUERIES	Calculation	tdvt/logicaltests/staples	Query.MultipleFilters	>=	Required
-TEMP_TABLES_AND_SUBQUERIES		tdvt/logicaltests/staples	Query.MultipleFilters	$SYS_NARY_AND$	Required
-TEMP_TABLES_AND_SUBQUERIES	Filters	tdvt/logicaltests/staples	Query.MultipleFilters	==	Required
-LOD_STYLE_JOIN	Operator	tdvt/logicaltests/staples	Query.MultipleFilters	==	Required
-LOD_STYLE_JOIN	Calculation	tdvt/logicaltests/staples	Query.MultipleFilters	==	Required
-LOD_STYLE_JOIN	Reference Line	tdvt/logicaltests/staples	Query.MultipleFilters	SUM	Required
-LOD_STYLE_JOIN	Filters	tdvt/logicaltests/staples	Query.MultipleFilters	SUM	Required
-LOD_STYLE_JOIN	Aggregation	tdvt/logicaltests/staples	Query.MultipleFilters	SUM	Required
-LOD_STYLE_JOIN	Calculation	tdvt/logicaltests/staples	Query.MultipleFilters	SUM	Required
-LOD_STYLE_JOIN	Filters	tdvt/logicaltests/staples	Query.MultipleFilters	<=	Required
-LOD_STYLE_JOIN	Operator	tdvt/logicaltests/staples	Query.MultipleFilters	<=	Required
-LOD_STYLE_JOIN	Calculation	tdvt/logicaltests/staples	Query.MultipleFilters	<=	Required
-LOD_STYLE_JOIN		tdvt/logicaltests/staples	Query.MultipleFilters	$SYS_NARY_OR$	Required
-LOD_STYLE_JOIN	Reference Line	tdvt/logicaltests/staples	Query.MultipleFilters	AVG	Required
-LOD_STYLE_JOIN	Filters	tdvt/logicaltests/staples	Query.MultipleFilters	AVG	Required
-LOD_STYLE_JOIN	Aggregation	tdvt/logicaltests/staples	Query.MultipleFilters	AVG	Required
-LOD_STYLE_JOIN	Calculation	tdvt/logicaltests/staples	Query.MultipleFilters	AVG	Required
-LOD_STYLE_JOIN		tdvt/logicaltests/staples	Query.Nest_FilterO1_SliceOQ	$NOT_IN_SET$	Required
-LOD_STYLE_JOIN		tdvt/logicaltests/staples	Query.Nest_FilterO1_SliceOQ	$SYS_NARY_AND$	Required
-LOD_STYLE_JOIN	Aggregation	tdvt/logicaltests/staples	Query.Nest_FilterO1_SliceOQ	AVG	Required
-ISNULL	Aggregation	tdvt/logicaltests/staples	Query.Nest_FilterO1_SliceOQ	SUM	Required
-ISNULL	Calculation	tdvt/logicaltests/staples	Query.Nest_FilterO1_SliceOQ	<=	Required
-ISNULL	Calculation	tdvt/logicaltests/staples	Query.Nest_FilterO1_SliceOQ	>=	Required
-!	Calculation	tdvt/logicaltests/staples	Query.Nest_FilterO1_SliceOQ	AVG	Required
-==	Calculation	tdvt/logicaltests/staples	Query.Nest_FilterO1_SliceOQ	SUM	Required
-AVG	Filters	tdvt/logicaltests/staples	Query.Nest_FilterO1_SliceOQ	<=	Required
-AVG	Filters	tdvt/logicaltests/staples	Query.Nest_FilterO1_SliceOQ	>=	Required
-COUNT	Filters	tdvt/logicaltests/staples	Query.Nest_FilterO1_SliceOQ	AVG	Required
-COUNT	Filters	tdvt/logicaltests/staples	Query.Nest_FilterO1_SliceOQ	SUM	Required
-COUNT	Operator	tdvt/logicaltests/staples	Query.Nest_FilterO1_SliceOQ	<=	Required
-SUM	Operator	tdvt/logicaltests/staples	Query.Nest_FilterO1_SliceOQ	>=	Required
-SUM	Reference Line	tdvt/logicaltests/staples	Query.Nest_FilterO1_SliceOQ	AVG	Required
-SUM	Reference Line	tdvt/logicaltests/staples	Query.Nest_FilterO1_SliceOQ	SUM	Required
-SUM		tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	$IN_SET$	Required
-SUM		tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	$NOT_IN_SET$	Required
-SUM		tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	$SYS_NARY_AND$	Required
-SUM		tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	$SYS_NARY_OR$	Required
-SUM	Aggregation	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	AVG	Required
-SUM	Aggregation	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	SUM	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	<=	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	>=	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	AVG	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	SUM	Required
-TEMP_TABLES_AND_SUBQUERIES	Filters	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	<=	Required
-TEMP_TABLES_AND_SUBQUERIES	Filters	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	>=	Required
-TEMP_TABLES_AND_SUBQUERIES	Filters	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	AVG	Required
-	Filters	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	SUM	Required
-	Operator	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	<=	Required
-	Operator	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	>=	Required
-	Reference Line	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	AVG	Required
-	Reference Line	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	SUM	Required
-		tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	$IN_SET$	Required
-		tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	$NOT_IN_SET$	Required
-		tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	$SYS_NARY_AND$	Required
-		tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	$SYS_NARY_OR$	Required
-	Aggregation	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	AVG	Required
-	Aggregation	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	SUM	Required
-	Calculation	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	<=	Required
-	Calculation	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	>=	Required
-	Calculation	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	AVG	Required
-	Calculation	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	SUM	Required
-	Filters	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	<=	Required
-	Filters	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	>=	Required
-	Filters	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	AVG	Required
-	Filters	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	SUM	Required
-	Operator	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	<=	Required
-	Operator	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	>=	Required
-	Reference Line	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	AVG	Required
-	Reference Line	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	SUM	Required
-	Reference Line	tdvt/logicaltests/staples	Query.Nest_SliceQ	SUM	Required
-	Filters	tdvt/logicaltests/staples	Query.Nest_SliceQ	SUM	Required
-	Aggregation	tdvt/logicaltests/staples	Query.Nest_SliceQ	SUM	Required
-	Calculation	tdvt/logicaltests/staples	Query.Nest_SliceQ	SUM	Required
-	Reference Line	tdvt/logicaltests/staples	Query.Nest_SliceQ	AVG	Required
-	Filters	tdvt/logicaltests/staples	Query.Nest_SliceQ	AVG	Required
-	Aggregation	tdvt/logicaltests/staples	Query.Nest_SliceQ	AVG	Required
-	Calculation	tdvt/logicaltests/staples	Query.Nest_SliceQ	AVG	Required
-	Filters	tdvt/logicaltests/staples	Query.Nest_SliceQ	<=	Required
-	Operator	tdvt/logicaltests/staples	Query.Nest_SliceQ	<=	Required
-	Calculation	tdvt/logicaltests/staples	Query.Nest_SliceQ	<=	Required
-AVG	Filters	tdvt/logicaltests/staples	Query.Nest_SliceQ	>=	Required
-AVG	Operator	tdvt/logicaltests/staples	Query.Nest_SliceQ	>=	Required
-AVG	Calculation	tdvt/logicaltests/staples	Query.Nest_SliceQ	>=	Required
-AVG		tdvt/logicaltests/staples	Query.Nest_SliceQ	$SYS_NARY_AND$	Required
-AVG		tdvt/logicaltests/staples	Query.Nest_SliceQO	$NOT_IN_SET$	Required
-AVG		tdvt/logicaltests/staples	Query.Nest_SliceQO	$SYS_NARY_AND$	Required
-COUNT	Aggregation	tdvt/logicaltests/staples	Query.Nest_SliceQO	AVG	Required
-COUNTD	Aggregation	tdvt/logicaltests/staples	Query.Nest_SliceQO	SUM	Required
-MIN	Calculation	tdvt/logicaltests/staples	Query.Nest_SliceQO	<=	Required
-MIN	Calculation	tdvt/logicaltests/staples	Query.Nest_SliceQO	>=	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Nest_SliceQO	AVG	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Nest_SliceQO	SUM	Required
-SUM	Filters	tdvt/logicaltests/staples	Query.Nest_SliceQO	<=	Required
-SUM	Filters	tdvt/logicaltests/staples	Query.Nest_SliceQO	>=	Required
-SUM	Filters	tdvt/logicaltests/staples	Query.Nest_SliceQO	AVG	Required
-SUM	Filters	tdvt/logicaltests/staples	Query.Nest_SliceQO	SUM	Required
-SUM	Operator	tdvt/logicaltests/staples	Query.Nest_SliceQO	<=	Required
-SUM	Operator	tdvt/logicaltests/staples	Query.Nest_SliceQO	>=	Required
-SUM	Reference Line	tdvt/logicaltests/staples	Query.Nest_SliceQO	AVG	Required
-SUM	Reference Line	tdvt/logicaltests/staples	Query.Nest_SliceQO	SUM	Required
-SUM	Reference Line	tdvt/logicaltests/staples	Query.Sort_Alphabetic_DESC_Top1	SUM	Required
-SUM	Filters	tdvt/logicaltests/staples	Query.Sort_Alphabetic_DESC_Top1	SUM	Required
-SUM	Aggregation	tdvt/logicaltests/staples	Query.Sort_Alphabetic_DESC_Top1	SUM	Required
-SUM	Calculation	tdvt/logicaltests/staples	Query.Sort_Alphabetic_DESC_Top1	SUM	Required
-SUM	Temp Tables and Subqueries	tdvt/logicaltests/staples	Query.Sort_Alphabetic_DESC_Top1	TEMP_TABLES_AND_SUBQUERIES	Required
-SUM	Filters	tdvt/logicaltests/staples	Query.Sort_Alphabetic_DESC_Top1	TEMP_TABLES_AND_SUBQUERIES	Required
-!	Reference Line	tdvt/logicaltests/staples	Query.Sort_Alphabetic_DESC_Top10	SUM	Required
-*	Filters	tdvt/logicaltests/staples	Query.Sort_Alphabetic_DESC_Top10	SUM	Required
-*	Aggregation	tdvt/logicaltests/staples	Query.Sort_Alphabetic_DESC_Top10	SUM	Required
-+	Calculation	tdvt/logicaltests/staples	Query.Sort_Alphabetic_DESC_Top10	SUM	Required
-+	Temp Tables and Subqueries	tdvt/logicaltests/staples	Query.Sort_Alphabetic_DESC_Top10	TEMP_TABLES_AND_SUBQUERIES	Required
-+	Filters	tdvt/logicaltests/staples	Query.Sort_Alphabetic_DESC_Top10	TEMP_TABLES_AND_SUBQUERIES	Required
--	Aggregation	tdvt/logicaltests/staples	Query.Sort_Natural_DESC	SUM	Required
--	Calculation	tdvt/logicaltests/staples	Query.Sort_Natural_DESC	SUM	Required
-/	Filters	tdvt/logicaltests/staples	Query.Sort_Natural_DESC	SUM	Required
-<	Reference Line	tdvt/logicaltests/staples	Query.Sort_Natural_DESC	SUM	Required
-<=	Aggregation	tdvt/logicaltests/staples	Query.Top99_ByField	AVG	Required
-<=	Calculation	tdvt/logicaltests/staples	Query.Top99_ByField	AVG	Required
-<=	Filters	tdvt/logicaltests/staples	Query.Top99_ByField	AVG	Required
-<=	Filters	tdvt/logicaltests/staples	Query.Top99_ByField	TEMP_TABLES_AND_SUBQUERIES	Required
-<=	Reference Line	tdvt/logicaltests/staples	Query.Top99_ByField	AVG	Required
-<=	Temp Tables and Subqueries	tdvt/logicaltests/staples	Query.Top99_ByField	TEMP_TABLES_AND_SUBQUERIES	Required
-<=		tdvt/logicaltests/staples	Query.Unaggregated_Filter	$IN_SET$	Required
-<=		tdvt/logicaltests/staples	Query.Unaggregated_Filter	$NOT_IN_SET$	Required
-<=		tdvt/logicaltests/staples	Query.Unaggregated_Filter	$SYS_NARY_AND$	Required
-<=	Calculation	tdvt/logicaltests/staples	Query.Unaggregated_Filter	<=	Required
-<=	Calculation	tdvt/logicaltests/staples	Query.Unaggregated_Filter	>=	Required
-<=	Calculation	tdvt/logicaltests/staples	Query.Unaggregated_Filter	DATEPART	Required
-<=	Date Aggregation	tdvt/logicaltests/staples	Query.Unaggregated_Filter	DATEPART	Required
-<=	Date Filters	tdvt/logicaltests/staples	Query.Unaggregated_Filter	DATEPART	Required
-<=	Filters	tdvt/logicaltests/staples	Query.Unaggregated_Filter	<=	Required
-<=	Filters	tdvt/logicaltests/staples	Query.Unaggregated_Filter	>=	Required
-<=	Operator	tdvt/logicaltests/staples	Query.Unaggregated_Filter	<=	Required
-<=	Operator	tdvt/logicaltests/staples	Query.Unaggregated_Filter	>=	Required
-==		tdvt/logicaltests/staples	Query.Unaggregated_Filter_NoDateTime	$IN_SET$	Required
-==	Date Aggregation	tdvt/logicaltests/staples	Query.Unaggregated_Filter_NoDateTime	DATEPART	Required
->=	Date Filters	tdvt/logicaltests/staples	Query.Unaggregated_Filter_NoDateTime	DATEPART	Required
->=	Calculation	tdvt/logicaltests/staples	Query.Unaggregated_Filter_NoDateTime	DATEPART	Required
->=	Filters	tdvt/logicaltests/staples	Query.Unaggregated_Filter_NoDateTime	>=	Required
->=	Operator	tdvt/logicaltests/staples	Query.Unaggregated_Filter_NoDateTime	>=	Required
->=	Calculation	tdvt/logicaltests/staples	Query.Unaggregated_Filter_NoDateTime	>=	Required
->=		tdvt/logicaltests/staples	Query.Unaggregated_Filter_NoDateTime	$SYS_NARY_AND$	Required
->=	Filters	tdvt/logicaltests/staples	Query.Unaggregated_Filter_NoDateTime	<=	Required
->=	Operator	tdvt/logicaltests/staples	Query.Unaggregated_Filter_NoDateTime	<=	Required
->=	Calculation	tdvt/logicaltests/staples	Query.Unaggregated_Filter_NoDateTime	<=	Required
->=		tdvt/logicaltests/staples	Query.Unaggregated_Filter_NoDateTime	$NOT_IN_SET$	Required
->=	Aggregation	tdvt/exprtests/standard	string.ascii	COUNT	Recommended
->=	Calculation	tdvt/exprtests/standard	string.ascii	ASCII	Recommended
->=	Calculation	tdvt/exprtests/standard	string.ascii	ASCII	Recommended
->=	Calculation	tdvt/exprtests/standard	string.ascii	COUNT	Recommended
->=	Domain	tdvt/exprtests/standard	string.ascii	COUNT	Recommended
->=	Filters	tdvt/exprtests/standard	string.ascii	COUNT	Recommended
->=	Reference Line	tdvt/exprtests/standard	string.ascii	COUNT	Recommended
-AVG	Calculation	tdvt/exprtests/standard	string.B21622	INT	Required
-AVG	Calculation	tdvt/exprtests/standard	string.B21622	INT	Required
-AVG	Calculation	tdvt/exprtests/standard	string.B21622	STR	Required
-AVG	Calculation	tdvt/exprtests/standard	string.B21622	STR	Required
-AVG	Cast	tdvt/exprtests/standard	string.B21622	INT	Required
-AVG	Cast	tdvt/exprtests/standard	string.B21622	INT	Required
-COUNT	Cast	tdvt/exprtests/standard	string.B21622	STR	Required
-COUNTD	Cast	tdvt/exprtests/standard	string.B21622	STR	Required
-DATEADD	Data Prep	tdvt/exprtests/standard	string.B21622	INT	Required
-DATEPART	Data Prep	tdvt/exprtests/standard	string.B21622	INT	Required
-DATEPART	Filters	tdvt/exprtests/standard	string.B21622	STR	Required
-DATEPART	Filters	tdvt/exprtests/standard	string.B21622	STR	Required
-DATEPART	Reference Line	tdvt/exprtests/bind	string.bind_trim	COUNT	Recommended
-DATEPART	Filters	tdvt/exprtests/bind	string.bind_trim	COUNT	Recommended
-DATEPART	Domain	tdvt/exprtests/bind	string.bind_trim	COUNT	Recommended
-DATEPART	Aggregation	tdvt/exprtests/bind	string.bind_trim	COUNT	Recommended
-DATEPART	Calculation	tdvt/exprtests/bind	string.bind_trim	COUNT	Recommended
-DATETRUNC	Operator	tdvt/exprtests/bind	string.bind_trim	+	Recommended
-DATETRUNC	Calculation	tdvt/exprtests/bind	string.bind_trim	+	Recommended
-FLOAT	Calculation	tdvt/exprtests/standard	string.char	CHAR	Smoke
-INT		tdvt/exprtests/standard	string.char	Low Priority	Smoke
-ISNULL	Reference Line	tdvt/exprtests/standard	string.char	COUNT	Smoke
-MIN	Filters	tdvt/exprtests/standard	string.char	COUNT	Smoke
-MIN	Domain	tdvt/exprtests/standard	string.char	COUNT	Smoke
-SUM	Aggregation	tdvt/exprtests/standard	string.char	COUNT	Smoke
-SUM	Calculation	tdvt/exprtests/standard	string.char	COUNT	Smoke
-SUM	Aggregation	tdvt/exprtests/standard	string.constants	COUNT	Required
-SUM	Calculation	tdvt/exprtests/standard	string.constants	+	Required
-SUM	Calculation	tdvt/exprtests/standard	string.constants	COUNT	Required
-SUM	Domain	tdvt/exprtests/standard	string.constants	COUNT	Required
-SUM	Filters	tdvt/exprtests/standard	string.constants	COUNT	Required
-SUM	Operator	tdvt/exprtests/standard	string.constants	+	Required
-SUM	Reference Line	tdvt/exprtests/standard	string.constants	COUNT	Required
-SUM	Aggregation	tdvt/exprtests/standard	string.contains	MAX	Required
-SUM	Aggregation	tdvt/exprtests/standard	string.contains	MIN	Required
-SUM	Calculation	tdvt/exprtests/standard	string.contains	CONTAINS	Required
-SUM	Calculation	tdvt/exprtests/standard	string.contains	MAX	Required
-SUM	Calculation	tdvt/exprtests/standard	string.contains	MIN	Required
-SUM	Domain	tdvt/exprtests/standard	string.contains	MAX	Required
-SUM	Domain	tdvt/exprtests/standard	string.contains	MIN	Required
-FLOAT	Filters	tdvt/exprtests/standard	string.contains	MAX	Required
-INT	Filters	tdvt/exprtests/standard	string.contains	MIN	Required
-!	Wildcard Filters	tdvt/exprtests/standard	string.contains	CONTAINS	Required
-FLOAT	Filters	tdvt/exprtests/standard	string.endswith	MAX	Required
-INT	Domain	tdvt/exprtests/standard	string.endswith	MAX	Required
-DATEADD	Aggregation	tdvt/exprtests/standard	string.endswith	MAX	Required
-DATEPART	Calculation	tdvt/exprtests/standard	string.endswith	MAX	Required
-DATEPART	Filters	tdvt/exprtests/standard	string.endswith	ENDSWITH	Required
-DATEPART	Calculation	tdvt/exprtests/standard	string.endswith	ENDSWITH	Required
-DATEPART	Filters	tdvt/exprtests/standard	string.endswith	MIN	Required
-DATEPART	Domain	tdvt/exprtests/standard	string.endswith	MIN	Required
-DATEPART	Aggregation	tdvt/exprtests/standard	string.endswith	MIN	Required
-DATEPART	Calculation	tdvt/exprtests/standard	string.endswith	MIN	Required
-DATEPART	Operator	tdvt/exprtests/standard	string.find	*	Required
-DATETRUNC	Calculation	tdvt/exprtests/standard	string.find	*	Required
-DATETRUNC	Data Prep	tdvt/exprtests/standard	string.find	FIND	Required
-DATEADD	Calculation	tdvt/exprtests/standard	string.find	FIND	Required
-DATEPART	Data Prep	tdvt/exprtests/standard	string.find	FIND	Required
-DATEPART	Calculation	tdvt/exprtests/standard	string.find	FIND	Required
-DATEPART	Data Prep	tdvt/exprtests/standard	string.left	LEFT	Required
-DATEPART	Calculation	tdvt/exprtests/standard	string.left	LEFT	Required
-DATEPART	Data Prep	tdvt/exprtests/standard	string.left	LEFT	Required
-DATEPART	Calculation	tdvt/exprtests/standard	string.left	LEFT	Required
-DATEPART	Data Prep	tdvt/exprtests/standard	string.left.negative	LEFT	Required If Supported
-DATEPART	Calculation	tdvt/exprtests/standard	string.left.negative	LEFT	Required If Supported
-DATETRUNC	Calculation	tdvt/exprtests/standard	string.left.real	LEFT	Recommended
-DATETRUNC	Calculation	tdvt/exprtests/standard	string.left.real	LEFT	Recommended
-COUNT	Data Prep	tdvt/exprtests/standard	string.left.real	LEFT	Recommended
-COUNTD	Data Prep	tdvt/exprtests/standard	string.left.real	LEFT	Recommended
-MIN	Reference Line	tdvt/exprtests/standard	string.len	COUNT	Required
-MIN	Filters	tdvt/exprtests/standard	string.len	COUNT	Required
-<	Domain	tdvt/exprtests/standard	string.len	COUNT	Required
-<=	Aggregation	tdvt/exprtests/standard	string.len	COUNT	Required
-<=	Calculation	tdvt/exprtests/standard	string.len	COUNT	Required
-<=	Data Prep	tdvt/exprtests/standard	string.len	LEN	Required
-<=	Calculation	tdvt/exprtests/standard	string.len	LEN	Required
-<=	Data Prep	tdvt/exprtests/standard	string.len	LEN	Required
-<=	Calculation	tdvt/exprtests/standard	string.len	LEN	Required
-<=	Filters	tdvt/exprtests/standard	string.lower	LOWER	Required
-<=	Calculation	tdvt/exprtests/standard	string.lower	LOWER	Required
-<=	Filters	tdvt/exprtests/standard	string.lower	LOWER	Required
-<=	Calculation	tdvt/exprtests/standard	string.lower	LOWER	Required
-<=	Calculation	tdvt/exprtests/standard	string.ltrim	+	Required
-<=	Calculation	tdvt/exprtests/standard	string.ltrim	LTRIM	Required
-<=	Operator	tdvt/exprtests/standard	string.ltrim	+	Required
-<=	Aggregation	tdvt/exprtests/standard	string.max	MAX	Required
-<=	Calculation	tdvt/exprtests/standard	string.max	MAX	Required
-<=	Domain	tdvt/exprtests/standard	string.max	MAX	Required
-<=	Filters	tdvt/exprtests/standard	string.max	MAX	Required
-<=	Calculation	tdvt/exprtests/standard	string.mid	MID	Required
-==	Calculation	tdvt/exprtests/standard	string.mid	MID	Required
-==	Data Prep	tdvt/exprtests/standard	string.mid	MID	Required
->=	Data Prep	tdvt/exprtests/standard	string.mid	MID	Required
->=	Calculation	tdvt/exprtests/standard	string.mid.calc	*	Required
->=	Calculation	tdvt/exprtests/standard	string.mid.calc	+	Required
->=	Calculation	tdvt/exprtests/standard	string.mid.calc	MID	Required
->=	Calculation	tdvt/exprtests/standard	string.mid.calc	MID	Required
->=	Data Prep	tdvt/exprtests/standard	string.mid.calc	MID	Required
->=	Data Prep	tdvt/exprtests/standard	string.mid.calc	MID	Required
->=	Operator	tdvt/exprtests/standard	string.mid.calc	*	Required
->=	Operator	tdvt/exprtests/standard	string.mid.calc	+	Required
->=	Reference Line	tdvt/exprtests/standard	string.min	COUNT	Required
->=	Filters	tdvt/exprtests/standard	string.min	COUNT	Required
->=	Domain	tdvt/exprtests/standard	string.min	COUNT	Required
->=	Aggregation	tdvt/exprtests/standard	string.min	COUNT	Required
->=	Calculation	tdvt/exprtests/standard	string.min	COUNT	Required
->=	Filters	tdvt/exprtests/standard	string.min	MIN	Required
->=	Domain	tdvt/exprtests/standard	string.min	MIN	Required
->=	Aggregation	tdvt/exprtests/standard	string.min	MIN	Required
-AVG	Calculation	tdvt/exprtests/standard	string.min	MIN	Required
-AVG	Aggregation	tdvt/exprtests/standard	string.replace	COUNT	Required If Supported
-AVG	Calculation	tdvt/exprtests/standard	string.replace	COUNT	Required If Supported
-AVG	Calculation	tdvt/exprtests/standard	string.replace	REPLACE	Required If Supported
-AVG	Domain	tdvt/exprtests/standard	string.replace	COUNT	Required If Supported
-AVG	Filters	tdvt/exprtests/standard	string.replace	COUNT	Required If Supported
-COUNT	Reference Line	tdvt/exprtests/standard	string.replace	COUNT	Required If Supported
-COUNTD	Aggregation	tdvt/exprtests/standard	string.right	COUNT	Required
-MIN	Calculation	tdvt/exprtests/standard	string.right	COUNT	Required
-MIN	Calculation	tdvt/exprtests/standard	string.right	RIGHT	Required
-SUM	Calculation	tdvt/exprtests/standard	string.right	RIGHT	Required
-SUM	Domain	tdvt/exprtests/standard	string.right	COUNT	Required
-SUM	Filters	tdvt/exprtests/standard	string.right	COUNT	Required
-SUM	Reference Line	tdvt/exprtests/standard	string.right	COUNT	Required
-SUM	Calculation	tdvt/exprtests/standard	string.right.real	RIGHT	Required
-SUM	Calculation	tdvt/exprtests/standard	string.right.real	RIGHT	Required
-SUM	Calculation	tdvt/exprtests/standard	string.rtrim	+	Required
-SUM	Calculation	tdvt/exprtests/standard	string.rtrim	RTRIM	Required
-SUM	Operator	tdvt/exprtests/standard	string.rtrim	+	Required
-SUM	Reference Line	tdvt/exprtests/standard	string.space	COUNT	Required
-SUM	Filters	tdvt/exprtests/standard	string.space	COUNT	Required
-SUM	Domain	tdvt/exprtests/standard	string.space	COUNT	Required
-SUM	Aggregation	tdvt/exprtests/standard	string.space	COUNT	Required
-SUM	Calculation	tdvt/exprtests/standard	string.space	COUNT	Required
-SUM	Operator	tdvt/exprtests/standard	string.space	+	Required
-SUM	Calculation	tdvt/exprtests/standard	string.space	+	Required
-TEMP_TABLES_AND_SUBQUERIES	Calculation	tdvt/exprtests/standard	string.space	SPACE	Required
-ISNULL	Data Prep	tdvt/exprtests/standard	string.space.int.constant	INT	Required
-!	Cast	tdvt/exprtests/standard	string.space.int.constant	INT	Required
-*	Calculation	tdvt/exprtests/standard	string.space.int.constant	INT	Required
-*	Data Prep	tdvt/exprtests/standard	string.space.int.constant	INT	Required
-+	Cast	tdvt/exprtests/standard	string.space.int.constant	INT	Required
-+	Calculation	tdvt/exprtests/standard	string.space.int.constant	INT	Required
-+	Reference Line	tdvt/exprtests/standard	string.space.int.constant	COUNT	Required
--	Filters	tdvt/exprtests/standard	string.space.int.constant	COUNT	Required
--	Domain	tdvt/exprtests/standard	string.space.int.constant	COUNT	Required
-/	Aggregation	tdvt/exprtests/standard	string.space.int.constant	COUNT	Required
-<	Calculation	tdvt/exprtests/standard	string.space.int.constant	COUNT	Required
-<=	Calculation	tdvt/exprtests/standard	string.space.int.constant	SPACE	Required
-<=	Calculation	tdvt/exprtests/standard	string.space.int.var	SPACE	Required
-<=	Reference Line	tdvt/exprtests/standard	string.split	COUNT	Required
-<=	Filters	tdvt/exprtests/standard	string.split	COUNT	Required
-<=	Domain	tdvt/exprtests/standard	string.split	COUNT	Required
-<=	Aggregation	tdvt/exprtests/standard	string.split	COUNT	Required
-<=	Calculation	tdvt/exprtests/standard	string.split	COUNT	Required
-<=	Data Prep	tdvt/exprtests/standard	string.split	SPLIT	Required
-<=	Calculation	tdvt/exprtests/standard	string.split	SPLIT	Required
-<=	Aggregation	tdvt/exprtests/standard	string.split.right	COUNT	Required If Supported
-<=	Calculation	tdvt/exprtests/standard	string.split.right	COUNT	Required If Supported
-<=	Calculation	tdvt/exprtests/standard	string.split.right	SPLIT	Required If Supported
-<=	Data Prep	tdvt/exprtests/standard	string.split.right	SPLIT	Required If Supported
-<=	Domain	tdvt/exprtests/standard	string.split.right	COUNT	Required If Supported
-<=	Filters	tdvt/exprtests/standard	string.split.right	COUNT	Required If Supported
-<=	Reference Line	tdvt/exprtests/standard	string.split.right	COUNT	Required If Supported
-<=	Aggregation	tdvt/exprtests/standard	string.startswith	COUNT	Required
-<=	Aggregation	tdvt/exprtests/standard	string.startswith	MAX	Required
-==	Aggregation	tdvt/exprtests/standard	string.startswith	MIN	Required
-==	Calculation	tdvt/exprtests/standard	string.startswith	COUNT	Required
->=	Calculation	tdvt/exprtests/standard	string.startswith	MAX	Required
->=	Calculation	tdvt/exprtests/standard	string.startswith	MIN	Required
->=	Calculation	tdvt/exprtests/standard	string.startswith	STARTSWITH	Required
->=	Domain	tdvt/exprtests/standard	string.startswith	COUNT	Required
->=	Domain	tdvt/exprtests/standard	string.startswith	MAX	Required
->=	Domain	tdvt/exprtests/standard	string.startswith	MIN	Required
->=	Filters	tdvt/exprtests/standard	string.startswith	COUNT	Required
->=	Filters	tdvt/exprtests/standard	string.startswith	MAX	Required
->=	Filters	tdvt/exprtests/standard	string.startswith	MIN	Required
->=	Filters	tdvt/exprtests/standard	string.startswith	STARTSWITH	Required
->=	Reference Line	tdvt/exprtests/standard	string.startswith	COUNT	Required
->=	Data Prep	tdvt/exprtests/standard	string.trim	TRIM	Required If Supported
->=	Calculation	tdvt/exprtests/standard	string.trim	TRIM	Required If Supported
->=	Operator	tdvt/exprtests/standard	string.trim	+	Required If Supported
->=	Calculation	tdvt/exprtests/standard	string.trim	+	Required If Supported
->=	Reference Line	tdvt/exprtests/standard	string.upper	COUNT	Required
->=	Filters	tdvt/exprtests/standard	string.upper	COUNT	Required
-AVG	Domain	tdvt/exprtests/standard	string.upper	COUNT	Required
-AVG	Aggregation	tdvt/exprtests/standard	string.upper	COUNT	Required
-AVG	Calculation	tdvt/exprtests/standard	string.upper	COUNT	Required
-AVG	Calculation	tdvt/exprtests/standard	string.upper	UPPER	Required
-AVG	Calculation	tdvt/exprtests/standard	string.upper	UPPER	Required
-AVG	Aggregation	tdvt/exprtests/standard	string.utf8	COUNT	Recommended
-COUNT	Calculation	tdvt/exprtests/standard	string.utf8	COUNT	Recommended
-COUNTD	Calculation	tdvt/exprtests/standard	string.utf8	FIND	Recommended
-SUM	Calculation	tdvt/exprtests/standard	string.utf8	REPLACE	Recommended
-SUM	Data Prep	tdvt/exprtests/standard	string.utf8	FIND	Recommended
-SUM	Domain	tdvt/exprtests/standard	string.utf8	COUNT	Recommended
-SUM	Filters	tdvt/exprtests/standard	string.utf8	COUNT	Recommended
-SUM	Reference Line	tdvt/exprtests/standard	string.utf8	COUNT	Recommended
-SUM		tdvt/logicaltests/staples	ZTesting.Staples9	$SYS_NARY_AND$	Recommended
-SUM	Calculation	tdvt/logicaltests/staples	ZTesting.Staples9	<=	Recommended
-SUM	Calculation	tdvt/logicaltests/staples	ZTesting.Staples9	==	Recommended
-SUM	Calculation	tdvt/logicaltests/staples	ZTesting.Staples9	>=	Recommended
-SUM	Calculation	tdvt/logicaltests/staples	ZTesting.Staples9	DATEPART	Recommended
-SUM	Date Aggregation	tdvt/logicaltests/staples	ZTesting.Staples9	DATEPART	Recommended
-SUM	Date Filters	tdvt/logicaltests/staples	ZTesting.Staples9	DATEPART	Recommended
-SUM	Filters	tdvt/logicaltests/staples	ZTesting.Staples9	<=	Recommended
-SUM	Filters	tdvt/logicaltests/staples	ZTesting.Staples9	==	Recommended
-SUM	Filters	tdvt/logicaltests/staples	ZTesting.Staples9	>=	Recommended
-SUM	Operator	tdvt/logicaltests/staples	ZTesting.Staples9	<=	Recommended
-TEMP_TABLES_AND_SUBQUERIES	Operator	tdvt/logicaltests/staples	ZTesting.Staples9	==	Recommended
-TEMP_TABLES_AND_SUBQUERIES	Operator	tdvt/logicaltests/staples	ZTesting.Staples9	>=	Recommended
+Test Category	Test Path Categorized	Test Name Categorized	Function Categorized	Priority
+Aggregation	tdvt/exprtests/standard	agg.avg	AVG	Required
+Aggregation	tdvt/exprtests/standard	agg.avg	COUNT	Required
+Aggregation	tdvt/exprtests/standard	agg.count	COUNT	Required
+Aggregation	tdvt/exprtests/standard	agg.countd	COUNT	Required
+Aggregation	tdvt/exprtests/standard	agg.countd	COUNTD	Required
+Column Metadata Nullability	tdvt/exprtests/standard	agg.countd	COLUMN_NULLABILITY	Required
+Aggregation	tdvt/exprtests/standard	agg.max	COUNT	Required
+Aggregation	tdvt/exprtests/standard	agg.max	MAX	Required
+Aggregation	tdvt/exprtests/standard	agg.min	COUNT	Required
+Aggregation	tdvt/exprtests/standard	agg.min	MIN	Required
+Aggregation	tdvt/exprtests/standard	agg.stddev	COUNT	Required
+Aggregation	tdvt/exprtests/standard	agg.stddev	STDEVP	Required
+Aggregation	tdvt/exprtests/standard	agg.stddev	STDEV	Required
+Aggregation	tdvt/exprtests/standard	agg.sum	COUNT	Required
+Aggregation	tdvt/exprtests/standard	agg.sum	SUM	Required
+Aggregation	tdvt/exprtests/standard	agg.var	COUNT	Required
+Aggregation	tdvt/exprtests/standard	agg.var	VAR	Required
+Aggregation	tdvt/exprtests/standard	agg.var	VARP	Required
+Operator	tdvt/logicaltests/staples	BUGS.B14080	-	Required
+Operator	tdvt/logicaltests/staples	BUGS.B14080	!	Required
+Sets	tdvt/logicaltests/staples	BUGS.B14080	$IN_SET$	Required
+Logical	tdvt/logicaltests/staples	BUGS.B14080	$SYS_NARY_AND$	Required
+Cast	tdvt/logicaltests/staples	BUGS.B14080	FLOAT	Required
+Calculation	tdvt/logicaltests/staples	BUGS.B14080	ISNULL	Required
+NULL Semantics	tdvt/logicaltests/staples	BUGS.B14080	ISNULL	Required
+Aggregation	tdvt/logicaltests/staples	BUGS.B14080	SUM	Required
+Filters	tdvt/logicaltests/calcs	BUGS.B1713	<=	Required
+Operator	tdvt/logicaltests/calcs	BUGS.B1713	<=	Required
+Filters	tdvt/logicaltests/calcs	BUGS.B1713	>=	Required
+Operator	tdvt/logicaltests/calcs	BUGS.B1713	>=	Required
+Logical	tdvt/logicaltests/calcs	BUGS.B1713	$SYS_NARY_AND$	Required
+Logical	tdvt/logicaltests/calcs	BUGS.B1713	$SYS_NARY_OR$	Required
+Aggregation	tdvt/logicaltests/calcs	BUGS.B1713	COUNT	Required
+Aggregation	tdvt/logicaltests/calcs	BUGS.B1713	SUM	Required
+Filters	tdvt/logicaltests/calcs	BUGS.B1713	TEMP_TABLES_AND_SUBQUERIES	Required
+Temp Tables and Subqueries	tdvt/logicaltests/calcs	BUGS.B1713	TEMP_TABLES_AND_SUBQUERIES	Required
+Filters	tdvt/logicaltests/staples	BUGS.B24394	<=	Required
+Operator	tdvt/logicaltests/staples	BUGS.B24394	<=	Required
+Date Filters	tdvt/logicaltests/staples	BUGS.B24394	DATEPART	Required
+Date Filters	tdvt/logicaltests/staples	BUGS.B24394	DATETRUNC	Required
+Date Filters	tdvt/logicaltests/calcs	BUGS.B26728	DATEDIFF	Required
+Bins	tdvt/logicaltests/calcs	BUGS.B26728	SYS_NUMBIN	Required
+Aggregation	tdvt/logicaltests/calcs	BUGS.B27875-asc-nulls-first	SUM	Recommended
+Filters	tdvt/logicaltests/calcs	BUGS.B27875-asc-nulls-first	TEMP_TABLES_AND_SUBQUERIES	Recommended
+Temp Tables and Subqueries	tdvt/logicaltests/calcs	BUGS.B27875-asc-nulls-first	TEMP_TABLES_AND_SUBQUERIES	Recommended
+Aggregation	tdvt/logicaltests/calcs	BUGS.B27875-desc-nulls-last	SUM	Recommended
+Filters	tdvt/logicaltests/calcs	BUGS.B27875-desc-nulls-last	TEMP_TABLES_AND_SUBQUERIES	Recommended
+Temp Tables and Subqueries	tdvt/logicaltests/calcs	BUGS.B27875-desc-nulls-last	TEMP_TABLES_AND_SUBQUERIES	Recommended
+Filters	tdvt/logicaltests/staples	BUGS.B340	<=	Recommended
+Operator	tdvt/logicaltests/staples	BUGS.B340	<=	Recommended
+Filters	tdvt/logicaltests/staples	BUGS.B340	>=	Recommended
+Operator	tdvt/logicaltests/staples	BUGS.B340	>=	Recommended
+Logical	tdvt/logicaltests/staples	BUGS.B340	$SYS_NARY_AND$	Recommended
+Aggregation	tdvt/logicaltests/staples	BUGS.B340	MIN	Recommended
+Aggregation	tdvt/logicaltests/staples	BUGS.B340	SUM	Recommended
+Temp Tables and Subqueries	tdvt/logicaltests/staples	BUGS.B340	TEMP_TABLES_AND_SUBQUERIES	Recommended
+Filters	tdvt/logicaltests/staples	BUGS.B340	TEMP_TABLES_AND_SUBQUERIES	Recommended
+Operator	tdvt/logicaltests/staples	BUGS.B530764	/	Recommended
+Aggregation	tdvt/logicaltests/staples	BUGS.B530764	COUNT	Recommended
+Aggregation	tdvt/logicaltests/staples	BUGS.B530764	SUM	Recommended
+Filters	tdvt/logicaltests/calcs	BUGS.B59740	==	Required
+Operator	tdvt/logicaltests/calcs	BUGS.B59740	==	Required
+Sets	tdvt/logicaltests/calcs	BUGS.B59740	$IN_SET$	Required
+Sets	tdvt/logicaltests/calcs	BUGS.B641638	$IN_SET$	Recommended
+Aggregation	tdvt/logicaltests/calcs	BUGS.B641638	SUM	Recommended
+Operator	tdvt/logicaltests/staples	BUGS.B8888	-	Recommended
+Operator	tdvt/logicaltests/staples	BUGS.B8888	/	Recommended
+Operator	tdvt/logicaltests/staples	BUGS.B8888	+	Recommended
+Filters	tdvt/logicaltests/staples	BUGS.B8888	<	Recommended
+Operator	tdvt/logicaltests/staples	BUGS.B8888	<	Recommended
+Aggregation	tdvt/logicaltests/staples	BUGS.B8888	COUNTD	Recommended
+Date Filters	tdvt/logicaltests/staples	BUGS.B8888	DATEADD	Recommended
+Date Filters	tdvt/logicaltests/staples	BUGS.B8888	DATEPART	Recommended
+Date Filters	tdvt/logicaltests/staples	BUGS.B8888	DATETRUNC	Recommended
+Cast	tdvt/logicaltests/staples	BUGS.B8888	INT	Recommended
+Filters	tdvt/logicaltests/calcs	BUGS.TFS660780	==	Required
+Operator	tdvt/logicaltests/calcs	BUGS.TFS660780	==	Required
+Aggregation	tdvt/logicaltests/calcs	BUGS.TFS660780	COUNT	Required
+Aggregation	tdvt/logicaltests/calcs	BUGS.TFS660780	SUM	Required
+Filters	tdvt/logicaltests/union	calcs.union	TEMP_TABLES_AND_SUBQUERIES	Required If Supported
+Temp Tables and Subqueries	tdvt/logicaltests/union	calcs.union	TEMP_TABLES_AND_SUBQUERIES	Required If Supported
+Union	tdvt/logicaltests/union	calcs.union	UNION	Required If Supported
+Aggregation	tdvt/exprtests/standard	calcs_data	MAX	Required If Supported
+Time Values	tdvt/exprtests/standard	calcs_data	TIME1899	Required If Supported
+Aggregation	tdvt/exprtests/standard	calcs_data	MIN	Required If Supported
+Cast	tdvt/exprtests/standard	cast.float	FLOAT	Required
+Cast	tdvt/exprtests/standard	cast.float.string	FLOAT	Required
+Operator	tdvt/exprtests/standard	cast.float.string	+	Required
+Calculation	tdvt/exprtests/standard	cast.float.string	RIGHT	Required
+Cast	tdvt/exprtests/standard	cast.float.string	FLOAT	Required
+Cast	tdvt/exprtests/standard	cast.int	INT	Required
+Cast	tdvt/exprtests/standard	cast.int.nulls	INT	Required
+Cast	tdvt/exprtests/standard	cast.int.nulls	INT	Required
+Cast	tdvt/exprtests/standard	cast.int.nulls	STR	Required
+Cast	tdvt/exprtests/standard	cast.int.nulls	STR	Required
+Operator	tdvt/exprtests/standard	cast.int.nulls	+	Required
+Cast	tdvt/exprtests/standard	cast.str	STR	Required
+Cast	tdvt/exprtests/standard	cast.str.date	DATE	Required
+Cast	tdvt/exprtests/standard	cast.str.date	STR	Required
+Cast	tdvt/exprtests/standard	cast.str.str	STR	Required
+Aggregation	tdvt/exprtests/standard	date.B639952	COUNT	Required
+Aggregation	tdvt/exprtests/standard	date.B639952	SUM	Required
+Cast	tdvt/exprtests/standard	date.B639952	DATE	Required
+Cast	tdvt/exprtests/standard	date.B639952	DATE	Required
+Date Filters	tdvt/exprtests/standard	date.B639952	DATEADD	Required
+Date Filters	tdvt/exprtests/standard	date.B639952	DATEADD	Required
+Operator	tdvt/exprtests/standard	date.B639952	+	Required
+Operator	tdvt/exprtests/standard	date.B639952	-	Required
+Cast	tdvt/exprtests/standard	date.cast.date	DATE	Required
+Aggregation	tdvt/exprtests/standard	date.cast.datetime.630831	COUNT	Smoke
+Cast	tdvt/exprtests/standard	date.cast.datetime.630831	DATE	Smoke
+Cast	tdvt/exprtests/standard	date.cast.datetime.630831	DATE	Smoke
+Cast	tdvt/exprtests/standard	date.cast.float	FLOAT	Recommended
+Aggregation	tdvt/exprtests/standard	date.cast.float.extended	COUNT	Recommended
+Cast	tdvt/exprtests/standard	date.cast.float.extended	FLOAT	Recommended
+Cast	tdvt/exprtests/standard	date.cast.float.extended	FLOAT	Recommended
+Aggregation	tdvt/exprtests/standard	date.cast.int.extended	COUNT	Recommended
+Cast	tdvt/exprtests/standard	date.cast.int.extended	INT	Recommended
+Cast	tdvt/exprtests/standard	date.cast.int.extended	INT	Recommended
+Cast	tdvt/exprtests/standard	date.cast.num_to_date	DATE	Recommended
+Calculation	tdvt/exprtests/standard	date.cast.str	TRIM	Required
+Cast	tdvt/exprtests/standard	date.cast.str	STR	Required
+Data Prep	tdvt/exprtests/standard	date.cast.str	TRIM	Required
+Date Filters	tdvt/exprtests/standard	date.dateadd.day	DATEADD	Required
+Date Filters	tdvt/exprtests/standard	date.dateadd.dayofyear	DATEADD	Required
+Date Filters	tdvt/exprtests/standard	date.dateadd.hour	DATEADD	Required
+Aggregation	tdvt/exprtests/iso8601week	date.dateadd.iso-week	COUNT	Recommended
+Date Filters	tdvt/exprtests/iso8601week	date.dateadd.iso-week	DATEADD	Recommended
+Aggregation	tdvt/exprtests/iso8601week	date.dateadd.iso-weekday	COUNT	Recommended
+Date Filters	tdvt/exprtests/iso8601week	date.dateadd.iso-weekday	DATEADD	Recommended
+Date Filters	tdvt/exprtests/standard	date.dateadd.minute	DATEADD	Required
+Date Filters	tdvt/exprtests/standard	date.dateadd.month	DATEADD	Required
+Cast	tdvt/exprtests/standard	date.dateadd.nulls	DATE	Required If Supported
+Aggregation	tdvt/exprtests/standard	date.dateadd.nulls	COUNT	Required If Supported
+Date Filters	tdvt/exprtests/standard	date.dateadd.nulls	DATEADD	Required If Supported
+Date Filters	tdvt/exprtests/standard	date.dateadd.quarter	DATEADD	Required
+Date Filters	tdvt/exprtests/standard	date.dateadd.second	DATEADD	Required
+Date Filters	tdvt/exprtests/standard	date.dateadd.week	DATEADD	Required
+Date Filters	tdvt/exprtests/standard	date.dateadd.weekday	DATEADD	Required
+Date Filters	tdvt/exprtests/standard	date.dateadd.year	DATEADD	Required
+Date Filters	tdvt/exprtests/standard	date.datediff.day	DATEDIFF	Required
+Date Filters	tdvt/exprtests/standard	date.datediff.dayofyear	DATEDIFF	Required
+Date Filters	tdvt/exprtests/standard	date.datediff.hour	DATEDIFF	Required
+Aggregation	tdvt/exprtests/iso8601week	date.datediff.iso-week	COUNT	Recommended
+Date Filters	tdvt/exprtests/iso8601week	date.datediff.iso-week	DATEDIFF	Recommended
+Aggregation	tdvt/exprtests/iso8601week	date.datediff.iso-weekday	COUNT	Recommended
+Date Filters	tdvt/exprtests/iso8601week	date.datediff.iso-weekday	DATEDIFF	Recommended
+Date Filters	tdvt/exprtests/standard	date.datediff.minute	DATEDIFF	Required
+Date Filters	tdvt/exprtests/standard	date.datediff.month	DATEDIFF	Required
+Aggregation	tdvt/exprtests/standard	date.datediff.nulls	COUNT	Required If Supported
+Cast	tdvt/exprtests/standard	date.datediff.nulls	DATE	Required If Supported
+Date Filters	tdvt/exprtests/standard	date.datediff.nulls	DATEDIFF	Required If Supported
+Date Filters	tdvt/exprtests/standard	date.datediff.quarter	DATEDIFF	Required
+Date Filters	tdvt/exprtests/standard	date.datediff.second	DATEDIFF	Required
+Date Filters	tdvt/exprtests/standard	date.datediff.sow.day	DATEDIFF	Required
+Date Filters	tdvt/exprtests/standard	date.datediff.sow.dayofyear	DATEDIFF	Required
+Date Filters	tdvt/exprtests/standard	date.datediff.sow.hour	DATEDIFF	Required
+Date Filters	tdvt/exprtests/standard	date.datediff.sow.minute	DATEDIFF	Required
+Date Filters	tdvt/exprtests/standard	date.datediff.sow.month	DATEDIFF	Required
+Aggregation	tdvt/exprtests/standard	date.datediff.sow.nulls	COUNT	Recommended
+Cast	tdvt/exprtests/standard	date.datediff.sow.nulls	DATE	Recommended
+Date Filters	tdvt/exprtests/standard	date.datediff.sow.nulls	DATEDIFF	Recommended
+Date Filters	tdvt/exprtests/standard	date.datediff.sow.quarter	DATEDIFF	Required
+Date Filters	tdvt/exprtests/standard	date.datediff.sow.second	DATEDIFF	Required
+Date Filters	tdvt/exprtests/standard	date.datediff.sow.week	DATEDIFF	Required
+Date Filters	tdvt/exprtests/standard	date.datediff.sow.weekday	DATEDIFF	Required
+Date Filters	tdvt/exprtests/standard	date.datediff.sow.year	DATEDIFF	Required
+Date Filters	tdvt/exprtests/standard	date.datediff.week	DATEDIFF	Required
+Date Filters	tdvt/exprtests/standard	date.datediff.week.extended	DATEDIFF	Required
+Date Filters	tdvt/exprtests/standard	date.datediff.weekday	DATEDIFF	Required
+Date Filters	tdvt/exprtests/standard	date.datediff.year	DATEDIFF	Required
+Date Filters	tdvt/exprtests/standard	date.datename.day	DATENAME	Required
+Date Filters	tdvt/exprtests/standard	date.datename.dayofyear	DATENAME	Required
+Date Filters	tdvt/exprtests/standard	date.datename.hour	DATENAME	Required
+Aggregation	tdvt/exprtests/iso8601week	date.datename.iso-quarter	COUNT	Recommended
+Date Filters	tdvt/exprtests/iso8601week	date.datename.iso-quarter	DATENAME	Recommended
+Aggregation	tdvt/exprtests/iso8601week	date.datename.iso-week	COUNT	Recommended
+Date Filters	tdvt/exprtests/iso8601week	date.datename.iso-week	DATENAME	Recommended
+Aggregation	tdvt/exprtests/iso8601week	date.datename.iso-weekday	COUNT	Recommended
+Date Filters	tdvt/exprtests/iso8601week	date.datename.iso-weekday	DATENAME	Recommended
+Aggregation	tdvt/exprtests/iso8601week	date.datename.iso-year	COUNT	Recommended
+Date Filters	tdvt/exprtests/iso8601week	date.datename.iso-year	DATENAME	Recommended
+Date Filters	tdvt/exprtests/standard	date.datename.minute	DATENAME	Required
+Date Filters	tdvt/exprtests/standard	date.datename.month	DATENAME	Required
+Cast	tdvt/exprtests/standard	date.datename.nulls	DATE	Required If Supported
+Aggregation	tdvt/exprtests/standard	date.datename.nulls	COUNT	Required If Supported
+Date Filters	tdvt/exprtests/standard	date.datename.nulls	DATENAME	Required If Supported
+Date Filters	tdvt/exprtests/standard	date.datename.quarter	DATENAME	Required
+Date Filters	tdvt/exprtests/standard	date.datename.second	DATENAME	Required
+Date Filters	tdvt/exprtests/standard	date.datename.sow.day	DATENAME	Required
+Date Filters	tdvt/exprtests/standard	date.datename.sow.dayofyear	DATENAME	Required
+Date Filters	tdvt/exprtests/standard	date.datename.sow.hour	DATENAME	Required
+Date Filters	tdvt/exprtests/standard	date.datename.sow.minute	DATENAME	Required
+Date Filters	tdvt/exprtests/standard	date.datename.sow.month	DATENAME	Required
+Aggregation	tdvt/exprtests/standard	date.datename.sow.nulls	COUNT	Recommended
+Cast	tdvt/exprtests/standard	date.datename.sow.nulls	DATE	Recommended
+Date Filters	tdvt/exprtests/standard	date.datename.sow.nulls	DATENAME	Recommended
+Date Filters	tdvt/exprtests/standard	date.datename.sow.quarter	DATENAME	Required
+Date Filters	tdvt/exprtests/standard	date.datename.sow.second	DATENAME	Required
+Date Filters	tdvt/exprtests/standard	date.datename.sow.week	DATENAME	Required
+Date Filters	tdvt/exprtests/standard	date.datename.sow.weekday	DATENAME	Required
+Date Filters	tdvt/exprtests/standard	date.datename.sow.year	DATENAME	Required
+Date Filters	tdvt/exprtests/standard	date.datename.week	DATENAME	Required
+Date Filters	tdvt/exprtests/standard	date.datename.weekday	DATENAME	Required
+Date Filters	tdvt/exprtests/standard	date.datename.year	DATENAME	Required
+Aggregation	tdvt/exprtests/dateparse	date.dateparse.hour	COUNT	Recommended
+Date Filters	tdvt/exprtests/dateparse	date.dateparse.hour	DATEPARSE	Recommended
+Aggregation	tdvt/exprtests/dateparse	date.dateparse.month	COUNT	Recommended
+Date Filters	tdvt/exprtests/dateparse	date.dateparse.month	DATEPARSE	Recommended
+Aggregation	tdvt/exprtests/dateparse	date.dateparse.weekday	COUNT	Recommended
+Date Filters	tdvt/exprtests/dateparse	date.dateparse.weekday	DATEPARSE	Recommended
+Date Filters	tdvt/exprtests/dateparse	date.dateparse.year	DATEPARSE	Recommended
+Aggregation	tdvt/exprtests/dateparse	date.dateparse.year	COUNT	Recommended
+Date Filters	tdvt/exprtests/standard	date.datepart.dateadd.defect603107	DATEADD	Required
+Date Filters	tdvt/exprtests/standard	date.datepart.dateadd.defect603107	DATEPART	Required
+Operator	tdvt/exprtests/standard	date.datepart.dateadd.defect603107	+	Required
+Operator	tdvt/exprtests/standard	date.datepart.dateadd.defect603107	-	Required
+Date Filters	tdvt/exprtests/standard	date.datepart.day	DATEPART	Required
+Date Filters	tdvt/exprtests/standard	date.datepart.dayofyear	DATEPART	Required
+Date Filters	tdvt/exprtests/standard	date.datepart.hour	DATEPART	Required
+Aggregation	tdvt/exprtests/iso8601week	date.datepart.iso-quarter	COUNT	Recommended
+Date Filters	tdvt/exprtests/iso8601week	date.datepart.iso-quarter	DATEPART	Recommended
+Aggregation	tdvt/exprtests/iso8601week	date.datepart.iso-week	COUNT	Recommended
+Date Filters	tdvt/exprtests/iso8601week	date.datepart.iso-week	DATEPART	Recommended
+Aggregation	tdvt/exprtests/iso8601week	date.datepart.iso-weekday	COUNT	Recommended
+Date Filters	tdvt/exprtests/iso8601week	date.datepart.iso-weekday	DATEPART	Recommended
+Aggregation	tdvt/exprtests/iso8601week	date.datepart.iso-year	COUNT	Recommended
+Date Filters	tdvt/exprtests/iso8601week	date.datepart.iso-year	DATEPART	Recommended
+Date Filters	tdvt/exprtests/standard	date.datepart.minute	DATEPART	Required
+Date Filters	tdvt/exprtests/standard	date.datepart.month	DATEPART	Required
+Aggregation	tdvt/exprtests/standard	date.datepart.nulls	COUNT	Required If Supported
+Cast	tdvt/exprtests/standard	date.datepart.nulls	DATE	Required If Supported
+Date Filters	tdvt/exprtests/standard	date.datepart.nulls	DATEPART	Required If Supported
+Date Filters	tdvt/exprtests/standard	date.datepart.quarter	DATEPART	Required
+Date Filters	tdvt/exprtests/standard	date.datepart.second	DATEPART	Required
+Aggregation	tdvt/exprtests/standard	date.datepart.second.ms	COUNT	Required
+Date Filters	tdvt/exprtests/standard	date.datepart.second.ms	DATEPART	Required
+Date Filters	tdvt/exprtests/standard	date.datepart.sow.day	DATEPART	Required
+Date Filters	tdvt/exprtests/standard	date.datepart.sow.dayofyear	DATEPART	Required
+Date Filters	tdvt/exprtests/standard	date.datepart.sow.hour	DATEPART	Required
+Date Filters	tdvt/exprtests/standard	date.datepart.sow.minute	DATEPART	Required
+Date Filters	tdvt/exprtests/standard	date.datepart.sow.month	DATEPART	Required
+Cast	tdvt/exprtests/standard	date.datepart.sow.nulls	DATE	Recommended
+Aggregation	tdvt/exprtests/standard	date.datepart.sow.nulls	COUNT	Recommended
+Date Filters	tdvt/exprtests/standard	date.datepart.sow.nulls	DATEPART	Recommended
+Date Filters	tdvt/exprtests/standard	date.datepart.sow.quarter	DATEPART	Required
+Date Filters	tdvt/exprtests/standard	date.datepart.sow.second	DATEPART	Required
+Date Filters	tdvt/exprtests/standard	date.datepart.sow.week	DATEPART	Required
+Date Filters	tdvt/exprtests/standard	date.datepart.sow.weekday	DATEPART	Required
+Date Filters	tdvt/exprtests/standard	date.datepart.sow.year	DATEPART	Required
+Cast	tdvt/exprtests/standard	date.datepart.week	DATE	Required
+Date Filters	tdvt/exprtests/standard	date.datepart.week	DATEPART	Required
+Date Filters	tdvt/exprtests/standard	date.datepart.weekday	DATEPART	Required
+Date Filters	tdvt/exprtests/standard	date.datepart.year	DATEPART	Required
+Date Filters	tdvt/exprtests/standard	date.datetrunc.day	DATETRUNC	Required
+Date Filters	tdvt/exprtests/standard	date.datetrunc.dayofyear	DATETRUNC	Required
+Date Filters	tdvt/exprtests/standard	date.datetrunc.hour	DATETRUNC	Required
+Aggregation	tdvt/exprtests/iso8601week	date.datetrunc.iso-quarter	COUNT	Recommended
+Date Filters	tdvt/exprtests/iso8601week	date.datetrunc.iso-quarter	DATEPART	Recommended
+Date Filters	tdvt/exprtests/iso8601week	date.datetrunc.iso-quarter	DATETRUNC	Recommended
+Aggregation	tdvt/exprtests/iso8601week	date.datetrunc.iso-week	COUNT	Recommended
+Date Filters	tdvt/exprtests/iso8601week	date.datetrunc.iso-week	DATETRUNC	Recommended
+Aggregation	tdvt/exprtests/iso8601week	date.datetrunc.iso-weekday	COUNT	Recommended
+Date Filters	tdvt/exprtests/iso8601week	date.datetrunc.iso-weekday	DATETRUNC	Recommended
+Aggregation	tdvt/exprtests/iso8601week	date.datetrunc.iso-year	COUNT	Recommended
+Date Filters	tdvt/exprtests/iso8601week	date.datetrunc.iso-year	DATEPART	Recommended
+Date Filters	tdvt/exprtests/iso8601week	date.datetrunc.iso-year	DATETRUNC	Recommended
+Date Filters	tdvt/exprtests/standard	date.datetrunc.minute	DATETRUNC	Required
+Date Filters	tdvt/exprtests/standard	date.datetrunc.month	DATETRUNC	Required
+Cast	tdvt/exprtests/standard	date.datetrunc.nulls	DATE	Required If Supported
+Aggregation	tdvt/exprtests/standard	date.datetrunc.nulls	COUNT	Required If Supported
+Date Filters	tdvt/exprtests/standard	date.datetrunc.nulls	DATETRUNC	Required If Supported
+Date Filters	tdvt/exprtests/standard	date.datetrunc.quarter	DATETRUNC	Required
+Date Filters	tdvt/exprtests/standard	date.datetrunc.second	DATETRUNC	Required
+Date Filters	tdvt/exprtests/standard	date.datetrunc.sow.day	DATETRUNC	Required
+Date Filters	tdvt/exprtests/standard	date.datetrunc.sow.dayofyear	DATETRUNC	Required
+Date Filters	tdvt/exprtests/standard	date.datetrunc.sow.hour	DATETRUNC	Required
+Date Filters	tdvt/exprtests/standard	date.datetrunc.sow.minute	DATETRUNC	Required
+Date Filters	tdvt/exprtests/standard	date.datetrunc.sow.month	DATETRUNC	Required
+Aggregation	tdvt/exprtests/standard	date.datetrunc.sow.nulls	COUNT	Recommended
+Cast	tdvt/exprtests/standard	date.datetrunc.sow.nulls	DATE	Recommended
+Date Filters	tdvt/exprtests/standard	date.datetrunc.sow.nulls	DATETRUNC	Recommended
+Date Filters	tdvt/exprtests/standard	date.datetrunc.sow.quarter	DATETRUNC	Required
+Date Filters	tdvt/exprtests/standard	date.datetrunc.sow.second	DATETRUNC	Required
+Date Filters	tdvt/exprtests/standard	date.datetrunc.sow.week	DATETRUNC	Required
+Date Filters	tdvt/exprtests/standard	date.datetrunc.sow.weekday	DATETRUNC	Required
+Date Filters	tdvt/exprtests/standard	date.datetrunc.sow.year	DATETRUNC	Required
+Date Filters	tdvt/exprtests/standard	date.datetrunc.week	DATETRUNC	Required
+Date Filters	tdvt/exprtests/standard	date.datetrunc.weekday	DATETRUNC	Required
+Date Filters	tdvt/exprtests/standard	date.datetrunc.year	DATETRUNC	Required
+Aggregation	tdvt/exprtests/standard	date.math	COUNT	Recommended
+Aggregation	tdvt/exprtests/standard	date.math	MAX	Recommended
+Aggregation	tdvt/exprtests/standard	date.math	MIN	Recommended
+Date Filters	tdvt/exprtests/standard	date.math	DATEDIFF	Recommended
+Date Filters	tdvt/exprtests/standard	date.math	NOW	Recommended
+Date Filters	tdvt/exprtests/standard	date.math	TODAY	Recommended
+Filters	tdvt/exprtests/standard	date.math	<	Recommended
+Filters	tdvt/exprtests/standard	date.math	<=	Recommended
+Filters	tdvt/exprtests/standard	date.math	==	Recommended
+Filters	tdvt/exprtests/standard	date.math	>	Recommended
+Filters	tdvt/exprtests/standard	date.math	>=	Recommended
+Operator	tdvt/exprtests/standard	date.math	!=	Recommended
+Operator	tdvt/exprtests/standard	date.math	+	Recommended
+Operator	tdvt/exprtests/standard	date.math	-	Recommended
+Operator	tdvt/exprtests/standard	date.math	<	Recommended
+Operator	tdvt/exprtests/standard	date.math	<=	Recommended
+Operator	tdvt/exprtests/standard	date.math	==	Recommended
+Operator	tdvt/exprtests/standard	date.math	>	Recommended
+Operator	tdvt/exprtests/standard	date.math	>=	Recommended
+Operator	tdvt/exprtests/standard	date.math.date_minus_date	-	Recommended
+Aggregation	tdvt/exprtests/standard	date.max	COUNT	Required
+Aggregation	tdvt/exprtests/standard	date.max	MAX	Required
+Aggregation	tdvt/exprtests/standard	date.min	COUNT	Required
+Aggregation	tdvt/exprtests/standard	date.min	MIN	Required
+Cast	tdvt/exprtests/standard	date.misc	DATE	Required
+Date Filters	tdvt/exprtests/standard	date.misc	YEAR	Required
+Date Aggregation	tdvt/exprtests/standard	date.misc	YEAR	Required
+Calculation	tdvt/exprtests/standard	date.misc	YEAR	Required
+Date Filters	tdvt/exprtests/standard	date.misc	MONTH	Required
+Date Aggregation	tdvt/exprtests/standard	date.misc	MONTH	Required
+Calculation	tdvt/exprtests/standard	date.misc	MONTH	Required
+Date Aggregation	tdvt/exprtests/standard	date.misc	DAY	Required
+Date Filters	tdvt/exprtests/standard	date.misc	DAY	Required
+Calculation	tdvt/exprtests/standard	date.misc	DAY	Required
+Aggregation	tdvt/exprtests/standard	date.now	COUNT	Recommended
+Date Filters	tdvt/exprtests/standard	date.now	DATEPART	Recommended
+Aggregation	tdvt/exprtests/standard	date.now	MIN	Recommended
+Filters	tdvt/exprtests/standard	date.now	==	Recommended
+Operator	tdvt/exprtests/standard	date.now	==	Recommended
+Aggregation	tdvt/exprtests/standard	date.now	MAX	Recommended
+Date Filters	tdvt/exprtests/standard	date.now	DATEPART	Recommended
+Date Filters	tdvt/exprtests/standard	date.now	NOW	Recommended
+Date Filters	tdvt/exprtests/standard	date.now	NOW	Recommended
+Aggregation	tdvt/exprtests/standard	date.today	COUNT	Required
+Date Filters	tdvt/exprtests/standard	date.today	DATEPART	Required
+Aggregation	tdvt/exprtests/standard	date.today	MIN	Required
+Filters	tdvt/exprtests/standard	date.today	==	Required
+Operator	tdvt/exprtests/standard	date.today	==	Required
+Aggregation	tdvt/exprtests/standard	date.today	MAX	Required
+Date Filters	tdvt/exprtests/standard	date.today	DATEPART	Required
+Date Filters	tdvt/exprtests/standard	date.today	TODAY	Required
+Date Filters	tdvt/exprtests/standard	date.today	TODAY	Required
+Cast	tdvt/exprtests/standard	datetime.cast.date	DATE	Required
+Cast	tdvt/exprtests/standard	datetime.cast.float	FLOAT	Required
+Calculation	tdvt/exprtests/standard	datetime.cast.str	TRIM	Required
+Cast	tdvt/exprtests/standard	datetime.cast.str	STR	Required
+Data Prep	tdvt/exprtests/standard	datetime.cast.str	TRIM	Required
+Operator	tdvt/logicaltests/staples	Filter.Add_to_context	!	Required
+Filters	tdvt/logicaltests/staples	Filter.Add_to_context	==	Required
+Operator	tdvt/logicaltests/staples	Filter.Add_to_context	==	Required
+Logical	tdvt/logicaltests/staples	Filter.Add_to_context	$SYS_NARY_AND$	Required
+Aggregation	tdvt/logicaltests/staples	Filter.Add_to_context	SUM	Required
+Sets	tdvt/logicaltests/calcs	Filter.Date_In	$IN_SET$	Required
+Filters	tdvt/logicaltests/calcs	Filter.datetime_fractional	==	Recommended
+Operator	tdvt/logicaltests/calcs	Filter.datetime_fractional	==	Recommended
+Temp Tables and Subqueries	tdvt/logicaltests/calcs	Filter.datetime_fractional	TEMP_TABLES_AND_SUBQUERIES	Recommended
+Filters	tdvt/logicaltests/calcs	Filter.datetime_fractional	TEMP_TABLES_AND_SUBQUERIES	Recommended
+Operator	tdvt/logicaltests/calcs	Filter.Exclude-list-not-null	!	Required
+Sets	tdvt/logicaltests/calcs	Filter.Exclude-list-not-null	$IN_SET$	Required
+Logical	tdvt/logicaltests/calcs	Filter.Exclude-list-not-null	$SYS_NARY_OR$	Required
+NULL Semantics	tdvt/logicaltests/calcs	Filter.Exclude-list-not-null	ISNULL	Required
+Calculation	tdvt/logicaltests/calcs	Filter.Exclude-list-not-null	ISNULL	Required
+Operator	tdvt/logicaltests/calcs	Filter.Exclude-range-not-null	!	Required
+Filters	tdvt/logicaltests/calcs	Filter.Exclude-range-not-null	<=	Required
+Operator	tdvt/logicaltests/calcs	Filter.Exclude-range-not-null	<=	Required
+Filters	tdvt/logicaltests/calcs	Filter.Exclude-range-not-null	>=	Required
+Operator	tdvt/logicaltests/calcs	Filter.Exclude-range-not-null	>=	Required
+Logical	tdvt/logicaltests/calcs	Filter.Exclude-range-not-null	$SYS_NARY_AND$	Required
+Logical	tdvt/logicaltests/calcs	Filter.Exclude-range-not-null	$SYS_NARY_OR$	Required
+Calculation	tdvt/logicaltests/calcs	Filter.Exclude-range-not-null	ISNULL	Required
+NULL Semantics	tdvt/logicaltests/calcs	Filter.Exclude-range-not-null	ISNULL	Required
+Filters	tdvt/logicaltests/calcs	Filter.FilterBy-to-no-results	>	Required
+Operator	tdvt/logicaltests/calcs	Filter.FilterBy-to-no-results	>	Required
+Aggregation	tdvt/logicaltests/calcs	Filter.FilterBy-to-no-results	SUM	Required
+Filters	tdvt/logicaltests/staples	Filter.Q_date_instance_filter	<=	Required
+Operator	tdvt/logicaltests/staples	Filter.Q_date_instance_filter	<=	Required
+Filters	tdvt/logicaltests/staples	Filter.Q_date_instance_filter	>=	Required
+Operator	tdvt/logicaltests/staples	Filter.Q_date_instance_filter	>=	Required
+Logical	tdvt/logicaltests/staples	Filter.Q_date_instance_filter	$SYS_NARY_AND$	Required
+Aggregation	tdvt/logicaltests/staples	Filter.Q_date_instance_filter	COUNT	Required
+Filters	tdvt/logicaltests/staples	Filter.Q_date_month_instance_filter	<=	Required
+Operator	tdvt/logicaltests/staples	Filter.Q_date_month_instance_filter	<=	Required
+Date Filters	tdvt/logicaltests/staples	Filter.Q_date_month_instance_filter	DATEPART	Required
+Aggregation	tdvt/logicaltests/staples	Filter.Q_date_month_instance_filter	SUM	Required
+Filters	tdvt/logicaltests/calcs	Filter.QFilter-max-NotNull	<=	Required
+Operator	tdvt/logicaltests/calcs	Filter.QFilter-max-NotNull	<=	Required
+Aggregation	tdvt/logicaltests/calcs	Filter.QFilter-max-NotNull	SUM	Required
+Filters	tdvt/logicaltests/calcs	Filter.QFilter-max-Null	<=	Required
+Operator	tdvt/logicaltests/calcs	Filter.QFilter-max-Null	<=	Required
+Logical	tdvt/logicaltests/calcs	Filter.QFilter-max-Null	$SYS_NARY_OR$	Required
+NULL Semantics	tdvt/logicaltests/calcs	Filter.QFilter-max-Null	ISNULL	Required
+Calculation	tdvt/logicaltests/calcs	Filter.QFilter-max-Null	ISNULL	Required
+Aggregation	tdvt/logicaltests/calcs	Filter.QFilter-max-Null	SUM	Required
+Filters	tdvt/logicaltests/calcs	Filter.QFilter-min-NotNull	>=	Required
+Operator	tdvt/logicaltests/calcs	Filter.QFilter-min-NotNull	>=	Required
+Aggregation	tdvt/logicaltests/calcs	Filter.QFilter-min-NotNull	SUM	Required
+Filters	tdvt/logicaltests/calcs	Filter.QFilter-min-Null	>=	Required
+Operator	tdvt/logicaltests/calcs	Filter.QFilter-min-Null	>=	Required
+Logical	tdvt/logicaltests/calcs	Filter.QFilter-min-Null	$SYS_NARY_OR$	Required
+Calculation	tdvt/logicaltests/calcs	Filter.QFilter-min-Null	ISNULL	Required
+NULL Semantics	tdvt/logicaltests/calcs	Filter.QFilter-min-Null	ISNULL	Required
+Aggregation	tdvt/logicaltests/calcs	Filter.QFilter-min-Null	SUM	Required
+Filters	tdvt/logicaltests/calcs	Filter.QFilter-minmax-NotNull	<=	Required
+Operator	tdvt/logicaltests/calcs	Filter.QFilter-minmax-NotNull	<=	Required
+Filters	tdvt/logicaltests/calcs	Filter.QFilter-minmax-NotNull	>=	Required
+Operator	tdvt/logicaltests/calcs	Filter.QFilter-minmax-NotNull	>=	Required
+Logical	tdvt/logicaltests/calcs	Filter.QFilter-minmax-NotNull	$SYS_NARY_AND$	Required
+Aggregation	tdvt/logicaltests/calcs	Filter.QFilter-minmax-NotNull	SUM	Required
+Filters	tdvt/logicaltests/calcs	Filter.QFilter-minmax-Null	<=	Required
+Operator	tdvt/logicaltests/calcs	Filter.QFilter-minmax-Null	<=	Required
+Filters	tdvt/logicaltests/calcs	Filter.QFilter-minmax-Null	>=	Required
+Operator	tdvt/logicaltests/calcs	Filter.QFilter-minmax-Null	>=	Required
+Logical	tdvt/logicaltests/calcs	Filter.QFilter-minmax-Null	$SYS_NARY_AND$	Required
+Logical	tdvt/logicaltests/calcs	Filter.QFilter-minmax-Null	$SYS_NARY_OR$	Required
+Calculation	tdvt/logicaltests/calcs	Filter.QFilter-minmax-Null	ISNULL	Required
+NULL Semantics	tdvt/logicaltests/calcs	Filter.QFilter-minmax-Null	ISNULL	Required
+Aggregation	tdvt/logicaltests/calcs	Filter.QFilter-minmax-Null	SUM	Required
+Operator	tdvt/logicaltests/calcs	Filter.QFilter-NotNull	!	Required
+Calculation	tdvt/logicaltests/calcs	Filter.QFilter-NotNull	ISNULL	Required
+NULL Semantics	tdvt/logicaltests/calcs	Filter.QFilter-NotNull	ISNULL	Required
+Aggregation	tdvt/logicaltests/calcs	Filter.QFilter-NotNull	SUM	Required
+Calculation	tdvt/logicaltests/calcs	Filter.QFilter-Null	ISNULL	Required
+NULL Semantics	tdvt/logicaltests/calcs	Filter.QFilter-Null	ISNULL	Required
+Aggregation	tdvt/logicaltests/calcs	Filter.QFilter-Null	SUM	Required
+Filters	tdvt/logicaltests/staples	Filter.slicing_Q_date_instance_filter	<=	Required
+Operator	tdvt/logicaltests/staples	Filter.slicing_Q_date_instance_filter	<=	Required
+Filters	tdvt/logicaltests/staples	Filter.slicing_Q_date_instance_filter	>=	Required
+Operator	tdvt/logicaltests/staples	Filter.slicing_Q_date_instance_filter	>=	Required
+Logical	tdvt/logicaltests/staples	Filter.slicing_Q_date_instance_filter	$SYS_NARY_AND$	Required
+Aggregation	tdvt/logicaltests/staples	Filter.slicing_Q_date_instance_filter	SUM	Required
+Date Filters	tdvt/logicaltests/staples	Filter.slicing_Q_date_month_instance_filter	DATEPART	Required
+Filters	tdvt/logicaltests/calcs	Filter.TopN-context	<=	Required
+Operator	tdvt/logicaltests/calcs	Filter.TopN-context	<=	Required
+Filters	tdvt/logicaltests/calcs	Filter.TopN-context	>=	Required
+Operator	tdvt/logicaltests/calcs	Filter.TopN-context	>=	Required
+Logical	tdvt/logicaltests/calcs	Filter.TopN-context	$SYS_NARY_AND$	Required
+Logical	tdvt/logicaltests/calcs	Filter.TopN-context	$SYS_NARY_OR$	Required
+Aggregation	tdvt/logicaltests/calcs	Filter.TopN-context	COUNT	Required
+Aggregation	tdvt/logicaltests/calcs	Filter.TopN-context	SUM	Required
+Filters	tdvt/logicaltests/calcs	Filter.TopN-context	TEMP_TABLES_AND_SUBQUERIES	Required
+Temp Tables and Subqueries	tdvt/logicaltests/calcs	Filter.TopN-context	TEMP_TABLES_AND_SUBQUERIES	Required
+Filters	tdvt/logicaltests/staples	Filter.Trademark	<=	Smoke
+Operator	tdvt/logicaltests/staples	Filter.Trademark	<=	Smoke
+Filters	tdvt/logicaltests/staples	Filter.Trademark	>=	Smoke
+Operator	tdvt/logicaltests/staples	Filter.Trademark	>=	Smoke
+Sets	tdvt/logicaltests/staples	Filter.Trademark	$IN_SET$	Smoke
+Logical	tdvt/logicaltests/staples	Filter.Trademark	$SYS_NARY_AND$	Smoke
+Logical	tdvt/logicaltests/staples	Filter.Trademark	$SYS_NARY_OR$	Smoke
+Aggregation	tdvt/logicaltests/staples	Filter.Trademark	SUM	Smoke
+Column Metadata Nullability	tdvt/logicaltests/calcs	join.null.bool	COLUMN_NULLABILITY	Required If Supported
+Aggregation	tdvt/logicaltests/calcs	join.null.bool	SUM	Required If Supported
+Column Metadata Nullability	tdvt/logicaltests/calcs	join.null.date	COLUMN_NULLABILITY	Required If Supported
+Aggregation	tdvt/logicaltests/calcs	join.null.date	SUM	Required If Supported
+Column Metadata Nullability	tdvt/logicaltests/calcs	join.null.datetime	COLUMN_NULLABILITY	Required If Supported
+Aggregation	tdvt/logicaltests/calcs	join.null.datetime	SUM	Required If Supported
+Column Metadata Nullability	tdvt/logicaltests/calcs	join.null.int	COLUMN_NULLABILITY	Required If Supported
+Aggregation	tdvt/logicaltests/calcs	join.null.int	SUM	Required If Supported
+Column Metadata Nullability	tdvt/logicaltests/calcs	join.null.real	COLUMN_NULLABILITY	Required If Supported
+Aggregation	tdvt/logicaltests/calcs	join.null.real	SUM	Required If Supported
+Column Metadata Nullability	tdvt/logicaltests/calcs	join.null.str	COLUMN_NULLABILITY	Required If Supported
+Aggregation	tdvt/logicaltests/calcs	join.null.str	SUM	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.1_Difference From with Cross Join	COUNT	Required If Supported
+Date Filters	tdvt/logicaltests/lod	lod.1_Difference From with Cross Join	DATEDIFF	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.1_Difference From with Cross Join	LOD_STYLE_JOIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.1_Difference From with Cross Join	MIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.1_Difference From with Cross Join	SUM	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.10_As in-out Set	LOD_STYLE_JOIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.10_As in-out Set	MIN	Required If Supported
+Calculation	tdvt/logicaltests/lod	lod.11_As in-out Set	ISNULL	Required If Supported
+NULL Semantics	tdvt/logicaltests/lod	lod.11_As in-out Set	ISNULL	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.11_As in-out Set	LOD_STYLE_JOIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.11_As in-out Set	MIN	Required If Supported
+Filters	tdvt/logicaltests/lod	lod.11_As in-out Set	TEMP_TABLES_AND_SUBQUERIES	Required If Supported
+Temp Tables and Subqueries	tdvt/logicaltests/lod	lod.11_As in-out Set	TEMP_TABLES_AND_SUBQUERIES	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.12_As in-out Set	LOD_STYLE_JOIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.12_As in-out Set	MIN	Required If Supported
+Calculation	tdvt/logicaltests/lod	lod.13_As in-out Set	ISNULL	Required If Supported
+NULL Semantics	tdvt/logicaltests/lod	lod.13_As in-out Set	ISNULL	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.13_As in-out Set	LOD_STYLE_JOIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.13_As in-out Set	MIN	Required If Supported
+Filters	tdvt/logicaltests/lod	lod.13_As in-out Set	TEMP_TABLES_AND_SUBQUERIES	Required If Supported
+Temp Tables and Subqueries	tdvt/logicaltests/lod	lod.13_As in-out Set	TEMP_TABLES_AND_SUBQUERIES	Required If Supported
+Operator	tdvt/logicaltests/lod	lod.14_As in-out Set	!	Required If Supported
+Sets	tdvt/logicaltests/lod	lod.14_As in-out Set	$IN_SET$	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.14_As in-out Set	AVG	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.14_As in-out Set	COUNT	Required If Supported
+Calculation	tdvt/logicaltests/lod	lod.14_As in-out Set	ISNULL	Required If Supported
+NULL Semantics	tdvt/logicaltests/lod	lod.14_As in-out Set	ISNULL	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.14_As in-out Set	LOD_STYLE_JOIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.14_As in-out Set	MAX	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.14_As in-out Set	MIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.14_As in-out Set	SUM	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.15_As Bin	LOD_STYLE_JOIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.15_As Bin	SUM	Required If Supported
+Bins	tdvt/logicaltests/lod	lod.15_As Bin	SYS_NUMBIN	Required If Supported
+Filters	tdvt/logicaltests/lod	lod.16_As Group	==	Required If Supported
+Operator	tdvt/logicaltests/lod	lod.16_As Group	==	Required If Supported
+Sets	tdvt/logicaltests/lod	lod.16_As Group	$IN_SET$	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.16_As Group	AVG	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.16_As Group	COUNT	Required If Supported
+Date Filters	tdvt/logicaltests/lod	lod.16_As Group	DATEDIFF	Required If Supported
+Date Filters	tdvt/logicaltests/lod	lod.16_As Group	DATEPART	Required If Supported
+Cast	tdvt/logicaltests/lod	lod.16_As Group	FLOAT	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.16_As Group	LOD_STYLE_JOIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.16_As Group	MIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.16_As Group	SUM	Required If Supported
+Operator	tdvt/logicaltests/lod	lod.17_Nesting	/	Required If Supported
+Operator	tdvt/logicaltests/lod	lod.17_Nesting	+	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.17_Nesting	AVG	Required If Supported
+Cast	tdvt/logicaltests/lod	lod.17_Nesting	FLOAT	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.17_Nesting	LOD_STYLE_JOIN	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.2_Cross Join	$AGGREGATE$	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.2_Cross Join	LOD_STYLE_JOIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.2_Cross Join	SUM	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.3_Disjoint LOD	$AGGREGATE$	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.3_Disjoint LOD	LOD_STYLE_JOIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.3_Disjoint LOD	SUM	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.4_Subset Fixed	LOD_STYLE_JOIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.4_Subset Fixed	SUM	Required If Supported
+Cast	tdvt/logicaltests/lod	lod.5_Subset Fixed - 2	FLOAT	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.5_Subset Fixed - 2	LOD_STYLE_JOIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.5_Subset Fixed - 2	SUM	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.6_Include - 1	LOD_STYLE_JOIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.6_Include - 1	SUM	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.7_Percent of Total 1	LOD_STYLE_JOIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.7_Percent of Total 1	SUM	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.8_Precent of Total 2	LOD_STYLE_JOIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.8_Precent of Total 2	SUM	Required If Supported
+Date Filters	tdvt/logicaltests/lod	lod.9_Fixed as Dimension	DATEPART	Required If Supported
+Calculation	tdvt/logicaltests/lod	lod.9_Fixed as Dimension	FLOOR	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.9_Fixed as Dimension	LOD_STYLE_JOIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.9_Fixed as Dimension	MIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.9_Fixed as Dimension	SUM	Required If Supported
+Calculation	tdvt/logicaltests/lod	lod.calc.1.TopN	FLOOR	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.calc.1.TopN	LOD_STYLE_JOIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.calc.1.TopN	MIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.calc.1.TopN	SUM	Required If Supported
+Filters	tdvt/logicaltests/lod	lod.calc.1.TopN	TEMP_TABLES_AND_SUBQUERIES	Required If Supported
+Temp Tables and Subqueries	tdvt/logicaltests/lod	lod.calc.1.TopN	TEMP_TABLES_AND_SUBQUERIES	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.calc.11.Exclude	COUNT	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.calc.11.Exclude	LOD_STYLE_JOIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.calc.11.Exclude	SUM	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.calc.2.Two-level Agg	$AGGREGATE$	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.calc.2.Two-level Agg	AVG	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.calc.2.Two-level Agg	LOD_STYLE_JOIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.calc.2.Two-level Agg	SUM	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.calc.3.LOD Metadata	LOD_STYLE_JOIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.calc.3.LOD Metadata	SUM	Required If Supported
+Cast	tdvt/logicaltests/lod	lod.calc.4.Lookup	FLOAT	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.calc.4.Lookup	LOD_STYLE_JOIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.calc.4.Lookup	SUM	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.calc.5.LOD Set	LOD_STYLE_JOIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.calc.5.LOD Set	SUM	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.calc.6. LOD Dimension	LOD_STYLE_JOIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.calc.6. LOD Dimension	SUM	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.calc.7. LOD Bins	$AGGREGATE$	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.calc.7. LOD Bins	LOD_STYLE_JOIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.calc.7. LOD Bins	SUM	Required If Supported
+Bins	tdvt/logicaltests/lod	lod.calc.7. LOD Bins	SYS_NUMBIN	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.calc.8. Include	LOD_STYLE_JOIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.calc.8. Include	SUM	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.calc.9.Fixed	$AGGREGATE$	Required If Supported
+Level of Detail	tdvt/logicaltests/lod	lod.calc.9.Fixed	LOD_STYLE_JOIN	Required If Supported
+Aggregation	tdvt/logicaltests/lod	lod.calc.9.Fixed	SUM	Required If Supported
+Level of Detail	tdvt/exprtests/lodcalcs	lod.calcs	$AGGREGATE$	Required If Supported
+Table Calc	tdvt/exprtests/lodcalcs	lod.calcs	INDEX	Required If Supported
+Aggregation	tdvt/exprtests/lodcalcs	lod.calcs	AVG	Required If Supported
+Aggregation	tdvt/exprtests/lodcalcs	lod.calcs	COUNT	Required If Supported
+Aggregation	tdvt/exprtests/lodcalcs	lod.calcs	SUM	Required If Supported
+Calculation	tdvt/exprtests/lodcalcs	lod.calcs	EXCLUDE	Required If Supported
+Calculation	tdvt/exprtests/lodcalcs	lod.calcs	FIXED	Required If Supported
+Level of Detail	tdvt/exprtests/lodcalcs	lod.calcs	EXCLUDE	Required If Supported
+Level of Detail	tdvt/exprtests/lodcalcs	lod.calcs	FIXED	Required If Supported
+Operator	tdvt/exprtests/lodcalcs	lod.calcs	/	Required If Supported
+Logical	tdvt/exprtests/standard	logical	$CASE$	Required
+Aggregation	tdvt/exprtests/standard	logical	MIN	Required
+Cast	tdvt/exprtests/standard	logical	INT	Required
+Filters	tdvt/exprtests/standard	logical	LOWER	Required
+Calculation	tdvt/exprtests/standard	logical	LOWER	Required
+NULL Semantics	tdvt/exprtests/standard	logical	ISNULL	Required
+Calculation	tdvt/exprtests/standard	logical	ISNULL	Required
+Date Filters	tdvt/exprtests/standard	logical	DATEPART	Required
+Operator	tdvt/exprtests/standard	logical	!=	Required
+Operator	tdvt/exprtests/standard	logical	!	Required
+Aggregation	tdvt/exprtests/standard	logical	MIN	Required
+Calculation	tdvt/exprtests/standard	logical	IFNULL	Required
+Logical	tdvt/exprtests/standard	logical	IIF	Required
+Filters	tdvt/exprtests/standard	logical	>	Required
+Operator	tdvt/exprtests/standard	logical	>	Required
+Aggregation	tdvt/exprtests/standard	logical	COUNT	Required
+Date Filters	tdvt/exprtests/standard	logical	DATEPART	Required
+Filters	tdvt/exprtests/standard	logical	==	Required
+Operator	tdvt/exprtests/standard	logical	==	Required
+NULL Semantics	tdvt/exprtests/standard	logical	ISNULL	Required
+Calculation	tdvt/exprtests/standard	logical	ISNULL	Required
+Logical	tdvt/exprtests/standard	logical	IIF	Required
+Operator	tdvt/exprtests/standard	logical	&&	Required
+Logical	tdvt/exprtests/standard	logical	$IF$	Required
+Sets	tdvt/exprtests/standard	logical	$IN_SET$	Required
+Filters	tdvt/exprtests/standard	logical	LOWER	Required
+Calculation	tdvt/exprtests/standard	logical	LOWER	Required
+Cast	tdvt/exprtests/standard	logical	INT	Required
+Aggregation	tdvt/exprtests/standard	logical	MAX	Required
+Logical	tdvt/exprtests/standard	logical.bool	$IF$	Required
+Aggregation	tdvt/exprtests/standard	logical.bool	MAX	Required
+Aggregation	tdvt/exprtests/standard	logical.bool	MIN	Required
+Logical	tdvt/exprtests/standard	logical.bool	IIF	Required
+Logical	tdvt/exprtests/standard	logical.bool	IIF	Required
+Calculation	tdvt/exprtests/standard	logical.bool	ISNULL	Required
+Calculation	tdvt/exprtests/standard	logical.bool	ISNULL	Required
+Cast	tdvt/exprtests/standard	logical.bool	INT	Required
+Cast	tdvt/exprtests/standard	logical.bool	INT	Required
+Filters	tdvt/exprtests/standard	logical.bool	==	Required
+NULL Semantics	tdvt/exprtests/standard	logical.bool	ISNULL	Required
+NULL Semantics	tdvt/exprtests/standard	logical.bool	ISNULL	Required
+Operator	tdvt/exprtests/standard	logical.bool	==	Required
+Filters	tdvt/exprtests/standard	logical.case.null	==	Required
+Operator	tdvt/exprtests/standard	logical.case.null	==	Required
+Sets	tdvt/exprtests/standard	logical.case.null	$IN_SET$	Required
+Logical	tdvt/exprtests/standard	logical.case.null	$CASE$	Required
+Date Filters	tdvt/exprtests/standard	logical.case.null	DATEPART	Required
+Date Filters	tdvt/exprtests/standard	logical.case.null	DATEPART	Required
+Logical	tdvt/exprtests/standard	logical.case.str	$CASE$	Required
+Sets	tdvt/exprtests/standard	logical.case.str	$IN_SET$	Required
+Filters	tdvt/exprtests/standard	logical.case.str	==	Required
+Operator	tdvt/exprtests/standard	logical.case.str	==	Required
+Aggregation	tdvt/exprtests/standard	logical.ifnull	COUNT	Required
+Aggregation	tdvt/exprtests/standard	logical.ifnull	COUNTD	Required
+Calculation	tdvt/exprtests/standard	logical.ifnull	IFNULL	Required
+Calculation	tdvt/exprtests/standard	math.abs	ABS	Required
+Calculation	tdvt/exprtests/standard	math.abs	ABS	Required
+Calculation	tdvt/exprtests/standard	math.acos	ACOS	Recommended
+Calculation	tdvt/exprtests/standard	math.acos	ACOS	Recommended
+Operator	tdvt/exprtests/standard	math.acos	/	Recommended
+Calculation	tdvt/exprtests/standard	math.asin	ASIN	Recommended
+Calculation	tdvt/exprtests/standard	math.asin	ASIN	Recommended
+Operator	tdvt/exprtests/standard	math.asin	/	Recommended
+Calculation	tdvt/exprtests/standard	math.atan	ATAN	Recommended
+Calculation	tdvt/exprtests/standard	math.atan	ATAN	Recommended
+Calculation	tdvt/exprtests/standard	math.atan	ATAN2	Recommended
+Calculation	tdvt/exprtests/standard	math.atan	ATAN2	Recommended
+Calculation	tdvt/exprtests/standard	math.ceilfloor	CEILING	Required
+Calculation	tdvt/exprtests/standard	math.ceilfloor	FLOOR	Required
+Operator	tdvt/exprtests/standard	math.ceilfloor	+	Required
+Calculation	tdvt/exprtests/standard	math.cos	COS	Required
+Calculation	tdvt/exprtests/standard	math.cos	COS	Required
+Calculation	tdvt/exprtests/standard	math.cot	COT	Required
+Calculation	tdvt/exprtests/standard	math.cot	COT	Required
+Calculation	tdvt/exprtests/standard	math.degree	DEGREES	Required
+Calculation	tdvt/exprtests/standard	math.degree	DEGREES	Required
+Calculation	tdvt/exprtests/standard	math.div	DIV	Required
+Calculation	tdvt/exprtests/standard	math.div	DIV	Required
+Operator	tdvt/exprtests/standard	math.exp	*	Required
+Calculation	tdvt/exprtests/standard	math.exp	EXP	Required
+Calculation	tdvt/exprtests/standard	math.exp	EXP	Required
+Mapping	tdvt/exprtests/standard	math.hexbin	HEXBINX	Recommended
+Mapping	tdvt/exprtests/standard	math.hexbin	HEXBINY	Recommended
+Calculation	tdvt/exprtests/standard	math.ln	LN	Required
+Calculation	tdvt/exprtests/standard	math.ln	LN	Required
+Calculation	tdvt/exprtests/standard	math.log	LOG	Required
+Calculation	tdvt/exprtests/standard	math.log	LOG	Required
+Aggregation	tdvt/exprtests/standard	math.max	COUNT	Required
+Aggregation	tdvt/exprtests/standard	math.max	MAX	Required
+Aggregation	tdvt/exprtests/standard	math.min	COUNT	Required
+Aggregation	tdvt/exprtests/standard	math.min	MIN	Required
+Aggregation	tdvt/exprtests/standard	math.pi	COUNT	Required
+Calculation	tdvt/exprtests/standard	math.pi	PI	Required
+Calculation	tdvt/exprtests/standard	math.pi	PI	Required
+Operator	tdvt/exprtests/standard	math.pi	*	Required
+Table Calc	tdvt/exprtests/standard	math.power	POWER	Required
+Calculation	tdvt/exprtests/standard	math.power	POWER	Required
+Calculation	tdvt/exprtests/standard	math.power.real	POWER	Recommended
+Calculation	tdvt/exprtests/standard	math.power.real	POWER	Recommended
+Operator	tdvt/exprtests/standard	math.power.real	*	Recommended
+Table Calc	tdvt/exprtests/standard	math.power.real	POWER	Recommended
+Table Calc	tdvt/exprtests/standard	math.power.real	POWER	Recommended
+Calculation	tdvt/exprtests/standard	math.radians	RADIANS	Required
+Calculation	tdvt/exprtests/standard	math.radians	RADIANS	Required
+Calculation	tdvt/exprtests/standard	math.round	ROUND	Required
+Calculation	tdvt/exprtests/standard	math.round	ROUND	Required
+Calculation	tdvt/exprtests/standard	math.round.B584401	ROUND	Recommended
+Calculation	tdvt/exprtests/standard	math.sign	SIGN	Required
+Calculation	tdvt/exprtests/standard	math.sign	SIGN	Required
+Calculation	tdvt/exprtests/standard	math.sin	SIN	Required
+Calculation	tdvt/exprtests/standard	math.sin	SIN	Required
+Calculation	tdvt/exprtests/standard	math.sqrt	SQRT	Required
+Calculation	tdvt/exprtests/standard	math.sqrt	SQRT	Required
+Calculation	tdvt/exprtests/standard	math.square	SQUARE	Required
+Calculation	tdvt/exprtests/standard	math.square	SQUARE	Required
+Calculation	tdvt/exprtests/standard	math.tan	TAN	Required
+Calculation	tdvt/exprtests/standard	math.zn	ZN	Required
+Column Metadata Nullability	tdvt/exprtests/standard	math.zn	COLUMN_NULLABILITY	Required
+Table Calc	tdvt/exprtests/standard	math.zn	ZN	Required
+Logical	tdvt/exprtests/standard	operator.bool	$SYS_NARY_AND$	Required
+Logical	tdvt/exprtests/standard	operator.bool	$SYS_NARY_OR$	Required
+Aggregation	tdvt/exprtests/standard	operator.bool	COUNT	Required
+Aggregation	tdvt/exprtests/standard	operator.bool	MAX	Required
+Aggregation	tdvt/exprtests/standard	operator.bool	MIN	Required
+Filters	tdvt/exprtests/standard	operator.bool	==	Required
+Operator	tdvt/exprtests/standard	operator.bool	!	Required
+Operator	tdvt/exprtests/standard	operator.bool	!=	Required
+Operator	tdvt/exprtests/standard	operator.bool	&&	Required
+Operator	tdvt/exprtests/standard	operator.bool	==	Required
+Operator	tdvt/exprtests/standard	operator.bool	||	Required
+Aggregation	tdvt/exprtests/standard	operator.date	MAX	Required
+Aggregation	tdvt/exprtests/standard	operator.date	MIN	Required
+Filters	tdvt/exprtests/standard	operator.date	<	Required
+Filters	tdvt/exprtests/standard	operator.date	<=	Required
+Filters	tdvt/exprtests/standard	operator.date	==	Required
+Filters	tdvt/exprtests/standard	operator.date	>	Required
+Filters	tdvt/exprtests/standard	operator.date	>=	Required
+Operator	tdvt/exprtests/standard	operator.date	!=	Required
+Operator	tdvt/exprtests/standard	operator.date	+	Required
+Operator	tdvt/exprtests/standard	operator.date	-	Required
+Operator	tdvt/exprtests/standard	operator.date	<	Required
+Operator	tdvt/exprtests/standard	operator.date	<=	Required
+Operator	tdvt/exprtests/standard	operator.date	==	Required
+Operator	tdvt/exprtests/standard	operator.date	>	Required
+Operator	tdvt/exprtests/standard	operator.date	>=	Required
+Operator	tdvt/exprtests/standard	operator.int	%	Required
+Operator	tdvt/exprtests/standard	operator.int	/	Required
+Operator	tdvt/exprtests/standard	operator.int	^^	Required
+Operator	tdvt/exprtests/standard	operator.num	*	Required
+Filters	tdvt/exprtests/standard	operator.num	>=	Required
+Operator	tdvt/exprtests/standard	operator.num	>=	Required
+Operator	tdvt/exprtests/standard	operator.num	^^	Required
+Aggregation	tdvt/exprtests/standard	operator.num	MIN	Required
+Filters	tdvt/exprtests/standard	operator.num	==	Required
+Operator	tdvt/exprtests/standard	operator.num	==	Required
+Aggregation	tdvt/exprtests/standard	operator.num	MAX	Required
+Calculation	tdvt/exprtests/standard	operator.num	ABS	Required
+Calculation	tdvt/exprtests/standard	operator.num	ABS	Required
+Filters	tdvt/exprtests/standard	operator.num	<	Required
+Filters	tdvt/exprtests/standard	operator.num	<=	Required
+Filters	tdvt/exprtests/standard	operator.num	>	Required
+Operator	tdvt/exprtests/standard	operator.num	!=	Required
+Operator	tdvt/exprtests/standard	operator.num	+	Required
+Operator	tdvt/exprtests/standard	operator.num	-	Required
+Operator	tdvt/exprtests/standard	operator.num	/	Required
+Operator	tdvt/exprtests/standard	operator.num	<	Required
+Operator	tdvt/exprtests/standard	operator.num	<=	Required
+Operator	tdvt/exprtests/standard	operator.num	>	Required
+Aggregation	tdvt/exprtests/standard	operator.str	COUNT	Required
+Aggregation	tdvt/exprtests/standard	operator.str	MAX	Required
+Aggregation	tdvt/exprtests/standard	operator.str	MIN	Required
+Logical	tdvt/exprtests/standard	operator.str	IIF	Required
+Logical	tdvt/exprtests/standard	operator.str	IIF	Required
+Calculation	tdvt/exprtests/standard	operator.str	LOWER	Required
+Calculation	tdvt/exprtests/standard	operator.str	LOWER	Required
+Filters	tdvt/exprtests/standard	operator.str	<	Required
+Filters	tdvt/exprtests/standard	operator.str	<=	Required
+Filters	tdvt/exprtests/standard	operator.str	==	Required
+Filters	tdvt/exprtests/standard	operator.str	>	Required
+Filters	tdvt/exprtests/standard	operator.str	>=	Required
+Filters	tdvt/exprtests/standard	operator.str	LOWER	Required
+Filters	tdvt/exprtests/standard	operator.str	LOWER	Required
+Operator	tdvt/exprtests/standard	operator.str	!=	Required
+Operator	tdvt/exprtests/standard	operator.str	+	Required
+Operator	tdvt/exprtests/standard	operator.str	<	Required
+Operator	tdvt/exprtests/standard	operator.str	<=	Required
+Operator	tdvt/exprtests/standard	operator.str	==	Required
+Operator	tdvt/exprtests/standard	operator.str	>	Required
+Operator	tdvt/exprtests/standard	operator.str	>=	Required
+Operator	tdvt/logicaltests/staples	Query.Dates_MDY	*	Required
+Operator	tdvt/logicaltests/staples	Query.Dates_MDY	+	Required
+Date Filters	tdvt/logicaltests/staples	Query.Dates_MDY	DATEPART	Required
+Aggregation	tdvt/logicaltests/staples	Query.Dates_MDY	SUM	Required
+Operator	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	*	Required
+Operator	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	+	Required
+Filters	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	<=	Required
+Operator	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	<=	Required
+Filters	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	>=	Required
+Operator	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	>=	Required
+Logical	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	$SYS_NARY_AND$	Required
+Logical	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	$SYS_NARY_OR$	Required
+Date Filters	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	DATEPART	Required
+Aggregation	tdvt/logicaltests/staples	Query.Dates_MDY_Filtered	SUM	Required
+Filters	tdvt/logicaltests/staples	Query.Filter_AVG	<=	Required
+Operator	tdvt/logicaltests/staples	Query.Filter_AVG	<=	Required
+Filters	tdvt/logicaltests/staples	Query.Filter_AVG	>=	Required
+Operator	tdvt/logicaltests/staples	Query.Filter_AVG	>=	Required
+Logical	tdvt/logicaltests/staples	Query.Filter_AVG	$SYS_NARY_AND$	Required
+Aggregation	tdvt/logicaltests/staples	Query.Filter_AVG	AVG	Required
+Filters	tdvt/logicaltests/staples	Query.Filter_CNT	<=	Required
+Operator	tdvt/logicaltests/staples	Query.Filter_CNT	<=	Required
+Filters	tdvt/logicaltests/staples	Query.Filter_CNT	>=	Required
+Operator	tdvt/logicaltests/staples	Query.Filter_CNT	>=	Required
+Logical	tdvt/logicaltests/staples	Query.Filter_CNT	$SYS_NARY_AND$	Required
+Aggregation	tdvt/logicaltests/staples	Query.Filter_CNT	SUM	Required
+Filters	tdvt/logicaltests/staples	Query.Filter_Exclude1	<=	Required
+Operator	tdvt/logicaltests/staples	Query.Filter_Exclude1	<=	Required
+Filters	tdvt/logicaltests/staples	Query.Filter_Exclude1	>=	Required
+Operator	tdvt/logicaltests/staples	Query.Filter_Exclude1	>=	Required
+Logical	tdvt/logicaltests/staples	Query.Filter_Exclude1	$SYS_NARY_AND$	Required
+Logical	tdvt/logicaltests/staples	Query.Filter_Exclude1	$SYS_NARY_OR$	Required
+Aggregation	tdvt/logicaltests/staples	Query.Filter_Exclude1	SUM	Required
+Filters	tdvt/logicaltests/staples	Query.Filter_Include1	==	Required
+Operator	tdvt/logicaltests/staples	Query.Filter_Include1	==	Required
+Aggregation	tdvt/logicaltests/staples	Query.Filter_Include1	SUM	Required
+Filters	tdvt/logicaltests/staples	Query.Filter_MAX	<=	Required
+Operator	tdvt/logicaltests/staples	Query.Filter_MAX	<=	Required
+Filters	tdvt/logicaltests/staples	Query.Filter_MAX	>=	Required
+Operator	tdvt/logicaltests/staples	Query.Filter_MAX	>=	Required
+Logical	tdvt/logicaltests/staples	Query.Filter_MAX	$SYS_NARY_AND$	Required
+Aggregation	tdvt/logicaltests/staples	Query.Filter_MAX	MAX	Required
+Filters	tdvt/logicaltests/staples	Query.Filter_MIN	<=	Required
+Operator	tdvt/logicaltests/staples	Query.Filter_MIN	<=	Required
+Filters	tdvt/logicaltests/staples	Query.Filter_MIN	>=	Required
+Operator	tdvt/logicaltests/staples	Query.Filter_MIN	>=	Required
+Logical	tdvt/logicaltests/staples	Query.Filter_MIN	$SYS_NARY_AND$	Required
+Aggregation	tdvt/logicaltests/staples	Query.Filter_MIN	MIN	Required
+Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQ	<=	Required
+Operator	tdvt/logicaltests/staples	Query.Filter_SliceAggQ	<=	Required
+Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQ	>=	Required
+Operator	tdvt/logicaltests/staples	Query.Filter_SliceAggQ	>=	Required
+Logical	tdvt/logicaltests/staples	Query.Filter_SliceAggQ	$SYS_NARY_AND$	Required
+Aggregation	tdvt/logicaltests/staples	Query.Filter_SliceAggQ	AVG	Required
+Aggregation	tdvt/logicaltests/staples	Query.Filter_SliceAggQ	SUM	Required
+Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQ_AxisQ	<=	Required
+Operator	tdvt/logicaltests/staples	Query.Filter_SliceAggQ_AxisQ	<=	Required
+Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQ_AxisQ	>=	Required
+Operator	tdvt/logicaltests/staples	Query.Filter_SliceAggQ_AxisQ	>=	Required
+Logical	tdvt/logicaltests/staples	Query.Filter_SliceAggQ_AxisQ	$SYS_NARY_AND$	Required
+Aggregation	tdvt/logicaltests/staples	Query.Filter_SliceAggQ_AxisQ	SUM	Required
+Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQ	<=	Required
+Operator	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQ	<=	Required
+Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQ	>=	Required
+Operator	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQ	>=	Required
+Logical	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQ	$SYS_NARY_AND$	Required
+Aggregation	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQ	SUM	Required
+Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQO	<=	Required
+Operator	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQO	<=	Required
+Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQO	>=	Required
+Operator	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQO	>=	Required
+Sets	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQO	$NOT_IN_SET$	Required
+Logical	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQO	$SYS_NARY_AND$	Required
+Aggregation	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQO	SUM	Required
+Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQOYear	<=	Required
+Operator	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQOYear	<=	Required
+Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQOYear	>=	Required
+Operator	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQOYear	>=	Required
+Sets	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQOYear	$IN_SET$	Required
+Sets	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQOYear	$NOT_IN_SET$	Required
+Logical	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQOYear	$SYS_NARY_AND$	Required
+Date Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQOYear	DATEPART	Required
+Aggregation	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQ_AxisQOYear	SUM	Required
+Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear	<=	Required
+Operator	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear	<=	Required
+Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear	>=	Required
+Operator	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear	>=	Required
+Sets	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear	$IN_SET$	Required
+Sets	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear	$NOT_IN_SET$	Required
+Logical	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear	$SYS_NARY_AND$	Required
+Date Filters	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear	DATEPART	Required
+Aggregation	tdvt/logicaltests/staples	Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear	SUM	Required
+Filters	tdvt/logicaltests/staples	Query.Filter_SUM	<=	Required
+Operator	tdvt/logicaltests/staples	Query.Filter_SUM	<=	Required
+Filters	tdvt/logicaltests/staples	Query.Filter_SUM	>=	Required
+Operator	tdvt/logicaltests/staples	Query.Filter_SUM	>=	Required
+Logical	tdvt/logicaltests/staples	Query.Filter_SUM	$SYS_NARY_AND$	Required
+Aggregation	tdvt/logicaltests/staples	Query.Filter_SUM	SUM	Required
+Filters	tdvt/logicaltests/calcs	Query.Filter.IsNOTNULL	<=	Required
+Operator	tdvt/logicaltests/calcs	Query.Filter.IsNOTNULL	<=	Required
+Filters	tdvt/logicaltests/calcs	Query.Filter.IsNOTNULL	>=	Required
+Operator	tdvt/logicaltests/calcs	Query.Filter.IsNOTNULL	>=	Required
+Logical	tdvt/logicaltests/calcs	Query.Filter.IsNOTNULL	$SYS_NARY_AND$	Required
+Aggregation	tdvt/logicaltests/calcs	Query.Filter.IsNOTNULL	SUM	Required
+Calculation	tdvt/logicaltests/calcs	Query.Filter.IsNULL	ISNULL	Required
+NULL Semantics	tdvt/logicaltests/calcs	Query.Filter.IsNULL	ISNULL	Required
+Aggregation	tdvt/logicaltests/calcs	Query.Filter.IsNULL	SUM	Required
+Sets	tdvt/logicaltests/calcs	Query.Filter.NullAndOne	$IN_SET$	Required
+Logical	tdvt/logicaltests/calcs	Query.Filter.NullAndOne	$SYS_NARY_OR$	Required
+NULL Semantics	tdvt/logicaltests/calcs	Query.Filter.NullAndOne	ISNULL	Required
+Calculation	tdvt/logicaltests/calcs	Query.Filter.NullAndOne	ISNULL	Required
+Aggregation	tdvt/logicaltests/calcs	Query.Filter.NullAndOne	SUM	Required
+Filters	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	<	Required
+Operator	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	<	Required
+Filters	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	<=	Required
+Operator	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	<=	Required
+Filters	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	>=	Required
+Operator	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	>=	Required
+Sets	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	$IN_SET$	Required
+Sets	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	$NOT_IN_SET$	Required
+Logical	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	$SYS_NARY_AND$	Required
+Logical	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	$SYS_NARY_OR$	Required
+Date Filters	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	DATEPART	Required
+Aggregation	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	MIN	Required
+Aggregation	tdvt/logicaltests/staples	Query.FilterBy_DateTime_Slices	SUM	Required
+Filters	tdvt/logicaltests/staples	Query.FilterBy_Q	<	Required
+Operator	tdvt/logicaltests/staples	Query.FilterBy_Q	<	Required
+Aggregation	tdvt/logicaltests/staples	Query.FilterBy_Q	AVG	Required
+Aggregation	tdvt/logicaltests/staples	Query.FilterBy_Q	SUM	Required
+Filters	tdvt/logicaltests/staples	Query.HideEmptyRows	<=	Required
+Operator	tdvt/logicaltests/staples	Query.HideEmptyRows	<=	Required
+Filters	tdvt/logicaltests/staples	Query.HideEmptyRows	>=	Required
+Operator	tdvt/logicaltests/staples	Query.HideEmptyRows	>=	Required
+Logical	tdvt/logicaltests/staples	Query.HideEmptyRows	$SYS_NARY_AND$	Required
+Aggregation	tdvt/logicaltests/staples	Query.HideEmptyRows	AVG	Required
+Aggregation	tdvt/logicaltests/staples	Query.HideEmptyRows	MIN	Required
+Filters	tdvt/logicaltests/staples	Query.MultipleFilters	<=	Required
+Operator	tdvt/logicaltests/staples	Query.MultipleFilters	<=	Required
+Filters	tdvt/logicaltests/staples	Query.MultipleFilters	==	Required
+Operator	tdvt/logicaltests/staples	Query.MultipleFilters	==	Required
+Filters	tdvt/logicaltests/staples	Query.MultipleFilters	>=	Required
+Operator	tdvt/logicaltests/staples	Query.MultipleFilters	>=	Required
+Sets	tdvt/logicaltests/staples	Query.MultipleFilters	$IN_SET$	Required
+Logical	tdvt/logicaltests/staples	Query.MultipleFilters	$SYS_NARY_AND$	Required
+Logical	tdvt/logicaltests/staples	Query.MultipleFilters	$SYS_NARY_OR$	Required
+Aggregation	tdvt/logicaltests/staples	Query.MultipleFilters	AVG	Required
+Date Filters	tdvt/logicaltests/staples	Query.MultipleFilters	DATEPART	Required
+Aggregation	tdvt/logicaltests/staples	Query.MultipleFilters	SUM	Required
+Filters	tdvt/logicaltests/staples	Query.Nest_FilterO1_SliceOQ	<=	Required
+Operator	tdvt/logicaltests/staples	Query.Nest_FilterO1_SliceOQ	<=	Required
+Filters	tdvt/logicaltests/staples	Query.Nest_FilterO1_SliceOQ	>=	Required
+Operator	tdvt/logicaltests/staples	Query.Nest_FilterO1_SliceOQ	>=	Required
+Sets	tdvt/logicaltests/staples	Query.Nest_FilterO1_SliceOQ	$NOT_IN_SET$	Required
+Logical	tdvt/logicaltests/staples	Query.Nest_FilterO1_SliceOQ	$SYS_NARY_AND$	Required
+Aggregation	tdvt/logicaltests/staples	Query.Nest_FilterO1_SliceOQ	AVG	Required
+Aggregation	tdvt/logicaltests/staples	Query.Nest_FilterO1_SliceOQ	SUM	Required
+Filters	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	<=	Required
+Operator	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	<=	Required
+Filters	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	>=	Required
+Operator	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	>=	Required
+Sets	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	$IN_SET$	Required
+Sets	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	$NOT_IN_SET$	Required
+Logical	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	$SYS_NARY_AND$	Required
+Logical	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	$SYS_NARY_OR$	Required
+Aggregation	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	AVG	Required
+Aggregation	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1	SUM	Required
+Filters	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	<=	Required
+Operator	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	<=	Required
+Filters	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	>=	Required
+Operator	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	>=	Required
+Sets	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	$IN_SET$	Required
+Sets	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	$NOT_IN_SET$	Required
+Logical	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	$SYS_NARY_AND$	Required
+Logical	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	$SYS_NARY_OR$	Required
+Aggregation	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	AVG	Required
+Aggregation	tdvt/logicaltests/staples	Query.Nest_FilterO1O2_SliceOQ_SortByO1O2	SUM	Required
+Filters	tdvt/logicaltests/staples	Query.Nest_SliceQ	<=	Required
+Operator	tdvt/logicaltests/staples	Query.Nest_SliceQ	<=	Required
+Filters	tdvt/logicaltests/staples	Query.Nest_SliceQ	>=	Required
+Operator	tdvt/logicaltests/staples	Query.Nest_SliceQ	>=	Required
+Logical	tdvt/logicaltests/staples	Query.Nest_SliceQ	$SYS_NARY_AND$	Required
+Aggregation	tdvt/logicaltests/staples	Query.Nest_SliceQ	AVG	Required
+Aggregation	tdvt/logicaltests/staples	Query.Nest_SliceQ	SUM	Required
+Filters	tdvt/logicaltests/staples	Query.Nest_SliceQO	<=	Required
+Operator	tdvt/logicaltests/staples	Query.Nest_SliceQO	<=	Required
+Filters	tdvt/logicaltests/staples	Query.Nest_SliceQO	>=	Required
+Operator	tdvt/logicaltests/staples	Query.Nest_SliceQO	>=	Required
+Sets	tdvt/logicaltests/staples	Query.Nest_SliceQO	$NOT_IN_SET$	Required
+Logical	tdvt/logicaltests/staples	Query.Nest_SliceQO	$SYS_NARY_AND$	Required
+Aggregation	tdvt/logicaltests/staples	Query.Nest_SliceQO	AVG	Required
+Aggregation	tdvt/logicaltests/staples	Query.Nest_SliceQO	SUM	Required
+Aggregation	tdvt/logicaltests/staples	Query.Sort_Alphabetic_DESC_Top1	SUM	Required
+Temp Tables and Subqueries	tdvt/logicaltests/staples	Query.Sort_Alphabetic_DESC_Top1	TEMP_TABLES_AND_SUBQUERIES	Required
+Filters	tdvt/logicaltests/staples	Query.Sort_Alphabetic_DESC_Top1	TEMP_TABLES_AND_SUBQUERIES	Required
+Aggregation	tdvt/logicaltests/staples	Query.Sort_Alphabetic_DESC_Top10	SUM	Required
+Temp Tables and Subqueries	tdvt/logicaltests/staples	Query.Sort_Alphabetic_DESC_Top10	TEMP_TABLES_AND_SUBQUERIES	Required
+Filters	tdvt/logicaltests/staples	Query.Sort_Alphabetic_DESC_Top10	TEMP_TABLES_AND_SUBQUERIES	Required
+Aggregation	tdvt/logicaltests/staples	Query.Sort_Natural_DESC	SUM	Required
+Aggregation	tdvt/logicaltests/staples	Query.Top99_ByField	AVG	Required
+Filters	tdvt/logicaltests/staples	Query.Top99_ByField	TEMP_TABLES_AND_SUBQUERIES	Required
+Temp Tables and Subqueries	tdvt/logicaltests/staples	Query.Top99_ByField	TEMP_TABLES_AND_SUBQUERIES	Required
+Filters	tdvt/logicaltests/staples	Query.Unaggregated_Filter	<=	Required
+Operator	tdvt/logicaltests/staples	Query.Unaggregated_Filter	<=	Required
+Filters	tdvt/logicaltests/staples	Query.Unaggregated_Filter	>=	Required
+Operator	tdvt/logicaltests/staples	Query.Unaggregated_Filter	>=	Required
+Sets	tdvt/logicaltests/staples	Query.Unaggregated_Filter	$IN_SET$	Required
+Sets	tdvt/logicaltests/staples	Query.Unaggregated_Filter	$NOT_IN_SET$	Required
+Logical	tdvt/logicaltests/staples	Query.Unaggregated_Filter	$SYS_NARY_AND$	Required
+Date Filters	tdvt/logicaltests/staples	Query.Unaggregated_Filter	DATEPART	Required
+Filters	tdvt/logicaltests/staples	Query.Unaggregated_Filter_NoDateTime	<=	Required
+Operator	tdvt/logicaltests/staples	Query.Unaggregated_Filter_NoDateTime	<=	Required
+Filters	tdvt/logicaltests/staples	Query.Unaggregated_Filter_NoDateTime	>=	Required
+Operator	tdvt/logicaltests/staples	Query.Unaggregated_Filter_NoDateTime	>=	Required
+Sets	tdvt/logicaltests/staples	Query.Unaggregated_Filter_NoDateTime	$IN_SET$	Required
+Sets	tdvt/logicaltests/staples	Query.Unaggregated_Filter_NoDateTime	$NOT_IN_SET$	Required
+Logical	tdvt/logicaltests/staples	Query.Unaggregated_Filter_NoDateTime	$SYS_NARY_AND$	Required
+Date Filters	tdvt/logicaltests/staples	Query.Unaggregated_Filter_NoDateTime	DATEPART	Required
+Aggregation	tdvt/exprtests/standard	string.ascii	COUNT	Recommended
+Calculation	tdvt/exprtests/standard	string.ascii	ASCII	Recommended
+Calculation	tdvt/exprtests/standard	string.ascii	ASCII	Recommended
+Cast	tdvt/exprtests/standard	string.B21622	INT	Required
+Cast	tdvt/exprtests/standard	string.B21622	INT	Required
+Cast	tdvt/exprtests/standard	string.B21622	STR	Required
+Cast	tdvt/exprtests/standard	string.B21622	STR	Required
+Aggregation	tdvt/exprtests/bind	string.bind_trim	COUNT	Recommended
+Operator	tdvt/exprtests/bind	string.bind_trim	+	Recommended
+Calculation	tdvt/exprtests/standard	string.char	CHAR	Smoke
+Calculation	tdvt/exprtests/standard	string.char	CHAR	Smoke
+Aggregation	tdvt/exprtests/standard	string.char	COUNT	Smoke
+Aggregation	tdvt/exprtests/standard	string.constants	COUNT	Required
+Operator	tdvt/exprtests/standard	string.constants	+	Required
+Aggregation	tdvt/exprtests/standard	string.contains	MAX	Required
+Aggregation	tdvt/exprtests/standard	string.contains	MIN	Required
+Calculation	tdvt/exprtests/standard	string.contains	CONTAINS	Required
+Wildcard Filters	tdvt/exprtests/standard	string.contains	CONTAINS	Required
+Aggregation	tdvt/exprtests/standard	string.endswith	MAX	Required
+Filters	tdvt/exprtests/standard	string.endswith	ENDSWITH	Required
+Calculation	tdvt/exprtests/standard	string.endswith	ENDSWITH	Required
+Aggregation	tdvt/exprtests/standard	string.endswith	MIN	Required
+Operator	tdvt/exprtests/standard	string.find	*	Required
+Data Prep	tdvt/exprtests/standard	string.find	FIND	Required
+Calculation	tdvt/exprtests/standard	string.find	FIND	Required
+Data Prep	tdvt/exprtests/standard	string.find	FIND	Required
+Calculation	tdvt/exprtests/standard	string.find	FIND	Required
+Data Prep	tdvt/exprtests/standard	string.left	LEFT	Required
+Calculation	tdvt/exprtests/standard	string.left	LEFT	Required
+Data Prep	tdvt/exprtests/standard	string.left	LEFT	Required
+Calculation	tdvt/exprtests/standard	string.left	LEFT	Required
+Data Prep	tdvt/exprtests/standard	string.left.negative	LEFT	Required If Supported
+Calculation	tdvt/exprtests/standard	string.left.negative	LEFT	Required If Supported
+Calculation	tdvt/exprtests/standard	string.left.real	LEFT	Recommended
+Calculation	tdvt/exprtests/standard	string.left.real	LEFT	Recommended
+Data Prep	tdvt/exprtests/standard	string.left.real	LEFT	Recommended
+Data Prep	tdvt/exprtests/standard	string.left.real	LEFT	Recommended
+Aggregation	tdvt/exprtests/standard	string.len	COUNT	Required
+Data Prep	tdvt/exprtests/standard	string.len	LEN	Required
+Calculation	tdvt/exprtests/standard	string.len	LEN	Required
+Data Prep	tdvt/exprtests/standard	string.len	LEN	Required
+Calculation	tdvt/exprtests/standard	string.len	LEN	Required
+Filters	tdvt/exprtests/standard	string.lower	LOWER	Required
+Calculation	tdvt/exprtests/standard	string.lower	LOWER	Required
+Filters	tdvt/exprtests/standard	string.lower	LOWER	Required
+Calculation	tdvt/exprtests/standard	string.lower	LOWER	Required
+Calculation	tdvt/exprtests/standard	string.ltrim	LTRIM	Required
+Operator	tdvt/exprtests/standard	string.ltrim	+	Required
+Aggregation	tdvt/exprtests/standard	string.max	MAX	Required
+Calculation	tdvt/exprtests/standard	string.mid	MID	Required
+Calculation	tdvt/exprtests/standard	string.mid	MID	Required
+Data Prep	tdvt/exprtests/standard	string.mid	MID	Required
+Data Prep	tdvt/exprtests/standard	string.mid	MID	Required
+Calculation	tdvt/exprtests/standard	string.mid.calc	MID	Required
+Calculation	tdvt/exprtests/standard	string.mid.calc	MID	Required
+Data Prep	tdvt/exprtests/standard	string.mid.calc	MID	Required
+Data Prep	tdvt/exprtests/standard	string.mid.calc	MID	Required
+Operator	tdvt/exprtests/standard	string.mid.calc	*	Required
+Operator	tdvt/exprtests/standard	string.mid.calc	+	Required
+Aggregation	tdvt/exprtests/standard	string.min	COUNT	Required
+Aggregation	tdvt/exprtests/standard	string.min	MIN	Required
+Aggregation	tdvt/exprtests/standard	string.replace	COUNT	Required If Supported
+Calculation	tdvt/exprtests/standard	string.replace	REPLACE	Required If Supported
+Aggregation	tdvt/exprtests/standard	string.right	COUNT	Required
+Calculation	tdvt/exprtests/standard	string.right	RIGHT	Required
+Calculation	tdvt/exprtests/standard	string.right	RIGHT	Required
+Calculation	tdvt/exprtests/standard	string.right.real	RIGHT	Required
+Calculation	tdvt/exprtests/standard	string.right.real	RIGHT	Required
+Calculation	tdvt/exprtests/standard	string.rtrim	RTRIM	Required
+Operator	tdvt/exprtests/standard	string.rtrim	+	Required
+Aggregation	tdvt/exprtests/standard	string.space	COUNT	Required
+Operator	tdvt/exprtests/standard	string.space	+	Required
+Calculation	tdvt/exprtests/standard	string.space	SPACE	Required
+Cast	tdvt/exprtests/standard	string.space.int.constant	INT	Required
+Cast	tdvt/exprtests/standard	string.space.int.constant	INT	Required
+Aggregation	tdvt/exprtests/standard	string.space.int.constant	COUNT	Required
+Calculation	tdvt/exprtests/standard	string.space.int.constant	SPACE	Required
+Calculation	tdvt/exprtests/standard	string.space.int.var	SPACE	Required
+Aggregation	tdvt/exprtests/standard	string.split	COUNT	Required
+Data Prep	tdvt/exprtests/standard	string.split	SPLIT	Required
+Calculation	tdvt/exprtests/standard	string.split	SPLIT	Required
+Aggregation	tdvt/exprtests/standard	string.split.right	COUNT	Required If Supported
+Calculation	tdvt/exprtests/standard	string.split.right	SPLIT	Required If Supported
+Data Prep	tdvt/exprtests/standard	string.split.right	SPLIT	Required If Supported
+Aggregation	tdvt/exprtests/standard	string.startswith	COUNT	Required
+Aggregation	tdvt/exprtests/standard	string.startswith	MAX	Required
+Aggregation	tdvt/exprtests/standard	string.startswith	MIN	Required
+Calculation	tdvt/exprtests/standard	string.startswith	STARTSWITH	Required
+Filters	tdvt/exprtests/standard	string.startswith	STARTSWITH	Required
+Data Prep	tdvt/exprtests/standard	string.trim	TRIM	Required If Supported
+Calculation	tdvt/exprtests/standard	string.trim	TRIM	Required If Supported
+Operator	tdvt/exprtests/standard	string.trim	+	Required If Supported
+Aggregation	tdvt/exprtests/standard	string.upper	COUNT	Required
+Calculation	tdvt/exprtests/standard	string.upper	UPPER	Required
+Calculation	tdvt/exprtests/standard	string.upper	UPPER	Required
+Aggregation	tdvt/exprtests/standard	string.utf8	COUNT	Recommended
+Calculation	tdvt/exprtests/standard	string.utf8	FIND	Recommended
+Calculation	tdvt/exprtests/standard	string.utf8	REPLACE	Recommended
+Data Prep	tdvt/exprtests/standard	string.utf8	FIND	Recommended
+Filters	tdvt/logicaltests/staples	ZTesting.Staples9	<=	Recommended
+Operator	tdvt/logicaltests/staples	ZTesting.Staples9	<=	Recommended
+Filters	tdvt/logicaltests/staples	ZTesting.Staples9	==	Recommended
+Operator	tdvt/logicaltests/staples	ZTesting.Staples9	==	Recommended
+Filters	tdvt/logicaltests/staples	ZTesting.Staples9	>=	Recommended
+Operator	tdvt/logicaltests/staples	ZTesting.Staples9	>=	Recommended
+Logical	tdvt/logicaltests/staples	ZTesting.Staples9	$SYS_NARY_AND$	Recommended
+Date Filters	tdvt/logicaltests/staples	ZTesting.Staples9	DATEPART	Recommended


### PR DESCRIPTION
This supersedes my previous MR. Added the metadata file dir to the setup manifest and cleaned it up quite a bit. There are way too many tests to audit individually (a road I tried going down before), but I made sure each function was at least mapped to a correct set of categories.