### PR TITLE
Add French (Canada) to supported languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Tableau Connector SDK Changelog
+## 2021-08-23
+### Added
+- Add language support for French (Canada)
 ## 2021-01-22
 ### Removed
 - Remove support for `script` element and `cacheSize` attribute in ConnectionNormalizer-CT and ConnectionMatcher-CT in `tdr_latest.xsd`.  This has not been a recommended pattern since initial release and deprecated in 2020.3 release.  Documentation, samples and [API Reference](https://tableau.github.io/connector-plugin-sdk/docs/api-reference) have been previously updated.

--- a/connector-packager/connector_packager/xml_parser.py
+++ b/connector-packager/connector_packager/xml_parser.py
@@ -16,7 +16,7 @@ logger = logging.getLogger('packager_logger')
 MAX_FILE_SIZE = 1024 * 256  # This is based on the max file size we will load on the Tableau side
 HTTPS_STRING = "https://"
 TRANSLATABLE_STRING_PREFIX = "@string/"
-TABLEAU_SUPPORTED_LANGUAGES = ["de_DE", "en_GB", "en_US", "es_ES", "fr_FR", "ga_IE", "it_IT", "ja_JP", "ko_KR", "pt_BR",
+TABLEAU_SUPPORTED_LANGUAGES = ["de_DE", "en_GB", "en_US", "es_ES", "fr_CA", "fr_FR", "ga_IE", "it_IT", "ja_JP", "ko_KR", "pt_BR",
                                "zh_CN", "zh_TW"]
 
 

--- a/connector-packager/connector_packager/xml_parser.py
+++ b/connector-packager/connector_packager/xml_parser.py
@@ -16,8 +16,8 @@ logger = logging.getLogger('packager_logger')
 MAX_FILE_SIZE = 1024 * 256  # This is based on the max file size we will load on the Tableau side
 HTTPS_STRING = "https://"
 TRANSLATABLE_STRING_PREFIX = "@string/"
-TABLEAU_SUPPORTED_LANGUAGES = ["de_DE", "en_GB", "en_US", "es_ES", "fr_CA", "fr_FR", "ga_IE", "it_IT", "ja_JP", "ko_KR", "pt_BR",
-                               "zh_CN", "zh_TW"]
+TABLEAU_SUPPORTED_LANGUAGES = ["de_DE", "en_GB", "en_US", "es_ES", "fr_CA", "fr_FR", "ga_IE", "it_IT", "ja_JP", "ko_KR",
+                               "pt_BR", "zh_CN", "zh_TW"]
 
 
 class XMLParser:

--- a/connector-packager/tests/test_resources/valid_connector/connection-dialog.tcd
+++ b/connector-packager/tests/test_resources/valid_connector/connection-dialog.tcd
@@ -6,7 +6,7 @@
     </authentication-options>
     <db-name-prompt value="Database: " />
     <has-pre-connect-database value="true" />
-    <port-prompt value="@string/port_prompt" default="5432" />
+    <port-prompt value="@string/port_prompt/" default="5432" />
     <show-ssl-checkbox value="true" />
   </connection-config>
 </connection-dialog>

--- a/connector-packager/tests/test_resources/valid_connector/manifest.xml
+++ b/connector-packager/tests/test_resources/valid_connector/manifest.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<connector-plugin class='postgres_odbc' superclass='odbc' plugin-version='0.0.0' name='@string/postgres' version='18.1'>
+<connector-plugin class='postgres_odbc' superclass='odbc' plugin-version='0.0.0' name='@string/postgres/' version='18.1'>
   <vendor-information>
       <company name="Company Name"/>
       <support-link url="https://example.com"/>


### PR DESCRIPTION
Manual test:
- Confirmed that the resources-fr_CA.xml file can be successfully packaged into a taco file 
- Ran the connector packaged with a resources-fr_CA.xml file and confirmed that the strings are correctly translated after setting the language to French (Canada) in Tableau.

Unit test:
- Added Story 1305320: [Connector SDK] Add unit test to test that resource files are correctly detected

Filed a bug found from testing:
- Defect 1306176: [Connector SDK] Connector without a resources-en_US.xml file for localized strings packages successfully and causes Tableau Desktop to hang on startup

Updating related SDK doc:
- PR - https://github.com/tableau/connector-plugin-sdk/pull/842