### PR TITLE
Validate max length of company name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Tableau Connector SDK Changelog
+## 2021-09-02
+### Changed
+- Validate max length of `name` in Company-G in `connector_plugin_manifest_latest.xsd`
 ## 2021-08-23
 ### Added
 - Add language support for French (Canada)
@@ -14,7 +17,7 @@
 
 ## 2020-09-21
 ### Changed
-- Validate length of `name` in Company-G in `connector_plugin_manifest_latest.xsd`
+- Validate min length of `name` in Company-G in `connector_plugin_manifest_latest.xsd`
 
 ## 2020-08-27
 ### Added

--- a/connector-packager/tests/test_resources/company_name_length_validation/max/manifest.xml
+++ b/connector-packager/tests/test_resources/company_name_length_validation/max/manifest.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='utf-8' ?>
+
+<connector-plugin class='test' superclass='postgres' plugin-version='0.0.0' name='Test' version='18.1' min-version-tableau='2020.4'>
+
+  <vendor-information>
+      <company name="Long Company Name With More Than 24 Characters"/>
+      <support-link url="https://example.com"/>
+  </vendor-information>
+</connector-plugin>

--- a/connector-packager/tests/test_resources/company_name_length_validation/min/manifest.xml
+++ b/connector-packager/tests/test_resources/company_name_length_validation/min/manifest.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='utf-8' ?>
+
+<connector-plugin class='test' superclass='postgres' plugin-version='0.0.0' name='Test' version='18.1' min-version-tableau='2020.4'>
+
+  <vendor-information>
+      <company name=""/>
+      <support-link url="https://example.com"/>
+  </vendor-information>
+</connector-plugin>

--- a/connector-packager/tests/test_xsd_validator.py
+++ b/connector-packager/tests/test_xsd_validator.py
@@ -264,7 +264,7 @@ class TestXSDValidator(unittest.TestCase):
         self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
                          "Empty company name marked as valid")
 
-        print("Test that ompany name with length greater than 24 is invalidated")
+        print("Test that company name with length greater than 24 is invalidated")
         test_file = TEST_FOLDER / "company_name_length_validation/max/manifest.xml"
         self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
                          "Company name with length greater than 24 marked as valid")

--- a/connector-packager/tests/test_xsd_validator.py
+++ b/connector-packager/tests/test_xsd_validator.py
@@ -254,3 +254,17 @@ class TestXSDValidator(unittest.TestCase):
         test_file = TEST_FOLDER / "modular_dialog_connector/connectionResolver.xml"
         self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer, properties),
                         "Valid connector marked as invalid")
+
+    def test_validate_company_name_length(self):
+        xml_violations_buffer = []
+        file_to_test = ConnectorFile("manifest.xml", "manifest")
+
+        print("Test that company name with length less than 1 is invalidated")
+        test_file = TEST_FOLDER / "company_name_length_validation/min/manifest.xml"
+        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
+                         "Empty company name marked as valid")
+
+        print("Test that ompany name with length greater than 24 is invalidated")
+        test_file = TEST_FOLDER / "company_name_length_validation/max/manifest.xml"
+        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
+                         "Company name with length greater than 24 marked as valid")

--- a/validation/connector_plugin_manifest_latest.xsd
+++ b/validation/connector_plugin_manifest_latest.xsd
@@ -111,7 +111,7 @@
     <xs:sequence>
       <xs:element name="company">
         <xs:complexType>
-          <xs:attribute name="name" type="NonEmptyString-ST" use="required"/>
+          <xs:attribute name="name" type="NonEmptyCompanyName-ST" use="required"/>
         </xs:complexType>
       </xs:element>
     </xs:sequence>
@@ -172,9 +172,10 @@
   <xs:complexType name="Platform-ST">
     <xs:attribute name="name" type="OSShortName-ST" use="required"/>
   </xs:complexType>
-  <xs:simpleType name="NonEmptyString-ST">
+  <xs:simpleType name="NonEmptyCompanyName-ST">
     <xs:restriction base="xs:string">
       <xs:minLength value="1"/>
+      <xs:maxLength value="24"/>
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>


### PR DESCRIPTION
Changes:
- Added max length constraint to company name (defined [here](https://sourcegraph.prod.tableautools.com/teams/near/-/blob/modules/connectors/tabconnectorsbase/public/infrastructure/IConnectorPlugin.h#L7:22); already [enforced](https://sourcegraph.prod.tableautools.com/teams/near/-/blob/modules/connectors/tabmixins/main/infrastructure/ConnectorPluginValidator.cpp#L62) at load time so this change shouldn't break any existing gallery connectors)
- Renamed type `NonEmptyString-ST` to `NonEmptyCompanyName-ST`. It was provided a generic name, however it now has constraint specifically applies to company name so renamed it (currently this type is only used to validate company name).

Testing:
- Change the company name in \samples\plugins\postgres_jdbc\manifest.xml to an empty string and try packaging the connector
Found error in \connector-packager\packaging_logs.txt:
```
failed validating '' with XsdMinLengthFacet(value=1, fixed=False):
Reason: attribute name='': value length cannot be lesser than 1
```
- Change the company name in \samples\plugins\postgres_jdbc\manifest.xml to a string with length 28 and try packaging the connector
Found error in \connector-packager\packaging_logs.txt:
```
failed validating '1234567123456712345671234567' with XsdMaxLengthFacet(value=24, fixed=False):
Reason: attribute name='1234567123456712345671234567': value length cannot be greater than 24
```

To-Do: might need to add `NonEmptyCompanyName-ST` to the [root xsd](https://sourcegraph.prod.tableautools.com/teams/near/-/blob/modules/XSD/ConnectorPluginManifest-root.xsd) once I understand why `NonEmptyString-ST` is not there already. 

 