### PR TITLE
Replace non-breaking space with regular space

### DIFF
--- a/docs/dialect.md
+++ b/docs/dialect.md
@@ -16,7 +16,7 @@ Tableau searches for a TDD file in the location specified by the connector manif
 
 ### Dialect tag
 
-The <span style="font-family: courier new">dialect</span> tag serves as the root for the document. For example:
+The <span style="font-family: courier new">dialect</span> tag serves as the root for the document. For example:
 
 ```
 <dialect
@@ -25,7 +25,7 @@ The <span style="font-family: courier new">dialect</span> tag serves as the 
    version='20.1'>
 ```
 
-The <span style="font-family: courier new">dialect</span> tag has several required attributes and a couple of optional ones.
+The <span style="font-family: courier new">dialect</span> tag has several required attributes and a couple of optional ones.
 
 Attribute | Required | Description
 -|-|-
@@ -38,18 +38,18 @@ version | Y | Must match the current Tableau version in the format YY.Q; for exa
 
 ### Supported-aggregations element
 
-The <span style="font-family: courier new">supported-aggregations</span> element contains a list of aggregations and date truncation levels supported by the database, represented by one or more <span style="font-family: courier new">aggregation</span> elements.
+The <span style="font-family: courier new">supported-aggregations</span> element contains a list of aggregations and date truncation levels supported by the database, represented by one or more <span style="font-family: courier new">aggregation</span> elements.
 
 - __aggregation element__
 An <span style="font-family: courier new">aggregation</span> element has one required attribute, <span style="font-family: courier new">value</span>, which specifies a single aggregation or truncation. For a list, see [supported aggregations](https://github.com/tableau/connector-plugin-sdk/blob/master/samples/components/dialects/Annotated.tdd#L1051).
 
 ### Function-map element
 
-The <span style="font-family: courier new">function-map</span> element has no attributes and contains any number of <span style="font-family: courier new">function</span>, <span style="font-family: courier new">date-function</span>, and <span style="font-family: courier new">remove-function</span> elements.
+The <span style="font-family: courier new">function-map</span> element has no attributes and contains any number of <span style="font-family: courier new">function</span>, <span style="font-family: courier new">date-function</span>, and <span style="font-family: courier new">remove-function</span> elements.
 
 
 - __function element__
-Each <span style="font-family: courier new">function</span> element defines a single function. It has a few required attributes, contains a <span style="font-family: courier new">formula</span> element (and in some cases, an <span style="font-family: courier new">unagg-formula</span> element) and any number of <span style="font-family: courier new">argument</span> elements. For a list of supported functions, see the [FullFunctionMap.tdd](https://github.com/tableau/connector-plugin-sdk/blob/master/samples/components/dialects/FullFunctionMap.tdd) file sample.
+Each <span style="font-family: courier new">function</span> element defines a single function. It has a few required attributes, contains a <span style="font-family: courier new">formula</span> element (and in some cases, an <span style="font-family: courier new">unagg-formula</span> element) and any number of <span style="font-family: courier new">argument</span> elements. For a list of supported functions, see the [FullFunctionMap.tdd](https://github.com/tableau/connector-plugin-sdk/blob/master/samples/components/dialects/FullFunctionMap.tdd) file sample.
 
 
 
@@ -60,9 +60,9 @@ group | Y | Contains one or more (comma-separated) groups that this function bel
 return-type | Y | Indicates the return type of the function. For a list of allowable types, see [argument-element](#Argument) below.
 
 - __date-function element__
-The <span style="font-family: courier new">date-function</span> element is a specialized variant of <span style="font-family: courier new">function</span>. In addition to the base formula, you can specify one or more datepart formulas, which are used instead of the generic formula when available.
+The <span style="font-family: courier new">date-function</span> element is a specialized variant of <span style="font-family: courier new">function</span>. In addition to the base formula, you can specify one or more datepart formulas, which are used instead of the generic formula when available.
 The function <span style="font-family: courier new">name</span> must be one of these: DATEADD, DATEDIFF, DATENAME, DATEPARSE, DATEPART, DATETRUNC.
- Like <span style="font-family: courier new">function</span>, <span style="font-family: courier new">date-function</span> requires name and return-type, but unlike <span style="font-family: courier new">function</span>, group is not required.
+ Like <span style="font-family: courier new">function</span>, <span style="font-family: courier new">date-function</span> requires name and return-type, but unlike <span style="font-family: courier new">function</span>, group is not required.
 
   **Example: DATEPART without custom start of week**
 
@@ -124,20 +124,20 @@ The function <span style="font-family: courier new">name</span> must be one of t
   When writing datetime functions, use the default date 1900-01-01 where appropriate to standardize with other Tableau connectors.
 
 - __remove-function element__
-The <span style="font-family: courier new">remove-function</span> is used to remove existing functions in a function map without overriding them. It requires only a <span style="font-family: courier new">name</span> attribute and doesn't require you to specify any <span style="font-family: courier new">formula</span>.
+The <span style="font-family: courier new">remove-function</span> is used to remove existing functions in a function map without overriding them. It requires only a <span style="font-family: courier new">name</span> attribute and doesn't require you to specify any <span style="font-family: courier new">formula</span>.
 
 Each of the <span style="font-family: courier new">function</span>, <span style="font-family: courier new">date-function</span>, and <span style="font-family: courier new">remove-function</span> elements can contain the following:
 
 - __formula element__
-The <span style="font-family: courier new">formula</span> element is a required child of <span style="font-family: courier new">function</span> and <span style="font-family: courier new">date-function</span> elements and specifies the function's formula using standard Tableau string substitution syntax for arguments (%1, %2, etc.). You can use the optional <span style="font-family: courier new">part</span> attribute to specify a formula for a specific date part.
+The <span style="font-family: courier new">formula</span> element is a required child of <span style="font-family: courier new">function</span> and <span style="font-family: courier new">date-function</span> elements and specifies the function's formula using standard Tableau string substitution syntax for arguments (%1, %2, etc.). You can use the optional <span style="font-family: courier new">part</span> attribute to specify a formula for a specific date part.
 
 - __unagg-formula element__
-The <span style="font-family: courier new">unagg-formula</span> (unaggregated formula) element is an optional child of <span style="font-family: courier new">function</span> elements. It should be specified *only* if the function is part of the aggregate group. Unaggregated formulas should represent a reasonable way of expressing the aggregate of a single value. For example, for average, it should be the value itself. For variance, it should be 0.
+The <span style="font-family: courier new">unagg-formula</span> (unaggregated formula) element is an optional child of <span style="font-family: courier new">function</span> elements. It should be specified *only* if the function is part of the aggregate group. Unaggregated formulas should represent a reasonable way of expressing the aggregate of a single value. For example, for average, it should be the value itself. For variance, it should be 0.
 
 - __argument element__
-The <span style="font-family: courier new">argument</span> element is an optional child of all three types of <span style="font-family: courier new">function</span> elements. It contains a single attribute, <span style="font-family: courier new">type</span>, which specifies the abbreviated argument type. Arguments must be listed in the correct order.
-Allowable types: none, bool, real, int, str, datetime, date, localstr, null, error, any, tuple, spatial, localreal, localint.
-Allowable date parts: year, quarter, month, dayofyear, day, weekday, week, hour, minute, second.
+The <span style="font-family: courier new">argument</span> element is an optional child of all three types of <span style="font-family: courier new">function</span> elements. It contains a single attribute, <span style="font-family: courier new">type</span>, which specifies the abbreviated argument type. Arguments must be listed in the correct order.
+Allowable types: none, bool, real, int, str, datetime, date, localstr, null, error, any, tuple, spatial, localreal, localint.
+Allowable date parts: year, quarter, month, dayofyear, day, weekday, week, hour, minute, second.
 
 ### Join Support:
 

--- a/docs/package-sign.md
+++ b/docs/package-sign.md
@@ -4,7 +4,7 @@ title: Package and Sign Your Connector for Distribution 
 
 Packaging provides a convenient way to distribute your connector as a single .taco (Tableau Connector) file.  Signing ensures that Tableau will load only .taco files that have been signed with a currently valid certificate, ensuring that they haven't been tampered with. Signing is done using the JDK and a certificate trusted by a root certificate authority (CA) that has been installed in your Java environment. When the certificate expires, Tableau will reject the .taco file unless there is a valid timestamp.
 
-Tableau Desktop verifies and loads signed connectors from a standard location (My Tableau Repository\\Connectors) or from a user supplied directory. 
+Tableau Desktop verifies and loads signed connectors from a standard location (My Tableau Repository\\Connectors) or from a user supplied directory. 
 
 This document explains how to package and sign your connector using the Connector SDK. 
 
@@ -12,11 +12,11 @@ This document explains how to package and sign your connector using the Connecto
 
 Be sure your system includes the following:
 
--   Python version 3.7.3 or later 
+-   Python version 3.7.3 or later 
 
--   Java JDK is installed, JAVA\_HOME is set, and the JDK is in your PATH environment variable 
+-   Java JDK is installed, JAVA\_HOME is set, and the JDK is in your PATH environment variable 
 
--   Tableau Desktop 2019.4 or later   
+-   Tableau Desktop 2019.4 or later   
 
 -   A connector, developed with the Tableau Connector SDK, that you would like to package or sign 
 
@@ -47,16 +47,16 @@ Follow these steps to get the packaging tool and set up the virtual environment.
 Here's one method to do that:
     1. Open a terminal in the directory where you want to copy the Tableau Connector SDK.
     1. Run the following command to clone the Tableau Connector SDK git repository:
-    `git clone https://github.com/tableau/connector-plugin-sdk.git`
+    `git clone https://github.com/tableau/connector-plugin-sdk.git`
 
-1.  Set up the virtual environment by going to the connector-packager folder and running `python –m venv .venv`.     
-For example: 
-    `C:\connector-plugin-sdk\connector-packager> python -m venv .venv`
+1.  Set up the virtual environment by going to the connector-packager folder and running `python –m venv .venv`.     
+For example: 
+    `C:\connector-plugin-sdk\connector-packager> python -m venv .venv`
     For more information about venv, see [venv – Creation of virtual environments](https://docs.python.org/3/library/venv.html) on the Python website.
 
-1.  Activate the virtual environment using the activate command. 
+1.  Activate the virtual environment using the activate command. 
 For example, on Windows:
-`C:\connector-plugin-sdk\connector-packager>.\.venv\Scripts\activate`  
+`C:\connector-plugin-sdk\connector-packager>.\.venv\Scripts\activate`  
 Or, on Mac:
 `mac-3:connector-packager qa.auto$ source ./.venv/bin/activate`
 Or, on Linux:
@@ -66,18 +66,18 @@ Or, on Linux:
 1.  Install the packaging module in the virtual environment: 
 
     ```
-    (.venv) C:\connector-plugin-sdk\connector-packager>python setup.py install  
+    (.venv) C:\connector-plugin-sdk\connector-packager>python setup.py install  
     ```
 
 ## Package the connector
 
-You must run the connector-packager tool from the connector-plugin-sdk/connector-packager/ directory. The packaged TACO file, by  default, will be generated within packaged-connector folder. There are several ways to run the tool:
+You must run the connector-packager tool from the connector-plugin-sdk/connector-packager/ directory. The packaged TACO file, by  default, will be generated within packaged-connector folder. There are several ways to run the tool:
 
--   To package the connector, run this command: 
- `python -m connector_packager.package [path_to_plugin_folder]`
+-   To package the connector, run this command: 
+ `python -m connector_packager.package [path_to_plugin_folder]`
 
--   To validate that the XML files are valid without packaging the connector, run this command:
-`python -m connector_packager.package --validate-only [path_to_plugin_folder]`
+-   To validate that the XML files are valid without packaging the connector, run this command:
+`python -m connector_packager.package --validate-only [path_to_plugin_folder]`
 
 ### Packager examples
 __Example 1__
@@ -154,7 +154,7 @@ For more information about keytool arguments, see the Java Documentation about [
 
 __Step 2: Get the CSR signed by the certificate authority__
 
-Send the certificate signing request to the CA you want to create a certificate for you (for example, Verisign or Thawte). The CA will sign the CSR file with their own signature and send that certificate back to you. You can then use this signed certificate to sign the TACO file.
+Send the certificate signing request to the CA you want to create a certificate for you (for example, Verisign or Thawte). The CA will sign the CSR file with their own signature and send that certificate back to you. You can then use this signed certificate to sign the TACO file.
 
 After you receive/fetch the new certificate from the CA, along with any applicable "chain" or intermediate certificates, run the following command to install the new certificate and chain into the keystore:
 `keytool -importcert cert_from_ca -keystore your_keystore`


### PR DESCRIPTION
This was causing copy-paste on some of the command code samples to not work correctly. 

Replace [NBSP](https://en.wikipedia.org/wiki/Non-breaking_space) with [space](https://en.wikipedia.org/wiki/Space_(punctuation)).