### PR TITLE
Link MCD docs to authentication page

### DIFF
--- a/docs/mcd.md
+++ b/docs/mcd.md
@@ -157,7 +157,7 @@ The connection field names below should specify the `authentication` category.
 
 | Name  | Meaning | Optional? | Value Notes |
 | ----  | ------- | --------- | ----------- |
-| authentication | The authentication mode for connection | **No** | Allowed Values: Meaning <br> `auth-none`: None <br> `auth-user`: Username Only <br> `auth-user-pass`: Username and Password <br> `auth-pass`: Password Only <br> `oauth`: See the [OAuth Authentication Support](({{ site.baseurl }}/docs/oauth)) for details  |
+| authentication | The authentication mode for connection | **No** | See [Supported Authentication Modes]({{ site.baseurl }}/docs/auth-modes#supported-authentication-modes) for allowed values.  |
 | username | Username | Yes |  |
 | password | Password | Yes | Supports `secure` field attribute |
 | instanceurl | OAuth Instance Url | Yes | Only supported for use when `authentication` value is `oauth` |


### PR DESCRIPTION
The MCD list of supported auth modes was missing `auth-integrated`. Instead of keeping two lists in sync, just linking the MCD page to the authentication page.
