### PR TITLE
Enforce 'dbname' is present in required attributes if using "database" in connection-metadata

### DIFF
--- a/connector-packager/connector_packager/connector_properties.py
+++ b/connector-packager/connector_packager/connector_properties.py
@@ -3,3 +3,4 @@ class ConnectorProperties:
     def __init__(self):
         self.uses_tcd = False
         self.connection_fields = []
+        self.database_field = False

--- a/connector-packager/connector_packager/connector_properties.py
+++ b/connector-packager/connector_packager/connector_properties.py
@@ -5,4 +5,4 @@ class ConnectorProperties:
         self.connection_fields = []
         self.backwards_compatibility_mode = False
         self.is_jdbc = False
-        self.database_field = False
+        self.connection_metadata_database = True

--- a/connector-packager/connector_packager/xsd_validator.py
+++ b/connector-packager/connector_packager/xsd_validator.py
@@ -248,9 +248,11 @@ def validate_file_specific_rules_connection_metadata(file_to_test: ConnectorFile
     xml_tree = parse(str(path_to_file))
     root = xml_tree.getroot()
 
+    # connection-metadata file and database element are both optional, on by default
     for database in root.iter('database'):
-        for field in database.iter('field'):
-            properties.database_field = True
+        if 'enabled' in database.attrib:
+            if 'true' != database.attrib['enabled']:
+                properties.connection_metadata_database = False
 
     return True
 
@@ -281,9 +283,9 @@ def validate_file_specific_rules_tdr(file_to_test: ConnectorFile, path_to_file: 
                     xml_violations_buffer.append("Attribute '" + field + "' in connection-fields but not in required-attributes list.")
                     return False
 
-        if len(attributes) > 0 and properties.database_field:
+        if len(attributes) > 0 and properties.connection_metadata_database and not properties.uses_tcd:
             if 'dbname' not in attributes:
-                xml_violations_buffer.append("Field 'database' enabled in connection-metadata but 'dbname' not in required-attributes list.")
+                xml_violations_buffer.append("connection-metadata 'database' enabled but 'dbname' not in required-attributes list.")
                 return False
 
     properties_builder = root.find('.//connection-properties')

--- a/connector-packager/tests/test_connector_properties.py
+++ b/connector-packager/tests/test_connector_properties.py
@@ -64,7 +64,38 @@ class TestConnectorProperties(unittest.TestCase):
         properties = ConnectorProperties()
         self.assertTrue(validate_all_xml(files_list, test_folder, properties), "Valid connector not marked as valid")
         self.assertEqual(expected_connection_fields, properties.connection_fields, "Actual properties.connection_fields did not match expected")
-        self.assertTrue(properties.database_field, "Database field not detected")
+
+    def test_connection_metadata_property(self):
+        test_folder = TEST_FOLDER / Path("modular_dialog_connector")  # This connector uses a connection-fields.xml file
+
+        files_list = [
+            ConnectorFile("manifest.xml", "manifest"),
+            ConnectorFile("connectionFields.xml", "connection-fields"),
+            ConnectorFile("connectionMetadata.xml", "connection-metadata"),
+            ConnectorFile("connectionBuilder.js", "script"),
+            ConnectorFile("dialect.xml", "dialect"),
+            ConnectorFile("connectionResolver.xml", "connection-resolver"),
+            ConnectorFile("connectionProperties.js", "script")]
+
+        properties = ConnectorProperties()
+        self.assertTrue(validate_all_xml(files_list, test_folder, properties), "Valid connector not marked as valid")
+        self.assertTrue(properties.connection_metadata_database, "Database metadata not detected")
+
+        test_folder = TEST_FOLDER / Path("database_field_not_in_normalizer")  # This connector uses a connection-fields.xml file
+
+        files_list = [
+            ConnectorFile("manifest.xml", "manifest"),
+            ConnectorFile("connectionFields.xml", "connection-fields"),
+            ConnectorFile("connectionMetadata.xml", "connection-metadata"),
+            ConnectorFile("connectionBuilder.js", "script"),
+            ConnectorFile("dialect.xml", "dialect"),
+            ConnectorFile("connectionResolver.xml", "connection-resolver"),
+            ConnectorFile("connectionProperties.js", "script")]
+
+        properties = ConnectorProperties()
+        self.assertTrue(validate_all_xml(files_list, test_folder, properties), "Valid connector not marked as valid")
+        self.assertFalse(properties.connection_metadata_database, "Database metadata detected incorrectly")
+
 
     def test_is_jdbc_property(self):
         # Check that validate_all_xml properly sets is_jdbc to False if not using superclass=jdbc

--- a/connector-packager/tests/test_connector_properties.py
+++ b/connector-packager/tests/test_connector_properties.py
@@ -64,3 +64,4 @@ class TestConnectorProperties(unittest.TestCase):
         properties = ConnectorProperties()
         self.assertTrue(validate_all_xml(files_list, test_folder, properties), "Valid connector not marked as valid")
         self.assertEqual(expected_connection_fields, properties.connection_fields, "Actual properties.connection_fields did not match expected")
+        self.assertTrue(properties.database_field, "Database field not detected")

--- a/connector-packager/tests/test_resources/database_field_not_in_normalizer/connectionBuilder.js
+++ b/connector-packager/tests/test_resources/database_field_not_in_normalizer/connectionBuilder.js
@@ -1,0 +1,5 @@
+(function dsbuilder(attr) {
+    var urlBuilder = "jdbc:postgresql://" + attr[connectionHelper.attributeServer] + ":" + attr[connectionHelper.attributePort] + "/" + attr[connectionHelper.attributeDatabase] + "?";
+
+    return [urlBuilder];
+})

--- a/connector-packager/tests/test_resources/database_field_not_in_normalizer/connectionFields.xml
+++ b/connector-packager/tests/test_resources/database_field_not_in_normalizer/connectionFields.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<connection-fields>
+  <field name="server" label="Server" value-type="string" category="endpoint" >
+    <validation-rule reg-exp="^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$"/>
+  </field>
+
+  <field name="port" label="Port" value-type="string" category="endpoint" default-value="5432" />
+
+  <field name="v-custom" label="Custom" value-type="string" category="endpoint" />
+
+  <field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="auth-user-pass" />
+
+  <field name="username" label="Username" value-type="string" category="authentication" />
+
+  <field name="password" label="Password" value-type="string" category="authentication" secure="true" />
+
+  <field name="v-custom2" label="Advanced Custom" value-type="string" category="advanced" optional="false" default-value="test" />
+
+  <field name="vendor1" label="Advanced Vendor1" value-type="string" category="advanced" optional="false" default-value="testVendor1" />
+
+  <field name="vendor2" label="Advanced Vendor2" value-type="string" category="advanced" optional="false" default-value="testVendor2" />
+
+  <field name="vendor3" label="Advanced Vendor3" value-type="string" category="advanced" optional="false" default-value="testVendor3" />
+
+</connection-fields>

--- a/connector-packager/tests/test_resources/database_field_not_in_normalizer/connectionMetadata.xml
+++ b/connector-packager/tests/test_resources/database_field_not_in_normalizer/connectionMetadata.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<connection-metadata>
+  <database enabled='false' />
+  <schema enabled='false' />
+</connection-metadata>

--- a/connector-packager/tests/test_resources/database_field_not_in_normalizer/connectionProperties.js
+++ b/connector-packager/tests/test_resources/database_field_not_in_normalizer/connectionProperties.js
@@ -1,0 +1,7 @@
+(function propertiesbuilder(attr) {
+    var props = {};
+    props["user"] = attr[connectionHelper.attributeUsername];
+    props["password"] = attr[connectionHelper.attributePassword];
+    
+    return props;
+})

--- a/connector-packager/tests/test_resources/database_field_not_in_normalizer/connectionResolver.xml
+++ b/connector-packager/tests/test_resources/database_field_not_in_normalizer/connectionResolver.xml
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='utf-8' ?>
+
+<tdr class='postgres_mcd'>
+  <connection-resolver>
+    <connection-builder>
+      <script file='connectionBuilder.js'/>
+    </connection-builder>
+    <connection-normalizer>
+      <required-attributes>
+        <attribute-list>
+          <attr>server</attr>
+          <attr>port</attr>
+          <attr>v-custom</attr>
+          <attr>v-custom2</attr>
+          <attr>username</attr>
+          <attr>password</attr>
+          <attr>authentication</attr>
+          <attr>vendor1</attr>
+          <attr>vendor2</attr>
+          <attr>vendor3</attr>
+        </attribute-list>
+      </required-attributes>
+    </connection-normalizer>
+    <connection-properties>
+      <script file='connectionProperties.js'/>
+    </connection-properties>
+  </connection-resolver>
+</tdr>

--- a/connector-packager/tests/test_resources/database_field_not_in_normalizer/dialect.xml
+++ b/connector-packager/tests/test_resources/database_field_not_in_normalizer/dialect.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<dialect name='PostgresMCD'
+         class='postgres_mcd'
+         base='PostgreSQL90Dialect'
+         version='18.1'>
+</dialect>

--- a/connector-packager/tests/test_resources/database_field_not_in_normalizer/manifest.xml
+++ b/connector-packager/tests/test_resources/database_field_not_in_normalizer/manifest.xml
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='utf-8' ?>
+
+<connector-plugin class='postgres_mcd' superclass='jdbc' plugin-version='0.0.1' name='PostgreSQL MCD' version='18.1'>
+  <vendor-information>
+    <company name="Connector SDK"/>
+    <support-link url = "https://example.com"/>
+  </vendor-information>
+  <connection-customization class="postgres_mcd" enabled="true" version="10.0">
+    <vendor name="vendor"/>
+    <driver name="driver"/>
+    <customizations>
+      <customization name="CAP_SELECT_INTO" value="yes"/>
+      <customization name="CAP_SELECT_TOP_INTO" value="yes"/>
+      <customization name="CAP_CREATE_TEMP_TABLES" value="no"/>
+      <customization name="CAP_QUERY_BOOLEXPR_TO_INTEXPR" value="no"/>
+      <customization name="CAP_QUERY_GROUP_BY_BOOL" value="yes"/>
+      <customization name="CAP_QUERY_GROUP_BY_DEGREE" value="yes"/>
+      <customization name="CAP_QUERY_SORT_BY" value="yes"/>
+      <customization name="CAP_QUERY_SUBQUERIES" value="yes"/>
+      <customization name="CAP_QUERY_TOP_N" value="yes"/>
+      <customization name="CAP_QUERY_TOP_SAMPLE" value="yes"/>
+      <customization name="CAP_QUERY_TOP_SAMPLE_PERCENT" value="yes"/>
+      <customization name="CAP_QUERY_WHERE_FALSE_METADATA" value="yes"/>
+      <customization name="CAP_QUERY_SUBQUERIES_WITH_TOP" value="yes"/>
+      <customization name="CAP_SUPPORTS_SPLIT_FROM_LEFT" value="yes"/>
+      <customization name="CAP_SUPPORTS_SPLIT_FROM_RIGHT" value="yes"/>
+      <customization name="CAP_SUPPORTS_UNION" value="yes"/>
+      <customization name="CAP_QUERY_ALLOW_PARTIAL_AGGREGATION" value="no"/>
+      <customization name="CAP_QUERY_TIME_REQUIRES_CAST" value="yes"/>
+    </customizations>
+  </connection-customization>
+  <connection-fields file='connectionFields.xml'/>
+  <connection-metadata file='connectionMetadata.xml'/>
+  <connection-resolver file="connectionResolver.xml"/>
+  <dialect file='dialect.xml'/>
+</connector-plugin>

--- a/connector-packager/tests/test_xsd_validator.py
+++ b/connector-packager/tests/test_xsd_validator.py
@@ -240,6 +240,7 @@ class TestXSDValidator(unittest.TestCase):
         properties = ConnectorProperties()
         properties.uses_tcd = False
         properties.connection_fields = ['server', 'port', 'v-custom', 'username', 'password', 'v-custom2', 'vendor1', 'vendor2', 'vendor3']
+        properties.database_field = True
         xml_violations_buffer = []
 
 
@@ -254,6 +255,12 @@ class TestXSDValidator(unittest.TestCase):
         test_file = TEST_FOLDER / "modular_dialog_connector/connectionResolver.xml"
         self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer, properties),
                         "Valid connector marked as invalid")
+
+        print("Test that normalizer not containing 'dbname' if connection-metadata database field is used is invalidated")
+        file_to_test = ConnectorFile("connectionResolver.xml", "connection-resolver")
+        test_file = TEST_FOLDER / "database_field_not_in_normalizer/connectionResolver.xml"
+        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, properties),
+                         "Missing 'dbname' attribute not detected")
 
     def test_validate_company_name_length(self):
         xml_violations_buffer = []

--- a/connector-packager/tests/test_xsd_validator.py
+++ b/connector-packager/tests/test_xsd_validator.py
@@ -254,7 +254,7 @@ class TestXSDValidator(unittest.TestCase):
         properties = ConnectorProperties()
         properties.uses_tcd = False
         properties.connection_fields = ['server', 'port', 'v-custom', 'username', 'password', 'v-custom2', 'vendor1', 'vendor2', 'vendor3']
-        properties.database_field = True
+        properties.connection_metadata_database = True
         xml_violations_buffer = []
 
 


### PR DESCRIPTION
When [database](https://tableau.github.io/connector-plugin-sdk/docs/mcd#the-connection-metadata-file) in connection-metadata.xml is enabled 'dbname' should be found in the `<required-attributes>` list.

The connection-metadata file and database element are both optional, enabled by default.