### PR TITLE
Update readme and fix changelog for 2021.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,13 @@
 # Tableau Connector SDK Changelog
-
-## Unreleased
-## 2021-01-10
-### Added
-- Add OAuth Scenario for Snowflake
-## 2020-01-22
+## 2021-01-22
 ### Removed
 - Remove support for `script` element and `cacheSize` attribute in ConnectionNormalizer-CT and ConnectionMatcher-CT in `tdr_latest.xsd`.  This has not been a recommended pattern since initial release and deprecated in 2020.3 release.  Documentation, samples and [API Reference](https://tableau.github.io/connector-plugin-sdk/docs/api-reference) have been previously updated.
-
-## Unreleased
 ## 2021-01-10
 ### Added
 - Add OAuth Scenario for Snowflake
 ## 2020-10-01
 ### Added
-- Add JDBC Kerberos scenario for postgres 
+- Add JDBC Kerberos scenario for postgres
 
 ## 2020-09-21
 ### Changed
@@ -57,7 +50,7 @@
 - Fix issue with SSL in the MySQL ODBC sample
 ### Changed
 ### Removed
-- Removed INITSTMT from MySQL ODBC sample so that intialSQL does not run twice. 
+- Removed INITSTMT from MySQL ODBC sample so that intialSQL does not run twice.
 
 ## 2019-03-29
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This project consists of documentation, example files, the Tableau Datasource Verification Tool (TDVT) test harness, and a packaging tool that you can use to build and customize a Tableau Connector that uses an ODBC or JDBC driver.
 
-The latest version of the SDK is always targeted towards the latest, non-beta version of Tableau. Right now, this is **Tableau Desktop/Server 2021.1**. This means that the samples may not work on older versions of Tableau, and connectors packaged with newer versions of the SDK may not work in older versions of Tableau. You can download past releases of the SDK to work with older versions of Tableau if necessary.
+The latest version of the SDK is always targeted towards the latest, non-beta version of Tableau. Right now, this is **Tableau Desktop/Server 2021.2**. This means that the samples may not work on older versions of Tableau, and connectors packaged with newer versions of the SDK may not work in older versions of Tableau. You can download past releases of the SDK to work with older versions of Tableau if necessary.
 
 | Tool                                             | Latest Version     |
 |--------------------------------------------------|--------------------|


### PR DESCRIPTION
The changelog seems to have gotten a duplicated entry for adding the OAuth sample, which happened in master already. I also fixed the date for the last change added. We haven't been properly updating the changelog, that's something we should remember to do going forward.
