### PR TITLE
Verify JDBC-based connectors use <connection-properties>

### DIFF
--- a/connector-packager/connector_packager/connector_properties.py
+++ b/connector-packager/connector_packager/connector_properties.py
@@ -3,3 +3,4 @@ class ConnectorProperties:
     def __init__(self):
         self.uses_tcd = False
         self.connection_fields = []
+        self.is_jdbc = False

--- a/connector-packager/connector_packager/xsd_validator.py
+++ b/connector-packager/connector_packager/xsd_validator.py
@@ -261,8 +261,8 @@ def validate_file_specific_rules_tdr(file_to_test: ConnectorFile, path_to_file: 
     properties_builder = root.find('.//connection-properties')
 
     if not properties_builder and properties.is_jdbc:
-        xml_violations_buffer.append("Connectors using a 'jdbc' superclass must declare a <connection-properties> element in "
-                                     + str(path_to_file) + ".")
+        xml_violations_buffer.append("Connectors using a 'jdbc' superclass must declare a <connection-properties> element in " + 
+                                     str(path_to_file) + ".")
         return False
 
     return True

--- a/connector-packager/connector_packager/xsd_validator.py
+++ b/connector-packager/connector_packager/xsd_validator.py
@@ -163,10 +163,24 @@ def validate_file_specific_rules(file_to_test: ConnectorFile, path_to_file: Path
         Any rule violation messages will be appended to xml_violations_buffer
     """
 
-    if file_to_test.file_type == 'connection-fields':
+    if file_to_test.file_type == 'manifest':
+        return validate_file_specific_rules_manifest(file_to_test, path_to_file, properties)
+    elif file_to_test.file_type == 'connection-fields':
         return validate_file_specific_rules_connection_fields(file_to_test, path_to_file, xml_violations_buffer, properties)
     elif file_to_test.file_type == 'connection-resolver':
         return validate_file_specific_rules_tdr(file_to_test, path_to_file, xml_violations_buffer, properties)
+
+    return True
+
+
+def validate_file_specific_rules_manifest(file_to_test: ConnectorFile, path_to_file: Path, properties: ConnectorProperties) -> bool:
+    xml_tree = parse(str(path_to_file))
+    root = xml_tree.getroot()
+
+    if 'superclass' in root.attrib:
+        # other superclasses could be jdbc-based, but this will catch the common case
+        if 'jdbc' == root.attrib['superclass']:
+            properties.is_jdbc = True
 
     return True
 
@@ -243,6 +257,13 @@ def validate_file_specific_rules_tdr(file_to_test: ConnectorFile, path_to_file: 
                 if field not in attributes:
                     xml_violations_buffer.append("Attribute '" + field + "' in connection-fields but not in required-attributes list.")
                     return False
+
+    properties_builder = root.find('.//connection-properties')
+
+    if not properties_builder and properties.is_jdbc:
+        xml_violations_buffer.append("Connectors using a 'jdbc' superclass must declare a <connection-properties> element in "
+                                     + str(path_to_file) + ".")
+        return False
 
     return True
 

--- a/connector-packager/tests/test_connector_properties.py
+++ b/connector-packager/tests/test_connector_properties.py
@@ -64,3 +64,35 @@ class TestConnectorProperties(unittest.TestCase):
         properties = ConnectorProperties()
         self.assertTrue(validate_all_xml(files_list, test_folder, properties), "Valid connector not marked as valid")
         self.assertEqual(expected_connection_fields, properties.connection_fields, "Actual properties.connection_fields did not match expected")
+
+    def test_is_jdbc_property(self):
+        # Check that validate_all_xml properly sets is_jdbc to False if not using superclass=jdbc
+        test_folder = TEST_FOLDER / Path("valid_connector")  # This connector uses a .tcd file
+
+        files_list = [
+            ConnectorFile("manifest.xml", "manifest"),
+            ConnectorFile("connection-dialog.tcd", "connection-dialog"),
+            ConnectorFile("connectionBuilder.js", "script"),
+            ConnectorFile("dialect.tdd", "dialect"),
+            ConnectorFile("connectionResolver.tdr", "connection-resolver"),
+            ConnectorFile("resources-en_US.xml", "resource")]
+
+        properties_not_jdbc = ConnectorProperties()
+        self.assertTrue(validate_all_xml(files_list, test_folder, properties_not_jdbc), "Valid connector not marked as valid")
+        self.assertFalse(properties_not_jdbc.is_jdbc, "is_jdbc not set to False for connector with superclass other than jdbc")
+
+        # Check that validate_all_xml properly sets is_jdbc to True if using superclass=jdbc
+        test_folder = TEST_FOLDER / Path("modular_dialog_connector")  # This connector uses a connection-fields.xml file
+
+        files_list = [
+            ConnectorFile("manifest.xml", "manifest"),
+            ConnectorFile("connectionFields.xml", "connection-fields"),
+            ConnectorFile("connectionMetadata.xml", "connection-metadata"),
+            ConnectorFile("connectionBuilder.js", "script"),
+            ConnectorFile("dialect.xml", "dialect"),
+            ConnectorFile("connectionResolver.xml", "connection-resolver"),
+            ConnectorFile("connectionProperties.js", "script")]
+
+        properties_is_jdbc = ConnectorProperties()
+        self.assertTrue(validate_all_xml(files_list, test_folder, properties_is_jdbc), "Valid connector not marked as valid")
+        self.assertTrue(properties_is_jdbc.is_jdbc, "is_jdbc not set to True for connector with superclass jdbc")

--- a/connector-packager/tests/test_resources/properties_builder/jdbc/connectionResolver.xml
+++ b/connector-packager/tests/test_resources/properties_builder/jdbc/connectionResolver.xml
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='utf-8' ?>
+
+<tdr class='postgres_mcd'>
+  <connection-resolver>
+    <connection-normalizer>
+      <required-attributes>
+        <attribute-list>
+          <attr>server</attr>
+          <attr>port</attr>
+          <attr>authentication</attr>
+          <attr>username</attr>
+          <attr>password</attr>
+        </attribute-list>
+      </required-attributes>
+    </connection-normalizer>
+    <connection-builder>
+      <script file='connectionBuilder.js'/>
+    </connection-builder>
+    <connection-properties>
+      <script file='connectionProperties.js'/>
+    </connection-properties>
+  </connection-resolver>
+</tdr>

--- a/connector-packager/tests/test_resources/properties_builder/odbc/connectionResolver.xml
+++ b/connector-packager/tests/test_resources/properties_builder/odbc/connectionResolver.xml
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<tdr class='postgres_odbc'>
+    <connection-resolver>
+    <connection-builder>
+      <script file='connectionBuilder.js'/>
+    </connection-builder>
+    <connection-normalizer>
+      <required-attributes>
+        <attribute-list>
+          <attr>class</attr>
+          <attr>server</attr>
+          <attr>port</attr>
+          <attr>authentication</attr>
+          <attr>username</attr>
+          <attr>password</attr>
+        </attribute-list>
+      </required-attributes>
+    </connection-normalizer>
+    </connection-resolver>
+    <driver-resolver>
+    <driver-match >
+      <driver-name type='regex'>PostgreSQL Unicode*</driver-name>
+    </driver-match>
+  </driver-resolver>
+</tdr>

--- a/connector-packager/tests/test_xsd_validator.py
+++ b/connector-packager/tests/test_xsd_validator.py
@@ -268,3 +268,31 @@ class TestXSDValidator(unittest.TestCase):
         test_file = TEST_FOLDER / "company_name_length_validation/max/manifest.xml"
         self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
                          "Company name with length greater than 24 marked as valid")
+
+    def test_validate_jdbc_properties_builder(self):
+        properties = ConnectorProperties()
+        xml_violations_buffer = []
+        file_to_test = ConnectorFile("connectionResolver.xml", "connection-resolver")
+        test_file = TEST_FOLDER / "properties_builder/odbc/connectionResolver.xml"
+
+        print("Test that a connection resolver without <connection-properties> and non-jdbc superclass is valid")
+        properties.is_jdbc = False
+        self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer, properties),
+                         "optional connection-properties not found and marked invalid")
+
+        print("Test that a connection resolver without <connection-properties> and jdbc superclass is invalid")
+        properties.is_jdbc = True
+        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, properties),
+                         "required connection-properties not found and marked valid")
+
+        test_file = TEST_FOLDER / "properties_builder/jdbc/connectionResolver.xml"
+
+        print("Test that a connection resolver with <connection-properties> and non-jdbc superclass is valid")
+        properties.is_jdbc = False
+        self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer, properties),
+                         "optional connection-properties found and marked as invalid")
+
+        print("Test that a connection resolver with <connection-properties> and jdbc superclass is valid")
+        properties.is_jdbc = True
+        self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer, properties),
+                         "required connection-properties found and marked as invalid")

--- a/connector-packager/tests/test_xsd_validator.py
+++ b/connector-packager/tests/test_xsd_validator.py
@@ -278,7 +278,7 @@ class TestXSDValidator(unittest.TestCase):
         print("Test that a connection resolver without <connection-properties> and non-jdbc superclass is valid")
         properties.is_jdbc = False
         self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer, properties),
-                         "optional connection-properties not found and marked invalid")
+                        "optional connection-properties not found and marked invalid")
 
         print("Test that a connection resolver without <connection-properties> and jdbc superclass is invalid")
         properties.is_jdbc = True
@@ -290,9 +290,9 @@ class TestXSDValidator(unittest.TestCase):
         print("Test that a connection resolver with <connection-properties> and non-jdbc superclass is valid")
         properties.is_jdbc = False
         self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer, properties),
-                         "optional connection-properties found and marked as invalid")
+                        "optional connection-properties found and marked as invalid")
 
         print("Test that a connection resolver with <connection-properties> and jdbc superclass is valid")
         properties.is_jdbc = True
         self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer, properties),
-                         "required connection-properties found and marked as invalid")
+                        "required connection-properties found and marked as invalid")


### PR DESCRIPTION
Have the packager check for best practices from the samples and documentation.

Superclasses other than 'jdbc' can also be JDBC based, so make sure <connection-properties> validation is triggered on 'jdbc' or not 'jdbc'