### PR TITLE
Validate that authentication field exists

### DIFF
--- a/connector-packager/connector_packager/connector_properties.py
+++ b/connector-packager/connector_packager/connector_properties.py
@@ -3,3 +3,4 @@ class ConnectorProperties:
     def __init__(self):
         self.uses_tcd = False
         self.connection_fields = []
+        self.backwards_compatibility_mode = False

--- a/connector-packager/connector_packager/package.py
+++ b/connector-packager/connector_packager/package.py
@@ -31,6 +31,8 @@ def create_arg_parser() -> ArgumentParser:
                         default=os.getcwd())
     parser.add_argument('--validate-only', dest='validate_only', action='store_true',
                         help='runs package validation steps only', required=False)
+    parser.add_argument('--backwards-compatible', dest='backwards_compatible', action='store_true',
+                        help='forgives some validation errors to package connectors made with older versions of the SDK', required=False)
     parser.add_argument('-d', '--dest', dest='dest', help='destination folder for packaged connector',
                         default='packaged-connector', action=UniqueActionStore)
     return parser
@@ -91,6 +93,7 @@ def main():
 
     # Validate xml. If not valid, return.
     properties = ConnectorProperties()
+    properties.backwards_compatibility_mode = args.backwards_compatible
     if files_to_package and validate_all_xml(files_to_package, path_from_args, properties):
         logger.info("Validation succeeded.")
     else:

