### PR TITLE
Packager displays vendor-defined fields and warns that they will be logged

### DIFF
--- a/connector-packager/connector_packager/connector_properties.py
+++ b/connector-packager/connector_packager/connector_properties.py
@@ -3,6 +3,7 @@ class ConnectorProperties:
     def __init__(self):
         self.uses_tcd = False
         self.connection_fields = []
+        self.vendor_defined_fields = []
         self.backwards_compatibility_mode = False
         self.is_jdbc = False
         self.connection_metadata_database = True

--- a/connector-packager/connector_packager/package.py
+++ b/connector-packager/connector_packager/package.py
@@ -95,10 +95,17 @@ def main():
     properties = ConnectorProperties()
     properties.backwards_compatibility_mode = args.backwards_compatible
     if files_to_package and validate_all_xml(files_to_package, path_from_args, properties):
-        logger.info("Validation succeeded.")
+        logger.info("Validation succeeded.\n")
     else:
         logger.info("Validation failed. Check " + str(log_file) + " for more information.")
         return
+
+    # Display warning that vendor-defined attributes will be logged
+    if len(properties.vendor_defined_fields) > 0:
+        logger.info("Detected vendor-defined fields:")
+        logger.info(properties.vendor_defined_fields)
+        logger.info("Vendor-defined fields will be logged and persisted to Tableau workbook xml in plain text. You must" +
+                    " confirm that the user inputs for fields listed above do not contain PII before distributing this connector to customers.\n")
 
     # Double check that all files exist
     for f in files_to_package:
@@ -119,7 +126,7 @@ def main():
         logger.info("Taco packaging failed. Check " + str(log_file) + " for more information.")
         return
 
-    logger.info("Taco packaged. To sign taco file, use jarsigner.")
+    logger.info("\nTaco packaged. To sign taco file, use jarsigner.")
 
 
 if __name__ == '__main__':

--- a/connector-packager/tests/test_connector_properties.py
+++ b/connector-packager/tests/test_connector_properties.py
@@ -129,3 +129,58 @@ class TestConnectorProperties(unittest.TestCase):
         self.assertTrue(validate_all_xml(files_list, test_folder, properties_is_jdbc), "Valid connector not marked as valid")
         self.assertTrue(properties_is_jdbc.is_jdbc, "is_jdbc not set to True for connector with superclass jdbc")
 
+    def test_vendor_defined_fields_tcd(self):
+        # This connector uses a .tcd file and does not have vendor-defined fields
+        test_folder = TEST_FOLDER / Path("valid_connector")  # This connector uses a .tcd file
+
+        files_list = [
+            ConnectorFile("manifest.xml", "manifest"),
+            ConnectorFile("connection-dialog.tcd", "connection-dialog"),
+            ConnectorFile("connectionBuilder.js", "script"),
+            ConnectorFile("dialect.tdd", "dialect"),
+            ConnectorFile("connectionResolver.tdr", "connection-resolver"),
+            ConnectorFile("resources-en_US.xml", "resource")]
+
+        properties_no_vendor_defined_fields = ConnectorProperties()
+        self.assertTrue(validate_all_xml(files_list, test_folder, properties_no_vendor_defined_fields), "Valid connector not marked as valid")
+        self.assertFalse(properties_no_vendor_defined_fields.vendor_defined_fields, "Found vendor-defined fields when none were defined")
+
+        # This connector uses a .tcd file and has vendor-defined fields
+        test_folder = TEST_FOLDER / Path("tcd_vendor_defined_fields")
+
+        files_list = [
+            ConnectorFile("manifest.xml", "manifest"),
+            ConnectorFile("connection-dialog.tcd", "connection-dialog")]
+
+        properties_has_vendor_defined_fields = ConnectorProperties()
+        self.assertTrue(validate_all_xml(files_list, test_folder, properties_has_vendor_defined_fields), "Valid connector not marked as valid")
+        self.assertListEqual(properties_has_vendor_defined_fields.vendor_defined_fields, ['vendor1', 'vendor2', 'vendor3'], "Vendor-defined attributes not detected")
+
+    def test_vendor_defined_fields_mcd(self):
+        # This connector uses connection-fields file and does not have vendor-defined fields
+        test_folder = TEST_FOLDER / Path("mcd_no_vendor_defined_fields")  # This connector uses a .tcd file
+
+        files_list = [
+            ConnectorFile("manifest.xml", "manifest"),
+            ConnectorFile("connectionFields.xml", "connection-fields"),
+            ConnectorFile("connectionMetadata.xml", "connection-metadata")]
+
+        properties_no_vendor_defined_fields = ConnectorProperties()
+        self.assertTrue(validate_all_xml(files_list, test_folder, properties_no_vendor_defined_fields), "Valid connector not marked as valid")
+        self.assertFalse(properties_no_vendor_defined_fields.vendor_defined_fields, "Found vendor-defined fields when none were defined")
+
+        # This connector uses a connection-fields file and has vendor-defined fields
+        test_folder = TEST_FOLDER / Path("modular_dialog_connector")
+
+        files_list = [
+            ConnectorFile("manifest.xml", "manifest"),
+            ConnectorFile("connectionFields.xml", "connection-fields"),
+            ConnectorFile("connectionMetadata.xml", "connection-metadata"),
+            ConnectorFile("connectionBuilder.js", "script"),
+            ConnectorFile("dialect.xml", "dialect"),
+            ConnectorFile("connectionResolver.xml", "connection-resolver"),
+            ConnectorFile("connectionProperties.js", "script")]
+
+        properties_has_vendor_defined_fields = ConnectorProperties()
+        self.assertTrue(validate_all_xml(files_list, test_folder, properties_has_vendor_defined_fields), "Valid connector not marked as valid")
+        self.assertListEqual(properties_has_vendor_defined_fields.vendor_defined_fields, ['v-custom', 'v-custom2', 'vendor1', 'vendor2', 'vendor3'], "Vendor-defined attributes not detected")

