### PR TITLE
Add --ignore-validation argument

### DIFF
--- a/connector-packager/connector_packager/package.py
+++ b/connector-packager/connector_packager/package.py
@@ -31,6 +31,8 @@ def create_arg_parser() -> ArgumentParser:
                         default=os.getcwd())
     parser.add_argument('--validate-only', dest='validate_only', action='store_true',
                         help='runs package validation steps only', required=False)
+    parser.add_argument('--ignore-validation', dest='ignore_validation', action='store_true',
+                        help='packages taco even if validation fails', required=False)
     parser.add_argument('-d', '--dest', dest='dest', help='destination folder for packaged connector',
                         default='packaged-connector', action=UniqueActionStore)
     return parser
@@ -95,7 +97,14 @@ def main():
         logger.info("Validation succeeded.")
     else:
         logger.info("Validation failed. Check " + str(log_file) + " for more information.")
-        return
+
+        # If ignoring validation, continue and display warning. Otherwise, return out of main.
+        if args.ignore_validation:
+            logger.info("--ignore_validation flag on, packaging anyway.")
+            logger.warning("Warning: Invalid connector may not load in Tableau, or may have bugs. Packaging may fail.")
+
+        else:
+            return
 
     # Double check that all files exist
     for f in files_to_package:


### PR DESCRIPTION
Add a new command line argument that packages the connector even if validation fails. The use case for this is if a connector was made before we codified our best practices (for example, an existing connector missing authentication attribute), and our packager has since been updated to reject connectors not following the best practice, they can still package their connector if need be.

Updated help message:
```
(.venv) D:\connector-plugin-sdk\connector-packager>python -m connector_packager.package -h
usage: package.py [-h] [-v] [-l LOG_PATH] [--validate-only] [--ignore-validation] [-d DEST] input_dir

Tableau Connector Packaging Tool: package and sign connector files into a single Tableau Connector (.taco) file.

positional arguments:
  input_dir             path to directory of connector files to package and sign

optional arguments:
  -h, --help            show this help message and exit
  -v, --verbose         verbose output
  -l LOG_PATH, --log LOG_PATH
                        Path to directory for log output. Logs are saved in the file packaging_logs.txt. Default is the current working directory.
  --validate-only       runs package validation steps only
  --ignore-validation   packages taco even if validation fails
  -d DEST, --dest DEST  destination folder for packaged connector
```