### PR TITLE
Enforce connection-normalizer rules in packager

### DIFF
--- a/connector-packager/connector_packager/connector_properties.py
+++ b/connector-packager/connector_packager/connector_properties.py
@@ -1,0 +1,4 @@
+# A class containing properties pertaining to the entire connector
+class ConnectorProperties:
+    def __init__(self):
+        self.uses_tcd = False

--- a/connector-packager/connector_packager/jar_jdk_packager.py
+++ b/connector-packager/connector_packager/jar_jdk_packager.py
@@ -24,7 +24,7 @@ MIN_TABLEAU_VERSION_ATTR = "min-version-tableau"
 TABLEAU_SUPPORT_LINK = "https://www.tableau.com/support"
 
 
-def get_min_support_version(file_list: List[ConnectorFile], cur_min_version_tableau: str, manifest_plugin_elem: ET.Element) -> str:
+def get_min_support_version(file_list: List[ConnectorFile], cur_min_version_tableau: str, manifest_plugin_elem: ET.Element, input_dir: Path) -> str:
     """
     Get the minimum support version based on features used in the connector
 
@@ -57,6 +57,15 @@ def get_min_support_version(file_list: List[ConnectorFile], cur_min_version_tabl
             if 2021.1 > float(min_version_tableau):
                 min_version_tableau = "2021.1"
             reasons.append("Connector uses OAuth, which was added in the 2021.1 release")
+        elif connector_file.file_type == "connector-resolver":
+            # Check to see if we're using inferred connection resolver, which needs 2021.1+
+            tdr_root = ET.parse(input_dir / connector_file.file_name).getroot()
+            attribute_list = tdr_root.find('.//connection-normalizer/required-attributes/attribute-list')
+
+            if not attribute_list:
+                if 2021.1 > float(min_version_tableau):
+                    min_version_tableau = "2021.1"
+                reasons.append("Connector uses inferred connection resolver, which was added in the 2021.1 release")
 
     if version.parse(cur_min_version_tableau) > version.parse(min_version_tableau):
         reasons.append("min-tableau-version set to " + cur_min_version_tableau + ", since that is higher than calculated version of " + min_version_tableau)
@@ -102,7 +111,7 @@ def stamp_min_support_version(input_dir: Path, file_list: List[ConnectorFile], j
 
     # stamp the min-tableau-version onto original manifest
     cur_min_version_tableau = plugin_elem.get(MIN_TABLEAU_VERSION_ATTR, "0")
-    min_version_tableau, reasons = get_min_support_version(file_list, cur_min_version_tableau, plugin_elem)
+    min_version_tableau, reasons = get_min_support_version(file_list, cur_min_version_tableau, plugin_elem, input_dir)
     plugin_elem.set(MIN_TABLEAU_VERSION_ATTR, min_version_tableau)
     manifest.write(input_dir / manifest_file.file_name, encoding="utf-8", xml_declaration=True)
 

--- a/connector-packager/connector_packager/jar_jdk_packager.py
+++ b/connector-packager/connector_packager/jar_jdk_packager.py
@@ -48,6 +48,7 @@ def get_min_support_version(file_list: List[ConnectorFile], cur_min_version_tabl
 
     # Check file types
     for connector_file in file_list:
+
         # if we have a connection-fields file, then we are using modular dialogs and need 2020.3+
         if connector_file.file_type == "connection-fields":
             if 2020.3 > float(min_version_tableau):
@@ -57,7 +58,7 @@ def get_min_support_version(file_list: List[ConnectorFile], cur_min_version_tabl
             if 2021.1 > float(min_version_tableau):
                 min_version_tableau = "2021.1"
             reasons.append("Connector uses OAuth, which was added in the 2021.1 release")
-        elif connector_file.file_type == "connector-resolver":
+        elif connector_file.file_type == "connection-resolver":
             # Check to see if we're using inferred connection resolver, which needs 2021.1+
             tdr_root = ET.parse(input_dir / connector_file.file_name).getroot()
             attribute_list = tdr_root.find('.//connection-normalizer/required-attributes/attribute-list')

--- a/connector-packager/connector_packager/package.py
+++ b/connector-packager/connector_packager/package.py
@@ -7,6 +7,7 @@ from argparse import ArgumentParser
 
 from pathlib import Path
 
+from .connector_properties import ConnectorProperties
 from .jar_jdk_packager import jdk_create_jar
 from .xsd_validator import validate_all_xml
 from .xml_parser import XMLParser
@@ -89,7 +90,8 @@ def main():
     files_to_package = xmlparser.generate_file_list()  # validates XSD's as well
 
     # Validate xml. If not valid, return.
-    if files_to_package and validate_all_xml(files_to_package, path_from_args):
+    properties = ConnectorProperties()
+    if files_to_package and validate_all_xml(files_to_package, path_from_args, properties):
         logger.info("Validation succeeded.")
     else:
         logger.info("Validation failed. Check " + str(log_file) + " for more information.")

--- a/connector-packager/connector_packager/xml_parser.py
+++ b/connector-packager/connector_packager/xml_parser.py
@@ -1,6 +1,7 @@
 import logging
 from typing import List, Optional
 import os
+import sys
 
 from pathlib import Path
 
@@ -12,6 +13,7 @@ from .xsd_validator import validate_single_file
 logger = logging.getLogger('packager_logger')
 
 
+MAX_FILE_SIZE = 1024 * 256  # This is based on the max file size we will load on the Tableau side
 HTTPS_STRING = "https://"
 TRANSLATABLE_STRING_PREFIX = "@string/"
 TABLEAU_SUPPORTED_LANGUAGES = ["de_DE", "en_GB", "en_US", "es_ES", "fr_FR", "ga_IE", "it_IT", "ja_JP", "ko_KR", "pt_BR",
@@ -81,15 +83,6 @@ class XMLParser:
                 resource_file_name = "resources-" + language + ".xml"
                 path_to_resource = self.path_to_folder / Path(resource_file_name)
                 if path_to_resource.is_file():
-                    # Validate that the resource file is valid.
-                    new_file = ConnectorFile(resource_file_name, "resource")
-                    xml_violations_buffer = []
-
-                    if not validate_single_file(new_file, path_to_resource, xml_violations_buffer):
-                        for error in xml_violations_buffer:
-                            logging.debug(error)
-                        return None
-
                     self.file_list.append(ConnectorFile(resource_file_name, "resource"))
                     logging.debug("Adding file to list (name = " + resource_file_name + ", type = resource)")
 
@@ -116,17 +109,24 @@ class XMLParser:
         path_to_file = self.path_to_folder / str(file_to_parse.file_name)
         xml_violation_buffer = []
 
-        # if the file is not valid, return false
-        if not validate_single_file(file_to_parse, path_to_file, xml_violation_buffer):
-            for v in xml_violation_buffer:
-                logger.debug(v)
-            return False
-
         logger.debug("Parsing " + str(path_to_file))
 
+        # If the file is too big, we shouldn't try and parse it, just log the violation and move on
+        if path_to_file.stat().st_size > MAX_FILE_SIZE:
+            logging.error(file_to_parse.file_name + " exceeds maximum size of " + str(int(MAX_FILE_SIZE / 1024)) + " KB")
+            return False
+
         # Get XML file ready for parsing
-        xml_tree = parse(str(path_to_file))
-        root = xml_tree.getroot()
+        # Catch any errors and display them to user
+        try:
+            xml_tree = parse(str(path_to_file))
+            root = xml_tree.getroot()
+        except Exception:
+            saved_error_type = sys.exc_info()[0]
+            saved_error = sys.exc_info()[1]
+            logger.error("Error parsing " + file_to_parse.file_name + "\nError Type: " + str(saved_error_type) +
+                         "\n" + str(saved_error))
+            return False
 
         # Check children. If they have a "file" or a "script" attribute then make a new ConnectorFile and parse
         for child in root.iter():

--- a/connector-packager/connector_packager/xsd_validator.py
+++ b/connector-packager/connector_packager/xsd_validator.py
@@ -36,6 +36,7 @@ def validate_all_xml(files_list: List[ConnectorFile], folder_path: Path, propert
     Arguments:
         files_list {list[ConnectorFile]} -- List of files to validate
         folder_path {Path} -- path to folder that contains the files
+        properties {ConnectorProperties} -- an object contating properties that apply to the entire connector
 
     Returns:
         bool -- True if all xml files pass validation,false if they do not or there is an error
@@ -90,6 +91,7 @@ def validate_single_file(file_to_test: ConnectorFile, path_to_file: Path, xml_vi
         file_to_test {ConnectorFile} -- path to a single file to test
         path_to_file {Path} -- path to the file
         xml_violations_buffer {list[str]} -- a list of strings that holds the xml violation messages
+        properties {ConnectorProperties} -- an object contating properties that apply to the entire connector
 
     Returns:
         bool -- True if the xml file passes validation, false if it does not or there is an error
@@ -154,6 +156,7 @@ def validate_file_specific_rules(file_to_test: ConnectorFile, path_to_file: Path
         file_to_test {ConnectorFile} -- the file we want to validate
         path_to_file {Path} -- the path to the file we want to validate
         xml_violations_buffer {list[str]} -- a list of strings that holds the xml violation messages
+        properties {ConnectorProperties} -- an object contating properties that apply to the entire connector
 
     Returns:
         bool -- True if the file passes all the file specific rules, otherwise false

--- a/connector-packager/connector_packager/xsd_validator.py
+++ b/connector-packager/connector_packager/xsd_validator.py
@@ -31,7 +31,7 @@ XSD_DICT = {
     "oauth-config": "oauth_config"}
 
 
-def validate_all_xml(files_list: List[ConnectorFile], folder_path: Path) -> bool:
+def validate_all_xml(files_list: List[ConnectorFile], folder_path: Path, properties: ConnectorProperties) -> bool:
     """"
     Arguments:
         files_list {list[ConnectorFile]} -- List of files to validate