--- a/connector-packager/connector_packager/xsd_validator.py
+++ b/connector-packager/connector_packager/xsd_validator.py
@@ -218,8 +218,12 @@ def validate_file_specific_rules_connection_fields(file_to_test: ConnectorFile, 
 
     # Check that "authentication" is listed as a connection field
     if 'authentication' not in properties.connection_fields:
-        xml_violations_buffer.append("No authentication field present in " + file_to_test.file_name)
-        return False
+
+        if properties.backwards_compatibility_mode:
+            logger.warning("No authentication field present in " + file_to_test.file_name + ". Still packaging connector because of backwards compatibility mode.")
+        else:
+            xml_violations_buffer.append("No authentication field present in " + file_to_test.file_name)
+            return False
 
     return True
 

--- a/connector-packager/connector_packager/xsd_validator.py
+++ b/connector-packager/connector_packager/xsd_validator.py
@@ -215,6 +215,12 @@ def validate_file_specific_rules_connection_fields(file_to_test: ConnectorFile, 
                 xml_violations_buffer.append("Element 'field', attribute 'name'='" + field_name +
                                                 "': Required fields in the Advanced category must be assigned a default value.")
                 return False
+
+    # Check that "authentication" is listed as a connection field
+    if 'authentication' not in properties.connection_fields:
+        xml_violations_buffer.append("No authentication field present in " + file_to_test.file_name)
+        return False
+
     return True
 
 

--- a/connector-packager/tests/test_connector_properties.py
+++ b/connector-packager/tests/test_connector_properties.py
@@ -48,7 +48,7 @@ class TestConnectorProperties(unittest.TestCase):
 
     def test_connector_fields_property(self):
         # Check that we correctly populate the connection fields property
-        expected_connection_fields = ['server', 'port', 'v-custom', 'username', 'password', 'v-custom2', 'vendor1', 'vendor2', 'vendor3']
+        expected_connection_fields = ['server', 'port', 'v-custom', 'authentication', 'username', 'password', 'v-custom2', 'vendor1', 'vendor2', 'vendor3']
 
         test_folder = TEST_FOLDER / Path("modular_dialog_connector")  # This connector uses a connection-fields.xml file
 

--- a/connector-packager/tests/test_resources/advanced_required_missing_default/connectionFields.xml
+++ b/connector-packager/tests/test_resources/advanced_required_missing_default/connectionFields.xml
@@ -3,4 +3,5 @@
 <connection-fields>
   <field name="v-custom" label="Custom" value-type="string" category="advanced" optional="false" />
 
+  <field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="auth-user-pass" />
 </connection-fields>

--- a/connector-packager/tests/test_resources/authentication_attribute/connection_fields_no_authentication.xml
+++ b/connector-packager/tests/test_resources/authentication_attribute/connection_fields_no_authentication.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <connection-fields>
-  <field name="server" label="Server" value-type="string" category="endpoint" />
+  <field name="server" label="Server" value-type="string" category="endpoint" >
+    <validation-rule reg-exp="^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$"/>
+  </field>
 
   <field name="port" label="Port" value-type="string" category="endpoint" default-value="5432" />
-
-  <field name="warehouse" label="Warehouse" value-type="string" category="metadata" />
-
-  <field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="auth-user-pass" />
 
   <field name="username" label="Username" value-type="string" category="authentication" />
 

--- a/connector-packager/tests/test_resources/authentication_attribute/connection_fields_with_authentication.xml
+++ b/connector-packager/tests/test_resources/authentication_attribute/connection_fields_with_authentication.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <connection-fields>
-  <field name="server" label="Server" value-type="string" category="endpoint" />
+  <field name="server" label="Server" value-type="string" category="endpoint" >
+    <validation-rule reg-exp="^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$"/>
+  </field>
 
   <field name="port" label="Port" value-type="string" category="endpoint" default-value="5432" />
-
-  <field name="warehouse" label="Warehouse" value-type="string" category="metadata" />
 
   <field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="auth-user-pass" />
 

--- a/connector-packager/tests/test_resources/duplicate_fields/connectionFields.xml
+++ b/connector-packager/tests/test_resources/duplicate_fields/connectionFields.xml
@@ -2,6 +2,8 @@
 
 <connection-fields>
 
+<field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="auth-user-pass" />
+
 <field name="server" label="Server1" value-type="string" category="endpoint" />
 <field name="server" label="Server2" value-type="string" category="endpoint" />
 

--- a/connector-packager/tests/test_resources/field_name_validation/invalid/ending_space/connectionFields.xml
+++ b/connector-packager/tests/test_resources/field_name_validation/invalid/ending_space/connectionFields.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <connection-fields>
+  <field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="auth-user-pass" />
+
   <field name="username" label="Username" value-type="string" category="authentication" />
     <!-- Ending in space -->
   <field name="vendor1 " label="Advanced Vendor1" value-type="string" category="advanced" optional="false" default-value="testVendor1" />

--- a/connector-packager/tests/test_resources/field_name_validation/invalid/space_in_between/connectionFields.xml
+++ b/connector-packager/tests/test_resources/field_name_validation/invalid/space_in_between/connectionFields.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <connection-fields>
+  <field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="auth-user-pass" />
+
   <field name="username" label="Username" value-type="string" category="authentication" />
     <!-- Space in between -->
   <field name="vend or1" label="Advanced Vendor1" value-type="string" category="advanced" optional="false" default-value="testVendor3" />

--- a/connector-packager/tests/test_resources/field_name_validation/invalid/special_character/connectionFields.xml
+++ b/connector-packager/tests/test_resources/field_name_validation/invalid/special_character/connectionFields.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <connection-fields>
+  <field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="auth-user-pass" />
+
   <field name="username" label="Username" value-type="string" category="authentication" />
     <!-- Special character-->
   <field name="vendor$1" label="Advanced Vendor1" value-type="string" category="advanced" optional="false" default-value="testVendor1" />

--- a/connector-packager/tests/test_resources/field_name_validation/invalid/starting_number/connectionFields.xml
+++ b/connector-packager/tests/test_resources/field_name_validation/invalid/starting_number/connectionFields.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <connection-fields>
+  <field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="auth-user-pass" />
+
   <field name="username" label="Username" value-type="string" category="authentication" />
     <!-- Starting with number -->
   <field name="1vendor1" label="Advanced Vendor1" value-type="string" category="advanced" optional="false" default-value="testVendor1" />

--- a/connector-packager/tests/test_resources/field_name_validation/invalid/starting_space/connectionFields.xml
+++ b/connector-packager/tests/test_resources/field_name_validation/invalid/starting_space/connectionFields.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <connection-fields>
+  <field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="auth-user-pass" />
+
   <field name="username" label="Username" value-type="string" category="authentication" />
     <!-- Space in between -->
   <field name=" vendor1" label="Advanced Vendor1" value-type="string" category="advanced" optional="false" default-value="testVendor1" />

--- a/connector-packager/tests/test_resources/field_name_validation/valid/connectionFields.xml
+++ b/connector-packager/tests/test_resources/field_name_validation/valid/connectionFields.xml
@@ -1,22 +1,24 @@
 <connection-fields>
+  <field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="auth-user-pass" />
+
   <!-- -  is valid -->
-  <field label='LogModules' name='v-logmodules' 
-          value-type='string' default-value='' optional='true' 
+  <field label='LogModules' name='v-logmodules'
+          value-type='string' default-value='' optional='true'
           secure='false' category='advanced'>
   </field>
   <!-- Underscore end is valid -->
-  <field label='Logfile' name='v-logfile_' 
-          value-type='string' default-value='' optional='true' 
+  <field label='Logfile' name='v-logfile_'
+          value-type='string' default-value='' optional='true'
           secure='false' category='advanced'>
   </field>
   <!-- Underscore _ in between is valid -->
-  <field label='MaxLogFileCount' name='v-maxlogfi_lecount' 
-          value-type='string' default-value='-1' optional='true' 
+  <field label='MaxLogFileCount' name='v-maxlogfi_lecount'
+          value-type='string' default-value='-1' optional='true'
           secure='false' category='advanced'>
   </field>
   <!-- Numbers are valid if is not first character -->
-  <field label='MaxLogFileSize' name='v-maxlogfilesize33' 
-          value-type='string' default-value='100MB' optional='true' 
+  <field label='MaxLogFileSize' name='v-maxlogfilesize33'
+          value-type='string' default-value='100MB' optional='true'
           secure='false' category='advanced'>
   </field>
 </connection-fields>

--- a/connector-packager/tests/test_resources/inferred_connection_resolver/connectionFields.xml
+++ b/connector-packager/tests/test_resources/inferred_connection_resolver/connectionFields.xml
@@ -9,16 +9,18 @@
 
   <field name="v-custom" label="Custom" value-type="string" category="endpoint" />
 
+  <field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="auth-user-pass" />
+
   <field name="username" label="Username" value-type="string" category="authentication" />
 
   <field name="password" label="Password" value-type="string" category="authentication" secure="true" />
-  
+
   <field name="v-custom2" label="Advanced Custom" value-type="string" category="advanced" optional="false" default-value="test" />
-  
+
   <field name="vendor1" label="Advanced Vendor1" value-type="string" category="advanced" optional="false" default-value="testVendor1" />
-  
+
   <field name="vendor2" label="Advanced Vendor2" value-type="string" category="advanced" optional="false" default-value="testVendor2" />
-  
+
   <field name="vendor3" label="Advanced Vendor3" value-type="string" category="advanced" optional="false" default-value="testVendor3" />
 
 </connection-fields>

--- a/connector-packager/tests/test_resources/mcd_field_not_in_normalizer/connectionFields.xml
+++ b/connector-packager/tests/test_resources/mcd_field_not_in_normalizer/connectionFields.xml
@@ -9,16 +9,18 @@
 
   <field name="v-custom" label="Custom" value-type="string" category="endpoint" />
 
+  <field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="auth-user-pass" />
+
   <field name="username" label="Username" value-type="string" category="authentication" />
 
   <field name="password" label="Password" value-type="string" category="authentication" secure="true" />
-  
+
   <field name="v-custom2" label="Advanced Custom" value-type="string" category="advanced" optional="false" default-value="test" />
-  
+
   <field name="vendor1" label="Advanced Vendor1" value-type="string" category="advanced" optional="false" default-value="testVendor1" />
-  
+
   <field name="vendor2" label="Advanced Vendor2" value-type="string" category="advanced" optional="false" default-value="testVendor2" />
-  
+
   <field name="vendor3" label="Advanced Vendor3" value-type="string" category="advanced" optional="false" default-value="testVendor3" />
 
 </connection-fields>

--- a/connector-packager/tests/test_resources/modular_dialog_connector/connectionFields.xml
+++ b/connector-packager/tests/test_resources/modular_dialog_connector/connectionFields.xml
@@ -9,16 +9,18 @@
 
   <field name="v-custom" label="Custom" value-type="string" category="endpoint" />
 
+  <field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="auth-user-pass" />
+
   <field name="username" label="Username" value-type="string" category="authentication" />
 
   <field name="password" label="Password" value-type="string" category="authentication" secure="true" />
-  
+
   <field name="v-custom2" label="Advanced Custom" value-type="string" category="advanced" optional="false" default-value="test" />
-  
+
   <field name="vendor1" label="Advanced Vendor1" value-type="string" category="advanced" optional="false" default-value="testVendor1" />
-  
+
   <field name="vendor2" label="Advanced Vendor2" value-type="string" category="advanced" optional="false" default-value="testVendor2" />
-  
+
   <field name="vendor3" label="Advanced Vendor3" value-type="string" category="advanced" optional="false" default-value="testVendor3" />
 
 </connection-fields>

--- a/connector-packager/tests/test_xsd_validator.py
+++ b/connector-packager/tests/test_xsd_validator.py
@@ -182,6 +182,20 @@ class TestXSDValidator(unittest.TestCase):
         self.assertIn("'authentication' attribute is missing", cm.output[0],
                       "\"'authentication' attribute is missing\" not found in warning message")
 
+    def test_validate_auth_attr_in_connection_fields(self):
+        test_file = TEST_FOLDER / "authentication_attribute/connection_fields_with_authentication.xml"
+        file_to_test = ConnectorFile("connectionFields.xml", "connection-fields")
+        properties = ConnectorProperties()
+        xml_violations_buffer = []
+
+        self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer, properties),
+                        "XML Validation failed for valid connection fields file")
+
+        test_file = TEST_FOLDER / "authentication_attribute/connection_fields_no_authentication.xml"
+        properties = ConnectorProperties()
+        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, properties),
+                        "XML Validation passed for connection fields file without authentication field")
+
     def test_validate_connection_field_name(self):
         test_file = TEST_FOLDER / "field_name_validation/valid/connectionFields.xml"
         file_to_test = ConnectorFile("connectionFields.xml", "connection-fields")


### PR DESCRIPTION
Even if there is only one auth mode, we need to have the non-editable field in connection-fields so the default is properly set. Had to update a bunch of test files as well. (Plus, a bunch of whitespace changes since my VSCode is set to trim trailing spaces on saving.)

Also, right now authentication being missing in the connection-normalizer required attributes list is a warning, not an error. Is there a valid case for authentication not being there? I'm wondering if we should make that an error, or if I'm going about this PR wrong and should only warn if authentication is missing from the connection fields.
