### PR TITLE
Update manual test plan for partners

### DIFF
--- a/docs/manual-test.md
+++ b/docs/manual-test.md
@@ -114,6 +114,12 @@ Perform the publishing tests listed below. For more information about publishing
 
 * Publish a workbook without an extract to Tableau Server *with the connector* installed on the server.
 The workbook should publish without errors.
+    - Be sure not to embed credentials when you publish the workbook.
+    - Open the published workbook.
+    - Verify that a Sign In dialog opens.<br/>
+    ![]({{ site.baseurl }}/assets/mt-embed-credentials.png)<br/>
+    For more information, see [Set Credentials for Accessing Your Published Data](https://onlinehelp.tableau.com/current/pro/desktop/en-us/publishing_sharing_authentication.htm) in the Tableau Desktop and Web Authoring Help.
+
 
 * Publish a data source with an extract to Tableau Server.
     - Be sure the the connector is installed on the server.
@@ -122,15 +128,6 @@ The workbook should publish without errors.
         1. Under **Authentication**, select **Allow refresh access** from the dropdown list.<br/>
         ![]({{ site.baseurl }}/assets/mt-pub-allow-refresh.png)<br/>
 The workbook should publish without errors.
-
-* Publish a workbook without an extract to Tableau Server.
-    - Be sure the the connector is installed on the server.  *
-    - Be sure not to embed credentials when you publish the workbook.
-    - Open the published workbook.
-    - Verify that a Sign In dialog opens.<br/>
-    ![]({{ site.baseurl }}/assets/mt-embed-credentials.png)<br/>
-    For more information, see [Set Credentials for Accessing Your Published Data](https://onlinehelp.tableau.com/current/pro/desktop/en-us/publishing_sharing_authentication.htm) in the Tableau Desktop and Web Authoring Help.
-
 
 __Find publishing resources__
 

--- a/docs/manual-test.md
+++ b/docs/manual-test.md
@@ -66,7 +66,7 @@ __Connect to the database with valid credentials__
 After you click your connector, close the window. It should return to the previous window without error.<br/>
 ![]({{ site.baseurl }}/assets/mt-cancel.png)
 
-1. Make valid entries in each field (Server, Username, Password, Port, and so on) and verify that you can connect.
+1. Make valid entries in each field (Server, Username, Password, Port, and so on) and verify that you can connect. Repeat this step with each supported auth mode.
 
 1. Verify that the default connection name is correct, and that you can change it.<br/>
 ![]({{ site.baseurl }}/assets/mt-cconnection-name.png)
@@ -181,7 +181,7 @@ Create a workbook on Tableau Server with the connector installed on the server:
 1. Select your connector. In this example, the connector name is MariaDB.<br/>
 ![]({{ site.baseurl }}/assets/mt-wkbk-mariadb.png)
 
-1. Enter the required information to sign in.<br/>
+1. Enter the required information to sign in. Repeat as necessary to test all auth modes.<br/>
 ![]({{ site.baseurl }}/assets/mt-wkbk-signin.png)
 
 1. After you connect to the data source, you should be able to create a workbook and save it on the server.

--- a/docs/manual-test.md
+++ b/docs/manual-test.md
@@ -89,6 +89,20 @@ Right-click the data source, then click **Extract Data**. Verify that you can cr
 
 For more information, see [Refresh Extracts](https://onlinehelp.tableau.com/current/pro/desktop/en-us/extracting_refresh.htm) in Tableau Desktop and Web Authoring Help.
 
+__Edit your connection__
+
+Change all possible items and verify that changes are applied.
+
+1. Right-click the data source and click **Edit Data Source**.<br/>
+![]({{ site.baseurl }}/assets/mt-edit-data-source.png)
+The worksheet opens in Tableau.
+1. In the left pane, under **Connections**, click the dropdown menu next to the server name and click **Edit Connection**.<br/>
+![]({{ site.baseurl }}/assets/mt-edit-connection.png)
+1. Change something. For example, change the server.<br/>
+![]({{ site.baseurl }}/assets/mt-change-server.png)
+1. After you click **Sign In**, you should see the new server name under **Connections**.<br/>
+![]({{ site.baseurl }}/assets/mt-new-server.png)
+
 __Connect to the correct database with the wrong credentials__
 - Verify that an error message appears
 - **Verify that the error message says "Invalid username or password" instead of a generic error like "Bad Connection".** The correct error message is highlighted in the screenshot below.<br/>

--- a/docs/manual-test.md
+++ b/docs/manual-test.md
@@ -78,14 +78,6 @@ After you click your connector, close the window. It should return to the previo
 Select the **Require SSL** checkbox, and then click **Sign In**.<br/>
 ![]({{ site.baseurl }}/assets/mt-connect-ssl.png)
 
-1. Verify that you can duplicate the data source and that the duplicate source name has "(copy)" appended to the end.<br/>
-![]({{ site.baseurl }}/assets/mt-duplicate.png)<br/>
-![]({{ site.baseurl }}/assets/mt-duplicate-copy.png)
-
-1. Verify that the data source connection properties are correct.<br/>
-![]({{ site.baseurl }}/assets/mt-prop-menu.png)<br/>
-![]({{ site.baseurl }}/assets/mt-properties.png)
-
 __Test extracts__
 
 1. Create an extract.
@@ -110,45 +102,6 @@ The worksheet opens in Tableau.
 ![]({{ site.baseurl }}/assets/mt-change-server.png)
 1. After you click **Sign In**, you should see the new server name under **Connections**.<br/>
 ![]({{ site.baseurl }}/assets/mt-new-server.png)
-
-__Open a workbook with the connector missing__
-
-1. Create a workbook with a live connection using your connector.
-
-1. Save the workbook. The file should have a .twb filename extension.
-
-1. Close Tableau Desktop and remove your connector.
-
-1. Open Tableau Desktop and open the workbook you created. Verify that an error message displays:<br/>
-![]({{ site.baseurl }}/assets/mt-missing-connector-error.png)
-
-__Connect to a published data source with the connector missing__
-
-1. Remove your connector.
-
-1. Use Tableau Desktop to connect to a published data source with an extract. You should be able to connect without errors.
-
-1. Use Tableau Desktop to connect to a published data source without an extract. Verify that an error message displays:<br/>
-![]({{ site.baseurl }}/assets/mt-no-extract-error.png)
-
-__Download and open a workbook with the connector missing__
-
-1. Remove your connector.
-
-1. Download a workbook with an extract from Tableau Server and open it in Tableau Desktop. The workbook should open without errors.
-
-1. Download a workbook without an extract from Tableau Server and open it in Tableau Desktop. Verify that an error message displays:<br/>
-![]({{ site.baseurl }}/assets/mt-wkbk-no-extract-error.png)
-
-__Test localization__
-Change the language to any language but English (United States).
-
-1. From **Help**, select **Choose Language**, and then select a language.<br/>
-![]({{ site.baseurl }}/assets/mt-loc.png)
-
-1. Restart Tableau Desktop.
-
-1. Connect to your data source again and verify the localized text.
 
 __Connect to the correct database with the wrong credentials__
 - Verify that an error message appears

--- a/docs/manual-test.md
+++ b/docs/manual-test.md
@@ -89,20 +89,6 @@ Right-click the data source, then click **Extract Data**. Verify that you can cr
 
 For more information, see [Refresh Extracts](https://onlinehelp.tableau.com/current/pro/desktop/en-us/extracting_refresh.htm) in Tableau Desktop and Web Authoring Help.
 
-__Edit your connection__
-
-Change all possible items and verify that changes are applied.
-
-1. Right-click the data source and click **Edit Data Source**.<br/>
-![]({{ site.baseurl }}/assets/mt-edit-data-source.png)
-The worksheet opens in Tableau.
-1. In the left pane, under **Connections**, click the dropdown menu next to the server name and click **Edit Connection**.<br/>
-![]({{ site.baseurl }}/assets/mt-edit-connection.png)
-1. Change something. For example, change the server.<br/>
-![]({{ site.baseurl }}/assets/mt-change-server.png)
-1. After you click **Sign In**, you should see the new server name under **Connections**.<br/>
-![]({{ site.baseurl }}/assets/mt-new-server.png)
-
 __Connect to the correct database with the wrong credentials__
 - Verify that an error message appears
 - **Verify that the error message says "Invalid username or password" instead of a generic error like "Bad Connection".** The correct error message is highlighted in the screenshot below.<br/>


### PR DESCRIPTION
First attempt at making manual test passes less onerous for partners.

Removed:
- "Verify that you can duplicate the data source" step
- `Verify that the data source connection properties are correct.`
- "Edit your connection" step - they may not have multiple endpoints to test against.
- "Missing connector" steps

Added:
- connecting with each supported auth mode