@@ -52,8 +52,6 @@ def validate_all_xml(files_list: List[ConnectorFile], folder_path: Path) -> bool
     if len(files_list) < 1:
         logger.error("Error: validate_all_xml: input list is empty")
         return False
-
-    properties = ConnectorProperties()
 
     xml_violations_found = 0
     xml_violations_buffer = ["XML violations found."]

--- a/connector-packager/tests/test_connector_properties.py
+++ b/connector-packager/tests/test_connector_properties.py
@@ -1,0 +1,47 @@
+import unittest
+import logging
+from pathlib import Path
+
+from .jar_packager import create_jar
+from connector_packager.connector_file import ConnectorFile
+from connector_packager.connector_properties import ConnectorProperties
+from connector_packager.xsd_validator import validate_all_xml
+
+logger = logging.getLogger(__name__)
+
+TEST_FOLDER = Path("tests/test_resources")
+
+
+class TestConnectorProperties(unittest.TestCase):
+
+    def test_uses_tcd_property(self):
+        # Check that validate_all_xml properly sets uses_tcd to True if using .tcd file
+        test_folder = TEST_FOLDER / Path("valid_connector")  # This connector uses a .tcd file
+
+        files_list = [
+            ConnectorFile("manifest.xml", "manifest"),
+            ConnectorFile("connection-dialog.tcd", "connection-dialog"),
+            ConnectorFile("connectionBuilder.js", "script"),
+            ConnectorFile("dialect.tdd", "dialect"),
+            ConnectorFile("connectionResolver.tdr", "connection-resolver"),
+            ConnectorFile("resources-en_US.xml", "resource")]
+
+        properties_uses_tcd = ConnectorProperties()
+        self.assertTrue(validate_all_xml(files_list, test_folder, properties_uses_tcd), "Valid connector not marked as valid")
+        self.assertTrue(properties_uses_tcd.uses_tcd, "uses_tcd not set to True for connector using .tcd file")
+
+        # Check that validate_all_xml properly sets uses_tcd to False if not using .tcd file
+        test_folder = TEST_FOLDER / Path("modular_dialog_connector")  # This connector uses a conneciton-fields.xml file
+
+        files_list = [
+            ConnectorFile("manifest.xml", "manifest"),
+            ConnectorFile("connectionFields.xml", "connection-fields"),
+            ConnectorFile("connectionMetadata.xml", "connection-metadata"),
+            ConnectorFile("connectionBuilder.js", "script"),
+            ConnectorFile("dialect.xml", "dialect"),
+            ConnectorFile("connectionResolver.xml", "connection-resolver"),
+            ConnectorFile("connectionProperties.js", "script")]
+
+        properties_does_not_use_tcd = ConnectorProperties()
+        self.assertTrue(validate_all_xml(files_list, test_folder, properties_does_not_use_tcd), "Valid connector not marked as valid")
+        self.assertFalse(properties_does_not_use_tcd.uses_tcd, "uses_tcd not set to False for connector using .tcd file")

