### PR TITLE
Story 1272586: [SDK] Clean up tdr_latest.xsd

### DIFF
--- a/validation/tdr_latest.xsd
+++ b/validation/tdr_latest.xsd
@@ -16,19 +16,6 @@
       <xs:enumeration value="linux"/>
     </xs:restriction>
   </xs:simpleType>
-  <xs:simpleType name="Double-ST">
-    <xs:union memberTypes="xs:double XML-RealSpecial-ST"/>
-  </xs:simpleType>
-  <xs:simpleType name="Float-ST">
-    <xs:union memberTypes="xs:float XML-RealSpecial-ST"/>
-  </xs:simpleType>
-  <xs:simpleType name="XML-RealSpecial-ST">
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="nan"/>
-      <xs:enumeration value="inf"/>
-      <xs:enumeration value="-inf"/>
-    </xs:restriction>
-  </xs:simpleType>
   <xs:simpleType name="VersionNumber-ST">
     <xs:restriction base="xs:string">
       <xs:pattern value="(\d+)((\.)(\d+))*((-)(\d+))*"/>


### PR DESCRIPTION
- Remove `Double-ST
- Remove `Float-ST`
- Remove `XML-RealSpecial-ST`
from tdr_latest.xsd
These are not used anywhere in the XSD and are not present in the [monolith](https://sourcegraph.prod.tableautools.com/teams/near/-/blob/modules/XSD/ConnectionResolverDefinition-root.xsd#L95). 