### PR TITLE
Introduce common connection dialog page

### DIFF
--- a/_includes/docs_menu.html
+++ b/_includes/docs_menu.html
@@ -8,9 +8,7 @@
     <li><a href="{{ site.baseurl }}/docs/design">Design Considerations</a></li>
     <li><a href="{{ site.baseurl }}/docs/drivers">Driver Requirements</a></li>
     <li><a href="{{ site.baseurl }}/docs/dialect">Create a Dialect Definition (TDD)</a></li>
-    <li><a href="{{ site.baseurl }}/docs/ui">Build the Connection Dialog with Connection Dialog v1</a></li>
-    <li><a href="{{ site.baseurl }}/docs/mcd">Build the Connection Dialog with Connection Dialog v2</a></li>
-    <li><a href="{{ site.baseurl }}/docs/oauth">OAuth Authentication Support</a></li>
+    <li><a href="{{ site.baseurl }}/docs/connection-dialog">Build the Connection Dialog</a></li>
     <li><a href="{{ site.baseurl }}/docs/tdvt">Test with the TDVT Suite</a></li>
     <li><a href="{{ site.baseurl }}/docs/tdvt-test-case">Fixing TDVT Test Failures</a></li>
     <li><a href="{{ site.baseurl }}/docs/manual-test">Run Manual QA Tests</a></li>
@@ -23,6 +21,9 @@
     <li><a href="{{ site.baseurl }}/docs/capabilities">Capabilities</a></li>
     <li><a href="{{ site.baseurl }}/docs/metadata-enumeration">Metadata Enumeration</a></li>
     <li><a href="{{ site.baseurl }}/docs/auth-modes">Authentication Modes</a></li>
+    <li><a href="{{ site.baseurl }}/docs/oauth">OAuth Authentication Support</a></li>
+    <li><a href="{{ site.baseurl }}/docs/ui">Connection Dialog v1</a></li>
+    <li><a href="{{ site.baseurl }}/docs/mcd">Connection Dialog v2</a></li>
     <li><a href="{{ site.baseurl }}/docs/log-entries">Signature Verification Log Entries</a></li>
     <li><a href="{{ site.baseurl }}/docs/gallery-submission">Gallery Submission Guide</a></li>
   </ul>

--- a/docs/auth-modes.md
+++ b/docs/auth-modes.md
@@ -19,6 +19,7 @@ A combination of Connection Dialog and Connection Resolver changes implement eac
 | Username and Password | `auth-user-pass` | User is prompted for username and password during initial connection creation, and password only when reconnecting to the data source |
 | Password only | `auth-pass` | User is prompted for password during initial connection creation and reconnecting to the data source |
 | OAuth | `oauth` | User is prompted with the default brower for [OAuth]({{ site.baseurl }}/docs/oauth) credentials during initial connection creation and reconnecting to the data source |