--- a/connector-packager/tests/test_resources/inferred_connection_resolver/connectionBuilder.js
+++ b/connector-packager/tests/test_resources/inferred_connection_resolver/connectionBuilder.js
@@ -1,0 +1,5 @@
+(function dsbuilder(attr) {
+    var urlBuilder = "jdbc:postgresql://" + attr[connectionHelper.attributeServer] + ":" + attr[connectionHelper.attributePort] + "/" + attr[connectionHelper.attributeDatabase] + "?";
+
+    return [urlBuilder];
+})

--- a/connector-packager/tests/test_resources/inferred_connection_resolver/connectionFields.xml
+++ b/connector-packager/tests/test_resources/inferred_connection_resolver/connectionFields.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<connection-fields>
+  <field name="server" label="Server" value-type="string" category="endpoint" >
+    <validation-rule reg-exp="^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$"/>
+  </field>
+
+  <field name="port" label="Port" value-type="string" category="endpoint" default-value="5432" />
+
+  <field name="v-custom" label="Custom" value-type="string" category="endpoint" />
+
+  <field name="username" label="Username" value-type="string" category="authentication" />
+
+  <field name="password" label="Password" value-type="string" category="authentication" secure="true" />
+  
+  <field name="v-custom2" label="Advanced Custom" value-type="string" category="advanced" optional="false" default-value="test" />
+  
+  <field name="vendor1" label="Advanced Vendor1" value-type="string" category="advanced" optional="false" default-value="testVendor1" />
+  
+  <field name="vendor2" label="Advanced Vendor2" value-type="string" category="advanced" optional="false" default-value="testVendor2" />
+  
+  <field name="vendor3" label="Advanced Vendor3" value-type="string" category="advanced" optional="false" default-value="testVendor3" />
+
+</connection-fields>

