### PR TITLE
Packager validates that all fields are in normalizer

### DIFF
--- a/connector-packager/connector_packager/connector_properties.py
+++ b/connector-packager/connector_packager/connector_properties.py
@@ -2,3 +2,4 @@
 class ConnectorProperties:
     def __init__(self):
         self.uses_tcd = False
+        self.connection_fields = []

--- a/connector-packager/tests/test_connector_properties.py
+++ b/connector-packager/tests/test_connector_properties.py
@@ -31,7 +31,7 @@ class TestConnectorProperties(unittest.TestCase):
         self.assertTrue(properties_uses_tcd.uses_tcd, "uses_tcd not set to True for connector using .tcd file")
 
         # Check that validate_all_xml properly sets uses_tcd to False if not using .tcd file
-        test_folder = TEST_FOLDER / Path("modular_dialog_connector")  # This connector uses a conneciton-fields.xml file
+        test_folder = TEST_FOLDER / Path("modular_dialog_connector")  # This connector uses a connection-fields.xml file
 
         files_list = [
             ConnectorFile("manifest.xml", "manifest"),
@@ -45,3 +45,22 @@ class TestConnectorProperties(unittest.TestCase):
         properties_does_not_use_tcd = ConnectorProperties()
         self.assertTrue(validate_all_xml(files_list, test_folder, properties_does_not_use_tcd), "Valid connector not marked as valid")
         self.assertFalse(properties_does_not_use_tcd.uses_tcd, "uses_tcd not set to False for connector using .tcd file")
+
+    def test_connector_fields_property(self):
+        # Check that we correctly populate the connection fields property
+        expected_connection_fields = ['server', 'port', 'v-custom', 'username', 'password', 'v-custom2', 'vendor1', 'vendor2', 'vendor3']
+
+        test_folder = TEST_FOLDER / Path("modular_dialog_connector")  # This connector uses a connection-fields.xml file
+
+        files_list = [
+            ConnectorFile("manifest.xml", "manifest"),
+            ConnectorFile("connectionFields.xml", "connection-fields"),
+            ConnectorFile("connectionMetadata.xml", "connection-metadata"),
+            ConnectorFile("connectionBuilder.js", "script"),
+            ConnectorFile("dialect.xml", "dialect"),
+            ConnectorFile("connectionResolver.xml", "connection-resolver"),
+            ConnectorFile("connectionProperties.js", "script")]
+
+        properties = ConnectorProperties()
+        self.assertTrue(validate_all_xml(files_list, test_folder, properties), "Valid connector not marked as valid")
+        self.assertEqual(expected_connection_fields, properties.connection_fields, "Actual properties.connection_fields did not match expected")

--- a/connector-packager/tests/test_resources/mcd_field_not_in_normalizer/connectionBuilder.js
+++ b/connector-packager/tests/test_resources/mcd_field_not_in_normalizer/connectionBuilder.js
@@ -1,0 +1,5 @@
+(function dsbuilder(attr) {
+    var urlBuilder = "jdbc:postgresql://" + attr[connectionHelper.attributeServer] + ":" + attr[connectionHelper.attributePort] + "/" + attr[connectionHelper.attributeDatabase] + "?";
+
+    return [urlBuilder];
+})

--- a/connector-packager/tests/test_resources/mcd_field_not_in_normalizer/connectionFields.xml
+++ b/connector-packager/tests/test_resources/mcd_field_not_in_normalizer/connectionFields.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<connection-fields>
+  <field name="server" label="Server" value-type="string" category="endpoint" >
+    <validation-rule reg-exp="^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$"/>
+  </field>
+
+  <field name="port" label="Port" value-type="string" category="endpoint" default-value="5432" />
+
+  <field name="v-custom" label="Custom" value-type="string" category="endpoint" />
+
+  <field name="username" label="Username" value-type="string" category="authentication" />
+
+  <field name="password" label="Password" value-type="string" category="authentication" secure="true" />
+  
+  <field name="v-custom2" label="Advanced Custom" value-type="string" category="advanced" optional="false" default-value="test" />
+  
+  <field name="vendor1" label="Advanced Vendor1" value-type="string" category="advanced" optional="false" default-value="testVendor1" />
+  
+  <field name="vendor2" label="Advanced Vendor2" value-type="string" category="advanced" optional="false" default-value="testVendor2" />
+  
+  <field name="vendor3" label="Advanced Vendor3" value-type="string" category="advanced" optional="false" default-value="testVendor3" />
+
+</connection-fields>

--- a/connector-packager/tests/test_resources/mcd_field_not_in_normalizer/connectionMetadata.xml
+++ b/connector-packager/tests/test_resources/mcd_field_not_in_normalizer/connectionMetadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<connection-metadata>
+  <database enabled='true' label='Database'>
+    <field />
+  </database>
+  <schema enabled='false' />
+</connection-metadata>

--- a/connector-packager/tests/test_resources/mcd_field_not_in_normalizer/connectionProperties.js
+++ b/connector-packager/tests/test_resources/mcd_field_not_in_normalizer/connectionProperties.js
@@ -1,0 +1,7 @@
+(function propertiesbuilder(attr) {
+    var props = {};
+    props["user"] = attr[connectionHelper.attributeUsername];
+    props["password"] = attr[connectionHelper.attributePassword];
+    
+    return props;
+})

--- a/connector-packager/tests/test_resources/mcd_field_not_in_normalizer/connectionResolver.xml
+++ b/connector-packager/tests/test_resources/mcd_field_not_in_normalizer/connectionResolver.xml
@@ -16,7 +16,7 @@
           <attr>username</attr>
           <attr>password</attr>
           <attr>authentication</attr>
-          <attr>vendor1</attr>
+          <!-- <attr>vendor1</attr> -->
           <attr>vendor2</attr>
           <attr>vendor3</attr>
         </attribute-list>

--- a/connector-packager/tests/test_resources/mcd_field_not_in_normalizer/dialect.xml
+++ b/connector-packager/tests/test_resources/mcd_field_not_in_normalizer/dialect.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<dialect name='PostgresMCD'
+         class='postgres_mcd'
+         base='PostgreSQL90Dialect'
+         version='18.1'>
+</dialect>

--- a/connector-packager/tests/test_resources/mcd_field_not_in_normalizer/manifest.xml
+++ b/connector-packager/tests/test_resources/mcd_field_not_in_normalizer/manifest.xml
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='utf-8' ?>
+
+<connector-plugin class='postgres_mcd' superclass='jdbc' plugin-version='0.0.1' name='PostgreSQL MCD' version='18.1'>
+  <vendor-information>
+    <company name="Connector SDK"/>
+    <support-link url = "https://example.com"/>
+  </vendor-information>
+  <connection-customization class="postgres_mcd" enabled="true" version="10.0">
+    <vendor name="vendor"/>
+    <driver name="driver"/>
+    <customizations>
+      <customization name="CAP_SELECT_INTO" value="yes"/>
+      <customization name="CAP_SELECT_TOP_INTO" value="yes"/>
+      <customization name="CAP_CREATE_TEMP_TABLES" value="no"/>
+      <customization name="CAP_QUERY_BOOLEXPR_TO_INTEXPR" value="no"/>
+      <customization name="CAP_QUERY_GROUP_BY_BOOL" value="yes"/>
+      <customization name="CAP_QUERY_GROUP_BY_DEGREE" value="yes"/>
+      <customization name="CAP_QUERY_SORT_BY" value="yes"/>
+      <customization name="CAP_QUERY_SUBQUERIES" value="yes"/>
+      <customization name="CAP_QUERY_TOP_N" value="yes"/>
+      <customization name="CAP_QUERY_TOP_SAMPLE" value="yes"/>
+      <customization name="CAP_QUERY_TOP_SAMPLE_PERCENT" value="yes"/>
+      <customization name="CAP_QUERY_WHERE_FALSE_METADATA" value="yes"/>
+      <customization name="CAP_QUERY_SUBQUERIES_WITH_TOP" value="yes"/>
+      <customization name="CAP_SUPPORTS_SPLIT_FROM_LEFT" value="yes"/>
+      <customization name="CAP_SUPPORTS_SPLIT_FROM_RIGHT" value="yes"/>
+      <customization name="CAP_SUPPORTS_UNION" value="yes"/>
+      <customization name="CAP_QUERY_ALLOW_PARTIAL_AGGREGATION" value="no"/>
+      <customization name="CAP_QUERY_TIME_REQUIRES_CAST" value="yes"/>
+    </customizations>
+  </connection-customization>
+  <connection-fields file='connectionFields.xml'/>
+  <connection-metadata file='connectionMetadata.xml'/>
+  <connection-resolver file="connectionResolver.xml"/>
+  <dialect file='dialect.xml'/>
+</connector-plugin>

--- a/connector-packager/tests/test_xsd_validator.py
+++ b/connector-packager/tests/test_xsd_validator.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 TEST_FOLDER = Path("tests/test_resources")
 
-dummy_properties = ConnectorProperties
+dummy_properties = ConnectorProperties()
 
 
 class TestXSDValidator(unittest.TestCase):
@@ -234,5 +234,23 @@ class TestXSDValidator(unittest.TestCase):
         print("Test that connection resolver with connection-normalizer for a connector that uses a .tcd file is validated")
         properties.uses_tcd = False
         self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer, properties),