+| Integrated | `auth-integrated` | User is not prompted for credentials and relies on driver supported SSO like Kerberos: [details](https://github.com/tableau/connector-plugin-sdk/tree/master/samples/scenarios/jdbc_kerberos) |
 
 The ```authentication``` attribute in a Tableau workbook (twb) or Tableau data source (tds) file contains the ```value``` defined above.
 
@@ -30,7 +31,35 @@ The specific usage patterns of these values can be found on the individual Conne
 
 ### Multiple Authentication Modes
 
-User is prompted for which authentication option to use, then a set of fields appear, conditional on that option.  Depending on the option selected the user may or may not be prompted for credentials when reconnecting to the data source.
+User is prompted for which authentication option to use and conditionally shown additional fields.  Depending on the option selected, the user may or may not be prompted for credentials when reconnecting to the data source.
+
+These are the relevant segments from the [sample](https://github.com/tableau/connector-plugin-sdk/tree/master/samples/scenarios/multi_auth) that implements multiple authentication modes. 
+
+```xml
+<!-- Connection Dialog v2 -->
+<connection-fields>
+  ...
+  <field name="authentication" label="Authentication" category="authentication" value-type="selection" default-value="auth-user-pass" >
+    <selection-group>
+      <option value="auth-none" label="No Authentication"/>
+      <option value="auth-user" label="Username"/>
+      <option value="auth-user-pass" label="Username and Password"/>
+    </selection-group>
+  </field>
+  <field name="username" label="Username" category="authentication" value-type="string">
+    <conditions>
+      <condition field="authentication" value="auth-user"/>
+      <condition field="authentication" value="auth-user-pass"/>
+    </conditions>
+  </field>
+   <field name="password" label="Password" category="authentication" value-type="string" secure="true">
+    <conditions>
+      <condition field="authentication" value="auth-user-pass"/>
+    </conditions>
+  </field>
+  ...
+</connection-fields>
+```
 
 ```xml
 <!-- Connection Resolver -->
@@ -116,7 +145,7 @@ When using 'hadoophive' or 'spark' as a base class there are additional constrai
 In the Connection Dialog, any authentication ```option``` elements used must match the definition below.
 
 ```xml
-<!-- Connection Dialog -->
+<!-- Connection Dialog V1 -->
 
 <!-- <authentication-options> -->
 <option name="None" value="0" />

--- a/docs/auth-modes.md
+++ b/docs/auth-modes.md
@@ -12,195 +12,25 @@ A combination of Connection Dialog and Connection Resolver changes implement eac
 
 ## Supported Authentication Modes
 
-### No Authentication
-User is never prompted for credentials.
+| Name | value | Description |
+| - | - | - |
+| No Authentication | `auth-none` | User is never prompted for credentials |
+| Username only | `auth-user` | User is prompted for username during initial connection creation. |
+| Username and Password | `auth-user-pass` | User is prompted for username and password during initial connection creation, and password only when reconnecting to the data source |
+| Password only | `auth-pass` | User is prompted for password during initial connection creation and reconnecting to the data source |
+| OAuth | `oauth` | User is prompted with the default brower for [OAuth]({{ site.baseurl }}/docs/oauth) credentials during initial connection creation and reconnecting to the data source |
 
-```xml
-<!-- Connection Dialog -->
-<connection-dialog class='sample'>
-    <connection-config>
-        <authentication-mode value='None' />
-        <authentication-options>
-            <option name="None" default="true" value="auth-none" />
-        </authentication-options>
-        ...
-    </connection-config>
-</connection-dialog>
-```
+The ```authentication``` attribute in a Tableau workbook (twb) or Tableau data source (tds) file contains the ```value``` defined above.
 
-```xml
-<!-- Connection Resolver -->
-<tdr class='sample'>
-    <connection-resolver>
-        ...
-        <connection-normalizer>
-            <required-attributes>
-                <attribute-list>
-                    ...
-                    <attr>authentication</attr>
-                    ...
-                </attribute-list>
-            </required-attributes>
-        </connection-normalizer>
-    </connection-resolver>
-    ...
-</tdr>
-```
+The specific usage patterns of these values can be found on the individual Connection Dialog pages:
 
-Sample connection dialog [noAuthOption.tcd](https://github.com/tableau/connector-plugin-sdk/blob/master/samples/components/dialogs/noAuthOption.tcd)
+- [Connection Dialog v1]({{ site.baseurl }}/docs/ui#supported-authentication-modes) 
+- [Connection Dialog v2]({{ site.baseurl }}/docs/mcd#authentication)
 
-### Username only
-
-User is prompted for username during initial connection creation.  Before Tableau 2020.3 the ```option``` element required ```value='no'``` instead of example below.
-
-```xml
-<!-- Connection Dialog -->
-<connection-dialog class='sample'>
-    <connection-config>
-        <authentication-mode value='BasicUserNameOnly' />
-        <authentication-options>
-            <option name="Username" default="true" value="auth-user"/>
-        </authentication-options>
-        ...
-    </connection-config>
-</connection-dialog>
-```
-
-```xml
-<!-- Connection Resolver -->
-<tdr class='sample'>
-    <connection-resolver>
-        ...
-        <connection-normalizer>
-            <required-attributes>
-                <attribute-list>
-                    ...
-                    <attr>authentication</attr>
-                    <attr>username</attr>
-                    ...
-                </attribute-list>
-            </required-attributes>
-        </connection-normalizer>
-    </connection-resolver>
-    ...
-</tdr>
-```
-
-### Password only
-
-##### Tableau 2019.4 and later
-
-User is prompted for password during initial connection creation and reconnecting to the data source.
-
-```xml
-<!-- Connection Dialog -->
-<connection-dialog class='sample'>
-    <connection-config>
-        <authentication-mode value='PasswordOnly' />
-        <authentication-options>
-            <option name="Password" default="true" value="auth-pass"/>
-        </authentication-options>
-        ...
-    </connection-config>
-</connection-dialog>
-```
-
-```xml
-<!-- Connection Resolver -->
-<tdr class='sample'>
-    <connection-resolver>
-        ...
-        <connection-normalizer>
-            <required-attributes>
-                <attribute-list>
-                    ...
-                    <attr>authentication</attr>
-                    <attr>password</attr>
-                    ...
-                </attribute-list>
-            </required-attributes>
-        </connection-normalizer>
-    </connection-resolver>
-    ...
-</tdr>
-```
-
-
-### Username and Password
-
-User is prompted for username and password during initial connection creation, and password only when reconnecting to the data source.  If the username can be blank replace ```value='Basic'``` with ```value='BasicNoValidateFields'``` below.
-
-```xml
-<!-- Connection Dialog -->
-<connection-dialog class='sample'>
-    <connection-config>
-        <authentication-mode value='Basic' />
-        <authentication-options>
-            <option name="UsernameAndPassword" default="true" value="auth-user-pass"/>
-        </authentication-options>
-        ...
-    </connection-config>
-</connection-dialog>
-```
-
-```xml
-<!-- Connection Resolver -->
-<tdr class='sample'>
-    <connection-resolver>
-        ...
-        <connection-normalizer>
-            <required-attributes>
-                <attribute-list>
-                    ...
-                    <attr>authentication</attr>
-                    <attr>username</attr>
-                    <attr>password</attr>
-                    ...
-                </attribute-list>
-            </required-attributes>
-        </connection-normalizer>
-    </connection-resolver>
-    ...
-</tdr>
-```
 
 ### Multiple Authentication Modes
 
 User is prompted for which authentication option to use, then a set of fields appear, conditional on that option.  Depending on the option selected the user may or may not be prompted for credentials when reconnecting to the data source.
-
-Supported authentication options are below.  Starting in Tableau 2019.4, ```Password``` option is supported.
-
-```
-None
-Username
-Password
-UsernameAndPassword
-LDAP
-```
-
-```xml
-<!-- Connection Dialog -->
-<connection-dialog class='sample'>
-    <connection-config>
-        <authentication-mode value='ComboBoxIntegrated' />
-        <authentication-options>
-            <option name="None" value="auth-none" />
-            <option name="Username" value="auth-user" />
-            <option name="UsernameAndPassword" value="auth-user-pass" default="true" />
-        </authentication-options>
-        ...
-    </connection-config>
-</connection-dialog>
-```
-
-Note: the ```value``` attribute value for all options is customizable by connector author, except None, which is required to be ```auth-none```.  These option values are the persisted value of the authentication attribute in a Tableau workbook (twb) or Tableau data source (tds) file.  Starting in Tableau 2020.3, the recommendation is to standardize ```value``` to the following when possible:
-
-Option | ```value```
--|-
-None | auth-none
-Username | auth-user
-UsernameAndPassword | auth-user-pass
-Password | auth-pass
 
 ```xml
 <!-- Connection Resolver -->
@@ -224,8 +54,7 @@ Password | auth-pass
 ```
 
 ```javascript
-// Connection Builder
-(function dsbuilder(attr)
+// Connection Builder (ODBC) or Properties Builder (JDBC)
 {
     ...
     var authAttrValue = attr[connectionHelper.attributeAuthentication];

--- a/docs/connection-dialog.md
+++ b/docs/connection-dialog.md
@@ -6,9 +6,9 @@ The connection dialog prompts the user to enter connection and authentication in
 
 The connection dialog can be defined in two different ways:
 - [Connection Dialog v1]({{ site.baseurl }}/docs/ui) 
-- [Connection Dialog v2]({{ site.baseurl }}/docs/mcd) in Tableau 2020.3 or later 
+- [Connection Dialog v2]({{ site.baseurl }}/docs/mcd) in Tableau 2020.3 or later
 
-Connection Dialog v2 is the recommended pattern for new connectors.
+**Connection Dialog v2 is the recommended pattern for new connectors.**
 
 ## Set connector name and vendor information
 
@@ -22,6 +22,7 @@ These elements are defined in the manifest.xml file:
   <vendor-information>
       <company name="Company Name"/>
       <support-link url = "http://example.com"/>
+      <driver-download-link url="https://drivers.example.com"/>
   </vendor-information>
   ...
 </connector-plugin>
@@ -29,13 +30,13 @@ These elements are defined in the manifest.xml file:
 
 ## Define how the connector authenticates 
 
-The ```authentication``` attribute controls how a user is prompted to enter data source credentials. For information on authentication modes, see [Authentication modes]({{ site.baseurl }}/docs/auth-modes).
+The ```authentication``` attribute is a required field and controls how a user is prompted to enter data source credentials. For more information on authentication modes, see [Authentication modes]({{ site.baseurl }}/docs/auth-modes).
 
 ## Define custom vendor attributes
 
-Vendors can add customized attributes (fields) to their connector plugin by using the a ```field``` element in V2 or the pre-defined ```vendor*``` elements in V1.
+Vendors can add customized attributes (fields) to their connector plugin by using the a ```field``` element in V2 or the pre-defined ```vendor*``` elements in V1.  Ensure the vendor defined fields do not duplicate functionality defined in the [Connection Field Platform Integration]({{ site.baseurl }}/docs/mcd#connection-field-platform-integration) section.
 
-These fields have a custom label and can be used for attributes in the connection strings.
+These fields have a custom label and can be used for attributes in the connection strings.  
 
 To add a custom vendor attribute for an ODBC-based connector, you must modify these files:
 - connectionFields.xml or connection-dialog.tcd

--- a/docs/connection-dialog.md
+++ b/docs/connection-dialog.md
@@ -21,7 +21,7 @@ These elements are defined in the manifest.xml file:
 <connector-plugin class='postgres_odbc' superclass='odbc' plugin-version='0.0.0' name='PostgreSQL ODBC' version='20.1'>
   <vendor-information>
       <company name="Company Name"/>
-      <support-link url = "http://example.com"/>
+      <support-link url = "https://example.com"/>
       <driver-download-link url="https://drivers.example.com"/>
   </vendor-information>
   ...

--- a/docs/connection-dialog.md
+++ b/docs/connection-dialog.md
@@ -1,0 +1,101 @@
+---
+title: Build the Connection Dialog
+---
+
+The connection dialog prompts the user to enter connection and authentication information. That information is passed into the Connector Builder script to build the connection string. The dialog appears when creating a new connection or editing an existing connection and is used by both Tableau Desktop and Tableau Server.
+
+The connection dialog can be defined in two different ways:
+- [Connection Dialog v1]({{ site.baseurl }}/docs/ui) 
+- [Connection Dialog v2]({{ site.baseurl }}/docs/mcd) in Tableau 2020.3 or later 
+
+Connection Dialog v2 is the recommended pattern for new connectors.
+
+## Set connector name and vendor information
+
+The connector is displayed as "[Display Name] by [Company Name]" in the connection dialog and connection list.
+
+"For support, contact [Company Name]" is displayed at the bottom left of the connector. Clicking this link sends the user to the support link defined in the manifest. This link also displays in error messages. The support link must use HTTPS to be packaged into a TACO file.
+
+These elements are defined in the manifest.xml file:
+```xml
+<connector-plugin class='postgres_odbc' superclass='odbc' plugin-version='0.0.0' name='PostgreSQL ODBC' version='20.1'>
+  <vendor-information>
+      <company name="Company Name"/>
+      <support-link url = "http://example.com"/>
+  </vendor-information>
+  ...
+</connector-plugin>
+```
+
+## Define how the connector authenticates 
+
+The ```authentication``` attribute controls how a user is prompted to enter data source credentials. For information on authentication modes, see [Authentication modes]({{ site.baseurl }}/docs/auth-modes).
+
+## Define custom vendor attributes
+
+Vendors can add customized attributes (fields) to their connector plugin by using the a ```field``` element in V2 or the pre-defined ```vendor*``` elements in V1.
+
+These fields have a custom label and can be used for attributes in the connection strings.
+
+To add a custom vendor attribute for an ODBC-based connector, you must modify these files:
+- connectionFields.xml or connection-dialog.tcd
+- connectionResolver.tdr
+- connectionBuilder.js
+
+To add a custom vendor attribute for an JDBC-based connector, you must modify these files:
+- connectionFields.xml or connection-dialog.tcd
+- connectionResolver.tdr
+- connectionBuilder.js
+- connectionProperties.js
+
+**Vendor defined attributes will be logged and persisted to Tableau workbook xml in plain text.** This means the input for these fields cannot contain any Personally Identifiable Information (PII), as they are not secure and could leak sensitive customer information.
+
+See examples below.
+
+__connectionResolver.tdr__
+
+```xml
+    ...
+    <required-attributes>
+      <attribute-list>
+        ...
+        <attr>v-char-set</attr>
+
+      </attribute-list>
+    </required-attributes>
+    ...
+```
+
+__connectionFields.xml__
+
+```xml
+<connection-fields>
+  ...
+  <field name="v-char-set" label="Char Set" value-type="string" category="general" default-value="" />
+  ...
+</connection-fields>
+```
+
+__connectionBuilder.js (ODBC)__
+```js
+(function dsbuilder(attr)
+  {
+    var params = {};
+
+    ...
+    params["charSet"] = attr['v-char-set'];
+    ...
+
+```
+
+__connectionProperties.js (JDBC only)__
+```js
+      ...
+      params["charSet"] = attr['v-char-set'];
+      ...
+
+```
+
+## Localize your connector
+
+For information on localizing your connection dialogs, see [Localize Your Connector]({{ site.baseurl }}/docs/localize).

--- a/docs/mcd.md
+++ b/docs/mcd.md
@@ -1,5 +1,5 @@
 ---
-title: Build the Connection Dialog with Connection Dialog v2
+title: Connection Dialog v2
 ---
 **IMPORTANT:** This feature is available only in Tableau 2020.3 or later. For compatibility with older versions, use Connection Dialog v1 (documentation found [here]({{ site.baseurl }}/docs/ui)).
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -1,6 +1,8 @@
 ---
-title: Build the Connection Dialog with Connection Dialog v1
+title: Connection Dialog v1
 ---
+
+Connection Dialog v2 is the recommended pattern for new connectors. For more details see the [Connection Dialog v2]({{ site.baseurl }}/docs/mcd) page.
 
 ## Define Tableau Custom Dialog file elements
 
@@ -23,7 +25,7 @@ Here's an example of a TCD file:
 </connection-dialog>
 ```
 
-The ```authentication-mode``` and ```authentication-options``` tags control how a user is prompted to enter data source credentials. For information on authentication modes, see [Authentication modes]({{ site.baseurl }}/docs/auth-modes).
+The ```authentication-mode``` and ```authentication-options``` tags control how a user is prompted to enter data source credentials. For more information on authentication modes, see [Authentication modes]({{ site.baseurl }}/docs/auth-modes).
 
 The other tags control what prompts show up in the connection dialog. For example, this shows the Port prompt with the label of Port and a default value of 5432:
 
@@ -82,13 +84,7 @@ __connectionBuilder.js (ODBC only)__
 ```js
 (function dsbuilder(attr)
   {
-    var params = {};
-
-    params["SERVER"] = attr[connectionHelper.attributeServer];
-    params["PORT"] = attr[connectionHelper.attributePort];
-    params["DATABASE"] = attr[connectionHelper.attributeDatabase];
-    params["UID"] = attr[connectionHelper.attributeUsername];
-    params["PWD"] = attr[connectionHelper.attributePassword];
+    ...
     params["loglevel"] = attr[connectionHelper.attributeVendor1];
     params["protocolVersion"] = attr[connectionHelper.attributeVendor2];
     params["charSet"] = attr[connectionHelper.attributeVendor3];
@@ -99,13 +95,9 @@ __connectionBuilder.js (ODBC only)__
 __connectionProperties.js (JDBC only)__
 ```js
       ...
-      props["password"] = attr[connectionHelper.attributePassword];
       props["logLevel"] = attr[connectionHelper.attributeVendor1];
       props["protocolVersion"] = attr[connectionHelper.attributeVendor2];
       props["charSet"] = attr[connectionHelper.attributeVendor3];
-
-      if (attr[connectionHelper.attributeSSLMode] == "require")
-      {
       ...
 
 ```
@@ -343,7 +335,3 @@ Password | auth-pass
     ...
 })
 ```
-
-## Localize your connector
-
-For information on localizing your connection dialogs, see [Localize Your Connector]({{ site.baseurl }}/docs/localize).

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -2,30 +2,32 @@
 title: Build the Connection Dialog with Connection Dialog v1
 ---
 
-The connection dialog prompts the user to enter connection and authentication information. That information is passed into the Connector Builder script to build the connection string. The dialog appears when creating a new connection or editing an existing connection and is used by both Tableau Desktop and Tableau Server.
+## Define Tableau Custom Dialog file elements
 
-The connection dialog is mainly defined in the Tableau Custom Dialog (.tcd) file.
+The TCD file defines which UI elements display in the dialog.  The Connection Dialog V1 is a fixed list as defined by the file [XSD](https://github.com/tableau/connector-plugin-sdk/blob/master/validation/tcd_latest.xsd).
 
-Here's an example of a connection dialog:
+Here's an example of a TCD file:
 
-![]({{ site.baseurl }}/assets/connection-dialog.png)
-
-## Set connector name and vendor information
-
-The connector is displayed as "[Display Name] by [Company Name]" in the connection dialog and connection list.
-
-"For support, contact [Company Name]" is displayed at the bottom left of the connector. Clicking this link sends the user to the support link defined in the manifest. This link also displays in error messages. The support link must use HTTPS to be packaged into a TACO file.
-
-These elements are defined in the manifest.xml file:
 ```xml
-<connector-plugin class='postgres_odbc' superclass='odbc' plugin-version='0.0.0' name='PostgreSQL ODBC' version='20.1'>
-  <vendor-information>
-      <company name="Company Name"/>
-      <support-link url = "http://example.com"/>
-  </vendor-information>
-  ...
-</connector-plugin>
+<connection-dialog class='postgres_odbc'>
+  <connection-config>
+    <authentication-mode value='Basic' />
+    <authentication-options>
+      <option name="UsernameAndPassword" default="true" value="auth-user-pass" />
+    </authentication-options>
+    <db-name-prompt value="Database: " />
+    <has-pre-connect-database value="true" />
+    <port-prompt value="Port: " default="5432" />
+    <show-ssl-checkbox value="true" />
+  </connection-config>
+</connection-dialog>
 ```
+
+The ```authentication-mode``` and ```authentication-options``` tags control how a user is prompted to enter data source credentials. For information on authentication modes, see [Authentication modes]({{ site.baseurl }}/docs/auth-modes).
+
+The other tags control what prompts show up in the connection dialog. For example, this shows the Port prompt with the label of Port and a default value of 5432:
+
+`<port-prompt value="Port: " default="5432" />`
 
 ## Define custom vendor attributes
 Vendors can add customized attributes (fields) to their connector plugin by using the vendor attributes.
@@ -50,30 +52,30 @@ __connection-resolver.tdr__
 
 ```xml
     ...
-      <required-attributes>
+    <required-attributes>
       <attribute-list>
         ...
-        <attr> vendor1 </attr>
-        <attr> vendor2 </attr>
-        <attr> vendor3 </attr>
+        <attr>vendor1</attr>
+        <attr>vendor2</attr>
+        <attr>vendor3</attr>
 
       </attribute-list>
-      </required-attributes>
+    </required-attributes>
     ...
 ```
 
 __connection-dialog.tcd__
 
 ```xml
- <connector-plugin class='postgres_jdbc' superclass='jdbc' plugin-version='0.0.0' name='PostgreSQL JDBC' version='18.1'>
-          <connection-config>
-            ...
-            <vendor1-prompt value="Log Level: "/>
-            <vendor2-prompt value="Protocol Version: "/>
-            <vendor3-prompt value="Char Set: "/>
+<connection-dialog class='postgres_jdbc'>
+  <connection-config>
+    ...
+    <vendor1-prompt value="Log Level: "/>
+    <vendor2-prompt value="Protocol Version: "/>
+    <vendor3-prompt value="Char Set: "/>
 
-        </connection-config>
-      </connection-dialog>
+  </connection-config>
+</connection-dialog>
 ```
 
 __connectionBuilder.js (ODBC only)__
@@ -110,32 +112,237 @@ __connectionProperties.js (JDBC only)__
 
 See complete files [here](https://github.com/tableau/connector-plugin-sdk/tree/dev/samples/components/dialogs/new_text_field).
 
-## Define Tableau Custom Dialog file elements
+## Supported Authentication Modes
 
-The TCD file defines which UI elements display in the dialog.
-
-Here's an example of a TCD file:
+### No Authentication
+User is never prompted for credentials.
 
 ```xml
-<connection-dialog class='postgres_odbc'>
-  <connection-config>
-    <authentication-mode value='Basic' />
-    <authentication-options>
-      <option name="UsernameAndPassword" default="true" />
-    </authentication-options>
-    <db-name-prompt value="Database: " />
-    <has-pre-connect-database value="true" />
-    <port-prompt value="Port: " default="5432" />
-    <show-ssl-checkbox value="true" />
-  </connection-config>
+<!-- Connection Dialog -->
+<connection-dialog class='sample'>
+    <connection-config>
+        <authentication-mode value='None' />
+        <authentication-options>
+            <option name="None" default="true" value="auth-none" />
+        </authentication-options>
+        ...
+    </connection-config>
 </connection-dialog>
 ```
 
-The <span style="font-family: courier new">authentication-mode</span> and <span style="font-family: courier new">authentication-options</span> tags control how a user is prompted to enter data source credentials. For information on authentication modes, see [Authentication modes]({{ site.baseurl }}/docs/auth-modes).
+```xml
+<!-- Connection Resolver -->
+<tdr class='sample'>
+    <connection-resolver>
+        ...
+        <connection-normalizer>
+            <required-attributes>
+                <attribute-list>
+                    ...
+                    <attr>authentication</attr>
+                    ...
+                </attribute-list>
+            </required-attributes>
+        </connection-normalizer>
+    </connection-resolver>
+    ...
+</tdr>
+```
 
-The other tags control what prompts show up in the connection dialog. For example, this shows the Port prompt with the label of Port and a default value of 5432:
+Sample connection dialog [noAuthOption.tcd](https://github.com/tableau/connector-plugin-sdk/blob/master/samples/components/dialogs/noAuthOption.tcd)
 
-`<port-prompt value="Port: " default="5432" />`
+### Username only
+
+User is prompted for username during initial connection creation.  Before Tableau 2020.3 the ```option``` element required ```value='no'``` instead of example below.
+
+```xml
+<!-- Connection Dialog -->
+<connection-dialog class='sample'>
+    <connection-config>
+        <authentication-mode value='BasicUserNameOnly' />
+        <authentication-options>
+            <option name="Username" default="true" value="auth-user"/>
+        </authentication-options>
+        ...
+    </connection-config>
+</connection-dialog>
+```
+
+```xml
+<!-- Connection Resolver -->
+<tdr class='sample'>
+    <connection-resolver>
+        ...
+        <connection-normalizer>
+            <required-attributes>
+                <attribute-list>
+                    ...
+                    <attr>authentication</attr>
+                    <attr>username</attr>
+                    ...
+                </attribute-list>
+            </required-attributes>
+        </connection-normalizer>
+    </connection-resolver>
+    ...
+</tdr>
+```
+
+### Password only
+
+##### Tableau 2019.4 and later
+
+User is prompted for password during initial connection creation and reconnecting to the data source.
+
+```xml
+<!-- Connection Dialog -->
+<connection-dialog class='sample'>
+    <connection-config>
+        <authentication-mode value='PasswordOnly' />
+        <authentication-options>
+            <option name="Password" default="true" value="auth-pass"/>
+        </authentication-options>
+        ...
+    </connection-config>
+</connection-dialog>
+```
+
+```xml
+<!-- Connection Resolver -->
+<tdr class='sample'>
+    <connection-resolver>
+        ...
+        <connection-normalizer>
+            <required-attributes>
+                <attribute-list>
+                    ...
+                    <attr>authentication</attr>
+                    <attr>password</attr>
+                    ...
+                </attribute-list>
+            </required-attributes>
+        </connection-normalizer>
+    </connection-resolver>
+    ...
+</tdr>
+```
+
+
+### Username and Password
+
+User is prompted for username and password during initial connection creation, and password only when reconnecting to the data source.  If the username can be blank replace ```value='Basic'``` with ```value='BasicNoValidateFields'``` below.
+
+```xml
+<!-- Connection Dialog -->
+<connection-dialog class='sample'>
+    <connection-config>
+        <authentication-mode value='Basic' />
+        <authentication-options>
+            <option name="UsernameAndPassword" default="true" value="auth-user-pass"/>
+        </authentication-options>
+        ...
+    </connection-config>
+</connection-dialog>
+```
+
+```xml
+<!-- Connection Resolver -->
+<tdr class='sample'>
+    <connection-resolver>
+        ...
+        <connection-normalizer>
+            <required-attributes>
+                <attribute-list>
+                    ...
+                    <attr>authentication</attr>
+                    <attr>username</attr>
+                    <attr>password</attr>
+                    ...
+                </attribute-list>
+            </required-attributes>
+        </connection-normalizer>
+    </connection-resolver>
+    ...
+</tdr>
+```
+
+### Multiple Authentication Modes
+
+User is prompted for which authentication option to use, then a set of fields appear, conditional on that option.  Depending on the option selected the user may or may not be prompted for credentials when reconnecting to the data source.
+
+Supported authentication options are below.  Starting in Tableau 2019.4, ```Password``` option is supported.
+
+```
+None
+Username
+Password
+UsernameAndPassword
+```
+
+```xml
+<!-- Connection Dialog -->
+<connection-dialog class='sample'>
+    <connection-config>
+        <authentication-mode value='ComboBoxIntegrated' />
+        <authentication-options>
+            <option name="None" value="auth-none" />
+            <option name="Username" value="auth-user" />
+            <option name="UsernameAndPassword" value="auth-user-pass" default="true" />
+        </authentication-options>
+        ...
+    </connection-config>
+</connection-dialog>
+```
+
+Note: the ```value``` attribute value for all options is customizable by connector author, except None, which is required to be ```auth-none```.  These option values are the persisted value of the authentication attribute in a Tableau workbook (twb) or Tableau data source (tds) file.  Starting in Tableau 2020.3, the recommendation is to standardize ```value``` to the following when possible:
+
+Option | ```value```
+-|-
+None | auth-none
+Username | auth-user
+UsernameAndPassword | auth-user-pass
+Password | auth-pass
+
+```xml
+<!-- Connection Resolver -->
+<tdr class='sample'>
+    <connection-resolver>
+        ...
+        <connection-normalizer>
+            <required-attributes>
+                <attribute-list>
+                    ...
+                    <attr>authentication</attr>
+                    <attr>username</attr>
+                    <attr>password</attr>
+                    ...
+                </attribute-list>
+            </required-attributes>
+        </connection-normalizer>
+    </connection-resolver>
+    ...
+</tdr>
+```
+
+```javascript
+// Connection Builder
+(function dsbuilder(attr)
+{
+    ...
+    var authAttrValue = attr[connectionHelper.attributeAuthentication];
+    if (authAttrValue == "auth-none")
+        // no-op
+    else if (authAttrValue == "auth-user")
+        params["UID"] = attr[connectionHelper.attributeUsername];
+    else if (authAttrValue == "auth-user-pass")
+    {
+        params["UID"] = attr[connectionHelper.attributeUsername];
+        params["PWD"] = attr[connectionHelper.attributePassword];
+    }
+
+    ...
+})
+```
 
 ## Localize your connector
 


### PR DESCRIPTION
- V1 and V2 details on their own pages
- Update auth-modes to be common guidance for both V1 and V2
- Move V1 specific content from auth-modes to ui.md
- Update left side navigation bar