--- a/connector-packager/tests/test_resources/inferred_connection_resolver/connectionMetadata.xml
+++ b/connector-packager/tests/test_resources/inferred_connection_resolver/connectionMetadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<connection-metadata>
+  <database enabled='true' label='Database'>
+    <field />
+  </database>
+  <schema enabled='false' />
+</connection-metadata>

--- a/connector-packager/tests/test_resources/inferred_connection_resolver/connectionProperties.js
+++ b/connector-packager/tests/test_resources/inferred_connection_resolver/connectionProperties.js
@@ -1,0 +1,7 @@
+(function propertiesbuilder(attr) {
+    var props = {};
+    props["user"] = attr[connectionHelper.attributeUsername];
+    props["password"] = attr[connectionHelper.attributePassword];
+    
+    return props;
+})

--- a/connector-packager/tests/test_resources/inferred_connection_resolver/connectionResolver.xml
+++ b/connector-packager/tests/test_resources/inferred_connection_resolver/connectionResolver.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='utf-8' ?>
+
+<tdr class='postgres_mcd'>
+  <connection-resolver>
+    <connection-builder>
+      <script file='connectionBuilder.js'/>
+    </connection-builder>
+    <!-- Uses inferred connection resolver -->
+    <connection-properties>
+      <script file='connectionProperties.js'/>
+    </connection-properties>
+  </connection-resolver>
+</tdr>

--- a/connector-packager/tests/test_resources/inferred_connection_resolver/dialect.xml
+++ b/connector-packager/tests/test_resources/inferred_connection_resolver/dialect.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<dialect name='PostgresMCD'
+         class='postgres_mcd'
+         base='PostgreSQL90Dialect'
+         version='18.1'>
+</dialect>

