### PR TITLE
document sub-queries and/or temp table support required

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -96,7 +96,7 @@ Common capabilities and how they are used: [Capabilities]({{ site.baseurl }}/doc
 - CAP_QUERY_SUBQUERIES
 - CAP_QUERY_SUBQUERIES_WITH_TOP
 
-__Important:__ Your database must support subqueries or temporary tables for complete integration with Tableau. For the best user experience its recommended both are supported.
+__Important:__ Your database must support subqueries or temporary tables for complete integration with Tableau. For the best user experience it is recommended both are supported.
 
 ### Temporary Table support
 
@@ -108,9 +108,9 @@ If your database supports temp tables, we recommend that you enable them through
 
 A common example is filtering the top three regions by sum of sales. You can try this using our Staples sample table by dragging [Market Segment] to __Rows__, then drag it again to __Filters__. Click the Top tab and select [Sales Total] aggregated by sum.
 
-### Review capabilties list
+### Review Capabilities list
 
-There are some capabilities which Tableau either cannot provide a sensible default, or the platform default and current recommendation are different for backwards compatibility reasons.
+There are some capabilities for which Tableau either cannot provide a sensible default, or the platform default and current recommendation are different for backwards compatibility reasons.
 
 Review the [full list]({{ site.baseurl }}/docs/capabilities) of latest recommendations, highlighted in **<span style="color:red">Red</span>**, when writing a connector.  
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -61,6 +61,7 @@ These are valid values for <span style="font-family: courier new">base</span>:
 - Impala23Dialect
 - JetDialect
 - MySQL41UnicodeDriverDialect
+- MySQL8Dialect
 - Oracle102Dialect
 - PostgreSQL90Dialect
 - PrestoDialect

--- a/docs/design.md
+++ b/docs/design.md
@@ -81,25 +81,48 @@ Only if your database follows the SQL standards of a database that Tableau curre
 
 Without a dialect file, the dialect from the superclass is used. For more information, see [Create a Tableau Dialect Definition (TDD) File]({{ site.baseurl }}/docs/dialect).
 
-## Set connection capabilities
+## Set connector capabilities
 
-Tableau capabilities are Boolean settings you can use to tune many aspects of your connector behavior, including:
+Tableau capabilities are Boolean settings you can use to tune many aspects of your connector behavior based on database functionality, including:
 - The types of queries that Tableau generates
 - How metadata is read
 - How Tableau binds to the drivers result set
 
-For information on common capabilities and how they are used, see [Capabilities]({{ site.baseurl }}/docs/capabilities).
+Common capabilities and how they are used: [Capabilities]({{ site.baseurl }}/docs/capabilities) 
 
-## Consider database capability
+### Subquery support
 
-Consider these two questions:
+- CAP_QUERY_SUBQUERIES
+- CAP_QUERY_SUBQUERIES_WITH_TOP
 
-__Does your database support temporary tables?__
-__Important:__ Your database should support temporary tables and subqueries for the best user experience, but at least one of those is required to support complete integration with Tableau.
+__Important:__ Your database must support subqueries or temporary tables for complete integration with Tableau. For the best user experience its recommended both are supported.
 
-If your database supports temp tables, we recommend that you enable them through the appropriate [Capabilities]({{ site.baseurl }}/docs/capabilities). If the temp table capabilities are set, the connector will perform a simple check at connection time to confirm that the user can create a temp table in the current database environment. If the user does not have permission or the capabilities are disabled, then Tableau will attempt to generate an alternative query to retrieve the necessary results. Often these queries need subqueries and the performance can be poor, particularly with large data sets. If the connector does not support temporary tables or subqueries, then Tableau will report an error and will be unable to proceed.
+### Temporary Table support
+
+- CAP_CREATE_TEMP_TABLES
+- CAP_SELECT_INTO
+- CAP_SELECT_TOP_INTO
+
+If your database supports temp tables, we recommend that you enable them through the appropriate [Capabilities]({{ site.baseurl }}/docs/capabilities#temporary-tables). If the temp table capabilities are set, the connector will perform a simple check at connection time to confirm that the user can create a temp table in the current database environment. If the user does not have permission or the capabilities are disabled, then Tableau will attempt to generate an alternative query to retrieve the necessary results. Often these queries need subqueries and the performance can be poor, particularly with large data sets. If the connector does not support temporary tables or subqueries, then Tableau will report an error and will be unable to proceed.
 
 A common example is filtering the top three regions by sum of sales. You can try this using our Staples sample table by dragging [Market Segment] to __Rows__, then drag it again to __Filters__. Click the Top tab and select [Sales Total] aggregated by sum.
+
+### Review capabilties list
+
+There are some capabilities which Tableau either cannot provide a sensible default, or the platform default and current recommendation are different for backwards compatibility reasons.
+
+Review the [full list]({{ site.baseurl }}/docs/capabilities) of latest recommendations, highlighted in **<span style="color:red">Red</span>**, when writing a connector.  
+
+Common customizations:
+- CAP_QUERY_GROUP_BY_BOOL
+- CAP_QUERY_GROUP_BY_DEGREE
+- CAP_QUERY_SORT_BY
+- CAP_QUERY_SORT_BY_DEGREE 
+- CAP_QUERY_TOP_N 
+- CAP_JDBC_QUERY_ASYNC
+- [Metadata Enumeration]({{ site.baseurl }}/docs/metadata-enumeration)
+
+### Null Column Metadata support
 
 __Does your database support null column metadata?__
 Tableau relies on accurate column metadata from the ODBC or JDBC result set in order to make certain query optimizations. If information about whether a column contains null values is inaccurate, Tableau may generate inefficient or incorrect queries. If your database does not support null column information, then it is safer to indicate that all columns contain null values. This ensures that Tableau does not generate an optimized query that actually returns incorrect results.

--- a/docs/dialect.md
+++ b/docs/dialect.md
@@ -49,7 +49,7 @@ The <span style="font-family: courier new">function-map</span> element has
 
 
 - __function element__
-Each <span style="font-family: courier new">function</span> elements defines a single function. It has a few required attributes, contain a <span style="font-family: courier new">formula</span> element (and in some cases, an <span style="font-family: courier new">unagg-formula</span> element) and any number of <span style="font-family: courier new">argument</span> elements. For a list of supported functions, see the [full_dialect.tdd](https://github.com/tableau/connector-plugin-sdk/blob/master/samples/components/dialects/full_dialect.tdd) file sample.
+Each <span style="font-family: courier new">function</span> elements defines a single function. It has a few required attributes, contain a <span style="font-family: courier new">formula</span> element (and in some cases, an <span style="font-family: courier new">unagg-formula</span> element) and any number of <span style="font-family: courier new">argument</span> elements. For a list of supported functions, see the [FullFunctionMap.tdd](https://github.com/tableau/connector-plugin-sdk/blob/master/samples/components/dialects/FullFunctionMap.tdd) file sample.
 
 
 

--- a/docs/dialect.md
+++ b/docs/dialect.md
@@ -49,7 +49,7 @@ The <span style="font-family: courier new">function-map</span> element has
 
 
 - __function element__
-Each <span style="font-family: courier new">function</span> elements defines a single function. It has a few required attributes, contain a <span style="font-family: courier new">formula</span> element (and in some cases, an <span style="font-family: courier new">unagg-formula</span> element) and any number of <span style="font-family: courier new">argument</span> elements. For a list of supported functions, see the [FullFunctionMap.tdd](https://github.com/tableau/connector-plugin-sdk/blob/master/samples/components/dialects/FullFunctionMap.tdd) file sample.
+Each <span style="font-family: courier new">function</span> element defines a single function. It has a few required attributes, contains a <span style="font-family: courier new">formula</span> element (and in some cases, an <span style="font-family: courier new">unagg-formula</span> element) and any number of <span style="font-family: courier new">argument</span> elements. For a list of supported functions, see the [FullFunctionMap.tdd](https://github.com/tableau/connector-plugin-sdk/blob/master/samples/components/dialects/FullFunctionMap.tdd) file sample.
 
 
 


### PR DESCRIPTION
- restructure the Set connector capabilities section with sub-headings
- add the relevant capability names
- add MySQL8Dialect as a supported base dialect
- fix broken link on dialect page