### PR TITLE
Add force-package argument

### DIFF
--- a/connector-packager/connector_packager/package.py
+++ b/connector-packager/connector_packager/package.py
@@ -35,6 +35,7 @@ def create_arg_parser() -> ArgumentParser:
                         help='forgives some validation errors to package connectors made with older versions of the SDK', required=False)
     parser.add_argument('-d', '--dest', dest='dest', help='destination folder for packaged connector',
                         default='packaged-connector', action=UniqueActionStore)
+    parser.add_argument('--force-package', dest='force_package', action='store_true', help='Forces packager to package even if validation fails. Warning: may produce non-functional .taco files, and packaging process may fail.', required=False)
     return parser
 
 
@@ -98,7 +99,11 @@ def main():
         logger.info("Validation succeeded.\n")
     else:
         logger.info("Validation failed. Check " + str(log_file) + " for more information.")
-        return
+
+        if args.force_package:
+            logger.warning("--force-package detected, so attempting to package .taco file despite validation failing. Connector may be non-functional or buggy, and packaging process may fail.")
+        else:
+            return
 
     # Display warning that vendor-defined attributes will be logged
     if len(properties.vendor_defined_fields) > 0:

--- a/connector-packager/connector_packager/package.py
+++ b/connector-packager/connector_packager/package.py
@@ -101,7 +101,7 @@ def main():
         logger.info("Validation failed. Check " + str(log_file) + " for more information.")
 
         if args.force_package:
-            logger.warning("--force-package detected, so attempting to package .taco file despite validation failing. Connector may be non-functional or buggy, and packaging process may fail.")
+            logger.warning("--force-package detected, so attempting to package .taco file despite validation failing. Connector may be non-functional or contain bugs, and packaging process may fail.")
         else:
             return
 


### PR DESCRIPTION
This is a brute-force way to allow some tacos that fail the packager's validation step to still be packaged. For example, the recent Dremio issue where the validation rules were wrong and forced them to incorrectly add required attributes. 

Tested with the Dremio scenario, and it would have worked for them. For connectors with actual XML issues, the file list is not generated so if --force-package is used the packager will crash with a python error. This is fine in my opinion, those connectors would not load in Tableau anyway, we give plenty of warning, and we're not looking to document this outside of the built-in help for the packager. 