--- a/connector-packager/tests/test_resources/inferred_connection_resolver/manifest.xml
+++ b/connector-packager/tests/test_resources/inferred_connection_resolver/manifest.xml
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='utf-8' ?>
+
+<connector-plugin class='postgres_mcd' superclass='jdbc' plugin-version='0.0.1' name='PostgreSQL MCD' version='18.1'>
+  <vendor-information>
+    <company name="Connector SDK"/>
+    <support-link url = "https://example.com"/>
+  </vendor-information>
+  <connection-customization class="postgres_mcd" enabled="true" version="10.0">
+    <vendor name="vendor"/>
+    <driver name="driver"/>
+    <customizations>
+      <customization name="CAP_SELECT_INTO" value="yes"/>
+      <customization name="CAP_SELECT_TOP_INTO" value="yes"/>
+      <customization name="CAP_CREATE_TEMP_TABLES" value="no"/>
+      <customization name="CAP_QUERY_BOOLEXPR_TO_INTEXPR" value="no"/>
+      <customization name="CAP_QUERY_GROUP_BY_BOOL" value="yes"/>
+      <customization name="CAP_QUERY_GROUP_BY_DEGREE" value="yes"/>
+      <customization name="CAP_QUERY_SORT_BY" value="yes"/>
+      <customization name="CAP_QUERY_SUBQUERIES" value="yes"/>
+      <customization name="CAP_QUERY_TOP_N" value="yes"/>
+      <customization name="CAP_QUERY_TOP_SAMPLE" value="yes"/>
+      <customization name="CAP_QUERY_TOP_SAMPLE_PERCENT" value="yes"/>
+      <customization name="CAP_QUERY_WHERE_FALSE_METADATA" value="yes"/>
+      <customization name="CAP_QUERY_SUBQUERIES_WITH_TOP" value="yes"/>
+      <customization name="CAP_SUPPORTS_SPLIT_FROM_LEFT" value="yes"/>
+      <customization name="CAP_SUPPORTS_SPLIT_FROM_RIGHT" value="yes"/>
+      <customization name="CAP_SUPPORTS_UNION" value="yes"/>
+      <customization name="CAP_QUERY_ALLOW_PARTIAL_AGGREGATION" value="no"/>
+      <customization name="CAP_QUERY_TIME_REQUIRES_CAST" value="yes"/>
+    </customizations>
+  </connection-customization>
+  <connection-fields file='connectionFields.xml'/>
+  <connection-metadata file='connectionMetadata.xml'/>
+  <connection-resolver file="connectionResolver.xml"/>
+  <dialect file='dialect.xml'/>
+</connector-plugin>

--- a/connector-packager/tests/test_resources/valid_connector/connection-dialog.tcd
+++ b/connector-packager/tests/test_resources/valid_connector/connection-dialog.tcd
@@ -6,7 +6,7 @@
     </authentication-options>
     <db-name-prompt value="Database: " />
     <has-pre-connect-database value="true" />
-    <port-prompt value="Port: " default="5432" />
+    <port-prompt value="@string/port_prompt" default="5432" />
     <show-ssl-checkbox value="true" />
   </connection-config>
 </connection-dialog>

--- a/connector-packager/tests/test_resources/valid_connector/manifest.xml
+++ b/connector-packager/tests/test_resources/valid_connector/manifest.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<connector-plugin class='postgres_odbc' superclass='odbc' plugin-version='0.0.0' name='PostgreSQL ODBC' version='18.1'>
+<connector-plugin class='postgres_odbc' superclass='odbc' plugin-version='0.0.0' name='@string/postgres' version='18.1'>
   <vendor-information>
       <company name="Company Name"/>
       <support-link url="https://example.com"/>

--- a/connector-packager/tests/test_xml_parser.py
+++ b/connector-packager/tests/test_xml_parser.py
@@ -18,7 +18,8 @@ class TestXMLParser(unittest.TestCase):
             ConnectorFile("connection-dialog.tcd", "connection-dialog"),
             ConnectorFile("connectionBuilder.js", "script"),
             ConnectorFile("dialect.tdd", "dialect"),