-                        "Inferred connection resolver validated when tcd was used")
+                        "Valid connector marked as invalid")
 
+    def test_all_fields_in_normalizer(self):
+        properties = ConnectorProperties()
+        properties.uses_tcd = False
+        properties.connection_fields = ['server', 'port', 'v-custom', 'username', 'password', 'v-custom2', 'vendor1', 'vendor2', 'vendor3']
+        xml_violations_buffer = []
+
+
+        print("Test that normalizer not containing all the fields in connection-fields is invalidated")
+        file_to_test = ConnectorFile("connectionResolver.xml", "connection-resolver")
+        test_file = TEST_FOLDER / "mcd_field_not_in_normalizer/connectionResolver.xml"
+        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, properties),
+                         "Inferred connection resolver validated when tcd was used")
+
+        print("Test that normalizer containing all the fields in connection-fields is validated")
+        file_to_test = ConnectorFile("connectionResolver.xml", "connection-resolver")
+        test_file = TEST_FOLDER / "modular_dialog_connector/connectionResolver.xml"
+        self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer, properties),
+                        "Valid connector marked as invalid")


### PR DESCRIPTION
- Adds a new ConnectorProperty: connection_fields, which stores the connection fields
- Checks that all fields are in the required attributes list, rejects connector if one is missing
- Adds unit tests for the above scenario