--- a/connector-packager/tests/test_resources/mcd_no_vendor_defined_fields/connectionFields.xml
+++ b/connector-packager/tests/test_resources/mcd_no_vendor_defined_fields/connectionFields.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<connection-fields>
+  <field name="server" label="Server" value-type="string" category="endpoint" >
+    <validation-rule reg-exp="^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$"/>
+  </field>
+
+  <field name="port" label="Port" value-type="string" category="endpoint" default-value="5432" />
+
+  <field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="auth-user-pass" />
+
+  <field name="username" label="Username" value-type="string" category="authentication" />
+
+  <field name="password" label="Password" value-type="string" category="authentication" secure="true" />
+
+</connection-fields>

--- a/connector-packager/tests/test_resources/mcd_no_vendor_defined_fields/connectionMetadata.xml
+++ b/connector-packager/tests/test_resources/mcd_no_vendor_defined_fields/connectionMetadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<connection-metadata>
+  <database enabled='true' label='Database'>
+    <field />
+  </database>
+  <schema enabled='false' />
+</connection-metadata>

--- a/connector-packager/tests/test_resources/mcd_no_vendor_defined_fields/manifest.xml
+++ b/connector-packager/tests/test_resources/mcd_no_vendor_defined_fields/manifest.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='utf-8' ?>
+
+<connector-plugin class='postgres_mcd' superclass='postgres' plugin-version='0.0.1' name='PostgreSQL MCD' version='18.1'>
+  <vendor-information>
+    <company name="Connector SDK"/>
+    <support-link url = "https://example.com"/>
+  </vendor-information>
+  <connection-fields file='connectionFields.xml'/>
+  <connection-metadata file='connectionMetadata.xml'/>
+</connector-plugin>

--- a/connector-packager/tests/test_resources/tcd_vendor_defined_fields/connection-dialog.tcd
+++ b/connector-packager/tests/test_resources/tcd_vendor_defined_fields/connection-dialog.tcd
@@ -1,0 +1,15 @@
+<connection-dialog class='postgres_vendor'>
+  <connection-config>
+    <authentication-mode value='Basic' />
+    <authentication-options>
+      <option name="UsernameAndPassword" default="true" value="auth-user-pass" />
+    </authentication-options>
+    <db-name-prompt value="Database: " />
+    <has-pre-connect-database value="true" />
+    <port-prompt value="Port: " default="5432" />
+    <show-ssl-checkbox value="true" />
+    <vendor1-prompt value="Log Level: " />
+    <vendor2-prompt value="Protocol Version: " />
+    <vendor3-prompt value="Char Set: " />
+  </connection-config>
+</connection-dialog>

--- a/connector-packager/tests/test_resources/tcd_vendor_defined_fields/manifest.xml
+++ b/connector-packager/tests/test_resources/tcd_vendor_defined_fields/manifest.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='utf-8' ?>
+
+<connector-plugin class='postgres_vendor' superclass='postgres' plugin-version='0.0.0' name='Vendor Attributes Example' version='18.1' min-version-tableau='2019.4'>
+  <vendor-information>
+      <company name="Company Name"/>
+      <support-link url="https://example.com"/>
+      <driver-download-link url="https://drivers.example.com"/>
+  </vendor-information>
+  <connection-dialog file='connection-dialog.tcd'/>
+</connector-plugin>


### PR DESCRIPTION
- Detects vendor-defined fields from connection-fields and .tcd files and adds them to ConnectorProperties.vendor_defined_fields
- Displays all fields and tells user to confirm the inputs do not contain PII before distributing connector
- Adds tests for the new vendor_defined_fields

```
Detected vendor-defined fields:
['v-custom', 'v-custom2', 'vendor1', 'vendor2', 'vendor3']
Vendor-defined fields will be logged and persisted to Tableau workbook xml in plain text. You must confirm that the user inputs for fields listed above do not contain PII before distributing this connector to customers.
```