-            ConnectorFile("connectionResolver.tdr", "connection-resolver")]
+            ConnectorFile("connectionResolver.tdr", "connection-resolver"),
+            ConnectorFile("resources-en_US.xml", "resource")]
 
         actual_file_list, actual_class_name = self.parser_test_case(TEST_FOLDER / Path("valid_connector"),
                                                                     expected_file_list, expected_class_name)

--- a/connector-packager/tests/test_xml_parser.py
+++ b/connector-packager/tests/test_xml_parser.py
@@ -46,7 +46,7 @@ class TestXMLParser(unittest.TestCase):
                                                                     expected_file_list, expected_class_name)
         self.assertFalse(actual_file_list, "Connector with non-https urls returned a file list when it shouldn't")
 
-    def test_genreate_file_list_mcd(self):
+    def test_generate_file_list_mcd(self):
         # Test modular dialog connector
         expected_class_name = "postgres_mcd"
         expected_file_list = [
@@ -67,7 +67,7 @@ class TestXMLParser(unittest.TestCase):
         self.assertTrue(actual_class_name == expected_class_name,
                         "Actual class name does not match expected for valid connector")
 
-    def test_genreate_file_list_oauth(self):
+    def test_generate_file_list_oauth(self):
         # Test oauth connector
         expected_class_name = "test_oauth"
         expected_file_list = [

--- a/connector-packager/tests/test_xsd_validator.py
+++ b/connector-packager/tests/test_xsd_validator.py
@@ -4,10 +4,13 @@ from pathlib import Path
 
 from connector_packager.xsd_validator import validate_all_xml, validate_single_file, warn_file_specific_rules
 from connector_packager.connector_file import ConnectorFile
+from connector_packager.connector_properties import ConnectorProperties
 
 logger = logging.getLogger(__name__)
 
 TEST_FOLDER = Path("tests/test_resources")
+
+dummy_properties = ConnectorProperties
 
 
 class TestXSDValidator(unittest.TestCase):
@@ -39,25 +42,25 @@ class TestXSDValidator(unittest.TestCase):
         file_to_test = ConnectorFile("manifest.xml", "manifest")
         xml_violations_buffer = []
 
-        self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer),
+        self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
                         "Valid XML file not marked as valid")
 
         test_file = TEST_FOLDER / Path("big_manifest/manifest.xml")
 
-        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer),
+        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
                          "Big XML file marked as valid")
 
         print("\nTest broken xml. Throws XML validation error.")
         test_file = TEST_FOLDER / Path("broken_xml/manifest.xml")
 
-        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer),
+        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
                          "XML file that doesn't follow schema marked as valid")
 
         print("\nTest malformed xml. Throws XML validation error.")
         test_file = TEST_FOLDER / Path("broken_xml/connectionResolver.tdr")
         file_to_test = ConnectorFile("connectionResolver.tdr", "connection-resolver")
 
-        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer),
+        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
                          "Malformed XML file marked as valid")
 
         logging.debug("test_validate_single_file xml violations:")
@@ -70,12 +73,12 @@ class TestXSDValidator(unittest.TestCase):
         file_to_test = ConnectorFile("connectionFields.xml", "connection-fields")
         xml_violations_buffer = []
 
-        self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer),
+        self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
                         "Valid XML file not marked as valid")
 
         print("\nTest malformed xml. Throws XML validation error.")
         test_file = TEST_FOLDER / "broken_xml/connectionFields.xml"
-        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer),
+        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
                          "XML file with invalid name values marked as valid")
 
         logging.debug("test_validate_vendor_prefix xml violations:")
@@ -88,12 +91,12 @@ class TestXSDValidator(unittest.TestCase):
         file_to_test = ConnectorFile("connectionFields.xml", "connection-fields")
         xml_violations_buffer = []
 
-        self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer),
+        self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
                         "Valid XML file not marked as valid")
 
         print("\nTest missing default-value for non-optional advanced field. Throws XML validation error.")
         test_file = TEST_FOLDER / "advanced_required_missing_default/connectionFields.xml"
-        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer),
+        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
                          "XML file containing required field in 'advanced' category with no default value marked as valid")
 
         logging.debug("test_validate_required_advanced_field_has_default_value xml violations:")
@@ -106,12 +109,12 @@ class TestXSDValidator(unittest.TestCase):
         file_to_test = ConnectorFile("connectionFields.xml", "connection-fields")
         xml_violations_buffer = []
 
-        self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer),
+        self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
                         "Valid XML file not marked as valid")
 
         print("\nTest duplicate fields not allowed. Throws XML validation error.")
         test_file = TEST_FOLDER / "duplicate_fields/connectionFields.xml"
-        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer),
+        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
                          "A field with the field name = server already exists. Cannot have multiple fields with the same name.")
 
         logging.debug("test_validate_duplicate_fields_absent xml violations:")
@@ -123,14 +126,14 @@ class TestXSDValidator(unittest.TestCase):
         file_to_test = ConnectorFile("connectionFields.xml", "connection-fields")
         xml_violations_buffer = []
 
-        self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer),
+        self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
                         "Valid XML file not marked as valid")
 
         test_file = TEST_FOLDER / "instanceurl/connectionFields.xml"
         file_to_test = ConnectorFile("connectionFields.xml", "connection-fields")
         xml_violations_buffer = []
 
-        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer),
+        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
                         "An instanceurl field must be conditional to authentication field with value=oauth")
     def test_warn_defaultSQLDialect_as_base(self):
 
@@ -183,33 +186,33 @@ class TestXSDValidator(unittest.TestCase):
         file_to_test = ConnectorFile("connectionFields.xml", "connection-fields")
         print("Test connectionFields is validated by XSD when field name is vaild ")
         xml_violations_buffer = []
-        self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer),
+        self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
                         "XML Validation passed for connectionFields.xml")
 
-        print("Test connectionFields is invalidated by XSD when field name" 
+        print("Test connectionFields is invalidated by XSD when field name"
         "contains special character other than - or _")
         test_file = TEST_FOLDER / "field_name_validation/invalid/special_character/connectionFields.xml"
-        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer),
+        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
                          "XML Validation failed for connectionFields.xml")
 
         print("Test connectionFields is invalidated by XSD when field name starts with a number")
         test_file = TEST_FOLDER / "field_name_validation/invalid/starting_number/connectionFields.xml"
-        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer),
+        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
                          "XML Validation failed for connectionFields.xml")
 
         print("Test connectionFields is invalidated by XSD when field name starts with a space")
         test_file = TEST_FOLDER / "field_name_validation/invalid/starting_space/connectionFields.xml"
-        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer),
+        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
                          "XML Validation failed for connectionFields.xml")
         print("Test connectionFields is invalidated by XSD when field name has space in between")
 
         test_file = TEST_FOLDER / "field_name_validation/invalid/space_in_between/connectionFields.xml"
-        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer),
+        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
                          "XML Validation failed for connectionFields.xml")
 
         print("Test connectionFields is invalidated by XSD when field name ends with a space")
         test_file = TEST_FOLDER / "field_name_validation/invalid/ending_space/connectionFields.xml"
-        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer),
+        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
                          "XML Validation failed for connectionFields.xml")
 
         logging.debug("test_validate_connetion_field_name xml violations:")


### PR DESCRIPTION
- Sets min_tableau_version to 2021.1 if inferred connection resolver is used
- If no connection-normalizer element and connector uses Connection Dialog V1 (with a .tcd file), reject the connector
- Adds "ConnectorProperties", a new object that holds connector-wide properties that are derived from one file but needed by another file when validating the xml. (Needed to save the uses_tcd bool somewhere)
- Refactors parse_file so we only need to call validate_single_file on a file once for a given connector. Before, we'd run it twice: once to make sure that the xml file won't throw an error in parse_file, and once when running validate_all_xml
- Fixes the valid_connector test resource to use the strings from the resource file so we actually pick up the resource file in the file list
- Adds unit tests to check that we correctly accept/reject connectors using inferred connection resolver based on ConnectionProperties.uses_tcd, that we correctly set the min_tableau_version for a valid connector using inferred connection resolver, and that we correctly set ConnectionProperties.uses_tcd.
- Also fixed assorted typos in test names
