### PR TITLE
Add security considerations page

### DIFF
--- a/_includes/docs_menu.html
+++ b/_includes/docs_menu.html
@@ -16,6 +16,7 @@
     <li><a href="{{ site.baseurl }}/docs/package-sign">Package and Sign Your Connector for Distribution</a></li>
     <li><a href="{{ site.baseurl }}/docs/run-taco">Run Your Connector</a></li>
     <li><a href="{{ site.baseurl }}/docs/bug-artifacts">Filing a Bug with the SDK</a></li>
+    <li><a href="{{ site.baseurl }}/docs/security-considerations">Security Considerations</a></li>
     <li>Reference</li>
     <li><a href="{{ site.baseurl }}/docs/api-reference">API Reference</a></li>
     <li><a href="{{ site.baseurl }}/docs/capabilities">Capabilities</a></li>

--- a/docs/connection-dialog.md
+++ b/docs/connection-dialog.md
@@ -5,7 +5,7 @@ title: Build the Connection Dialog
 The connection dialog prompts the user to enter connection and authentication information. That information is passed into the Connector Builder script to build the connection string. The dialog appears when creating a new connection or editing an existing connection and is used by both Tableau Desktop and Tableau Server.
 
 The connection dialog can be defined in two different ways:
-- [Connection Dialog v1]({{ site.baseurl }}/docs/ui) 
+- [Connection Dialog v1]({{ site.baseurl }}/docs/ui)
 - [Connection Dialog v2]({{ site.baseurl }}/docs/mcd) in Tableau 2020.3 or later
 
 **Connection Dialog v2 is the recommended pattern for new connectors.**
@@ -28,7 +28,7 @@ These elements are defined in the manifest.xml file:
 </connector-plugin>
 ```
 
-## Define how the connector authenticates 
+## Define how the connector authenticates
 
 The ```authentication``` attribute is a required field and controls how a user is prompted to enter data source credentials. For more information on authentication modes, see [Authentication modes]({{ site.baseurl }}/docs/auth-modes).
 
@@ -36,7 +36,7 @@ The ```authentication``` attribute is a required field and controls how a user i
 
 Vendors can add customized attributes (fields) to their connector plugin by using the a ```field``` element in V2 or the pre-defined ```vendor*``` elements in V1.  Ensure the vendor defined fields do not duplicate functionality defined in the [Connection Field Platform Integration]({{ site.baseurl }}/docs/mcd#connection-field-platform-integration) section.
 
-These fields have a custom label and can be used for attributes in the connection strings.  
+These fields have a custom label and can be used for attributes in the connection strings.
 
 To add a custom vendor attribute for an ODBC-based connector, you must modify these files:
 - connectionFields.xml or connection-dialog.tcd
@@ -49,7 +49,7 @@ To add a custom vendor attribute for an JDBC-based connector, you must modify th
 - connectionBuilder.js
 - connectionProperties.js
 
-**Vendor defined attributes will be logged and persisted to Tableau workbook xml in plain text.** This means the input for these fields cannot contain any Personally Identifiable Information (PII), as they are not secure and could leak sensitive customer information.
+**Vendor defined attributes will be logged and persisted to Tableau workbook xml in plain text.** This means the input for these fields cannot contain any Personally Identifiable Information (PII), as they are not secure and could leak sensitive customer information. For more information, see [Security Considerations]({{ site.baseurl }}/docs/security-considerations)
 
 See examples below.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -4,6 +4,8 @@ title: Connector Design Considerations
 
 The choices you make when creating a connector can include which superclass and dialect to use, and how you want to tune your connection using Tableau capabilities.
 
+Also be sure to read the [Security Considerations]({{ site.baseurl }}/docs/security-considerations) page.
+
 ## Choose a connection class
 
 The <span style="font-family: courier new">class</span> attribute is a unique key for your connector. Make it something that is unlikely to be used by another connector. When Tableau loads the connectors at startup, if the class is already registered, the connector will not be loaded. The class is also stamped in Tableau Workbook (.twb or .twbx) files and Tableau Data Source (.tds) files to identify what connector that particular connection was using.
@@ -112,7 +114,7 @@ A common example is filtering the top three regions by sum of sales. You can try
 
 There are some capabilities for which Tableau either cannot provide a sensible default, or the platform default and current recommendation are different for backwards compatibility reasons.
 
-Review the [full list]({{ site.baseurl }}/docs/capabilities) of latest recommendations, highlighted in **<span style="color:red">Red</span>**, when writing a connector.  
+Review the [full list]({{ site.baseurl }}/docs/capabilities) of latest recommendations, highlighted in **<span style="color:red">Red</span>**, when writing a connector.
 
 Common customizations:
 - CAP_QUERY_GROUP_BY_BOOL

--- a/docs/gallery-submission.md
+++ b/docs/gallery-submission.md
@@ -2,7 +2,7 @@
 title: Connector Tableau Exchange Submission Guide
 ---
 
-**Note:** Download a PDF version of this guide [here]({{ site.baseurl }}/assets/Connector-Gallery-Submission-Guide.pdf).  
+**Note:** Download a PDF version of this guide [here]({{ site.baseurl }}/assets/Connector-Gallery-Submission-Guide.pdf).
 
 > ![]({{ site.baseurl }}/assets/tableau-logo.png)
 >
@@ -32,6 +32,8 @@ These are the steps you'll take to prepare and submit your connector to Tableau 
 Building a connector generally takes two to six weeks, depending on complexity. Then, before it can be published to Tableau Exchange, you'll need to submit the connector and beta test it. This typically takes another two to four weeks.
 
 ![]({{ site.baseurl }}/assets/timeline.png)
+
+Note: As part of the connector review we will perform a security review of the connector. Please read the [Security Considerations]({{ site.baseurl }}/docs/security-considerations) page to make sure your connector will be accepted. Connectors with security vulnerabilities will not be approved for the Exchange until a fix is provided, and connectors already posted to the Exchange that are found to have security vulnerabilities will be pulled until a fix is provided.
 
 ---
 
@@ -113,9 +115,9 @@ Briefly describe details about your connector that are most relevant for custome
 For your connector's detail page, provide a long description. Include these three parts.
 
 - A description of your application or database.
-- A description of what the connector does that makes better than using an Other ODBC/JDBC connection.  
+- A description of what the connector does that makes better than using an Other ODBC/JDBC connection.
 
-   Example:   
+   Example:
 
    _This connector provides a smooth and easy way to connect to Google Big Query. By using this connector, customers can leverage Google's internal storage and extract APIs, which offer up to 10x performance increases when extracting large amounts of data. This connector also allows users to use custom OAuth, which is not currently supported natively with an Other JDBC connection._
 - Known issues or version requirements for the connector
@@ -131,12 +133,12 @@ Installation instructions have two parts:
   * Installing the driver
 - Your custom installation instructions
 
-**Note on Prep Builder Instructions:** If your connector can be used with Prep Builder, add information about where to put the TACO file.    
-- For Tableau Prep Builder:  
-  - Windows: C:\Users\<Windows User>\Documents\My Tableau Prep Repository\Connectors  
-  - MacOS: /Users/<user>/Documents/My Tableau Prep Repository/Connectors  
-- For Tableau Server (Flow web authoring): <Tableau_Server_Installation_Directory>/data/tabsvc/flowqueryservice/Connectors  
-- For Tableau Server (Tableau Prep Conductor): <Tableau_Server_Installation_Directory>/data/tabsvc/flowprocessor/Connectors  
+**Note on Prep Builder Instructions:** If your connector can be used with Prep Builder, add information about where to put the TACO file.
+- For Tableau Prep Builder:
+  - Windows: C:\Users\<Windows User>\Documents\My Tableau Prep Repository\Connectors
+  - MacOS: /Users/<user>/Documents/My Tableau Prep Repository/Connectors
+- For Tableau Server (Flow web authoring): <Tableau_Server_Installation_Directory>/data/tabsvc/flowqueryservice/Connectors
+- For Tableau Server (Tableau Prep Conductor): <Tableau_Server_Installation_Directory>/data/tabsvc/flowprocessor/Connectors
 
 
 To make things easy, we've created a template for your custom installation instructions (included below, markdown friendly). Any additional installation instructions should be appended below the Tableau installation instructions.
@@ -194,7 +196,7 @@ We are happy to support partners looking to issue Tableau-specific press release
 
 The process:
 
-1. Partner drafts a press release using the Tableau Partner Brand Guidelines (available to partners in the PDC).  
+1. Partner drafts a press release using the Tableau Partner Brand Guidelines (available to partners in the PDC).
 
 Note: The release should not include the Tableau corporate boilerplate.
 2. Partner submits the draft to the Partner Marketing team via email (partnermarketing@tableau.com) for initial review.
@@ -212,7 +214,7 @@ When your connector is approved, it will be released to Tableau Exchange for bet
 
 ### Step 9: Get beta-testing feedback from five customers.
 
-After your connector is added to Tableau Exchange, you'll need to beta-test your connector with at least **five customers** before your connector can move to a General Audience (GA) release. While you'll be able to catch most issues with the TDVT suite, customer testing helps refine your results. Customers often have unique environments that need to be tested to ensure that everything works as expected.  
+After your connector is added to Tableau Exchange, you'll need to beta-test your connector with at least **five customers** before your connector can move to a General Audience (GA) release. While you'll be able to catch most issues with the TDVT suite, customer testing helps refine your results. Customers often have unique environments that need to be tested to ensure that everything works as expected.
 
 Customers can find our beta test scenarios and [Beta feedback form](https://forms.gle/xjWGk86tv8eD43Mk7) on the feedback button in Tableau Exchange. Note that the feedback form is specific to your connector, and you will be able to monitor the progress of the beta test on your own. The total beta testing process shouldn't take more than 30 minutes for a customer to complete.
 

--- a/docs/security-considerations.md
+++ b/docs/security-considerations.md
@@ -32,7 +32,7 @@ We recommend the following workarounds instead of an "Arbitrary Driver Propertie
 
 The Tableau Exchange does not host drivers, and the responsibility of ensuring the driver is secure falls onto the driver authors.
 
-However, for the connectors that are hosted in Tableau Online, Tableau will need to host the driver in our environments. In these cases, the driver will be scanned for security vulnerabilities, including out-of-date and vulnerable third-party libraries.
+There is an additional process for connectors that are hosted in Tableau Online. Tableau will need to host the driver in our environments so, the driver will be scanned for security vulnerabilities, including out-of-date and vulnerable third-party libraries.
 
 # JDBC Connectors not using connection-properties component
 

--- a/docs/security-considerations.md
+++ b/docs/security-considerations.md
@@ -1,0 +1,42 @@
+---
+title: Security Considerations
+---
+
+Connectors built with the Connector SDK handle authentication and customer data, and if handled incorrectly can cause security vulnerabilities and leakage of sensitive data.
+
+During the connector review for the Tableau Exchange, the connector will go through a security review. Failing to address these security concerns will mean that the connector will not be approved for the Exchange until the concerns are addressed.
+
+We will also pull any connector from the Tableau Exchange that we find a security vulnerability in, and that vulnerability must be addressed before the connector can go back to the Exchange.
+
+
+# Secure Attributes on the Connection Dialog
+
+The Connector SDK allows the connection dialog to be customized, using platform-defined fields as well as the creation of new fields, vendor-specific fields. It is important to note that these fields, with the exception of the built-in password field, are not secure. **The values of every non-secure UI field on the connection dialog will be logged in plain text by Tableau as well as persisted in easily-inspectable XML in Tableau workbooks, datasources and Prep flows..**
+
+At the moment, the only field that can be marked secure is password. This means that the values customers enter vendor-specific fields **cannot contain secrets, credentials or personally identifiable information (PII),** and connectors with such fields will not be approved for the Tableau Exchange. This is a known limitation of the SDK, and we are looking at ways to mitigate it in the long term.
+
+Examples of problematic UI fields that will be rejected:
+- Proxy Password
+- OAuth secrets (Use the official [Tableau OAuth flow](({{ site.baseurl }}/docs/oauth)) instead)
+- **Arbitrary JDBC Properties** (See following section)
+
+## Arbitrary Driver Properties
+
+**Arbitrary Driver Properties fields are not supported in the Connector SDK, and connectors using them will not be approved for the Tableau Exchange.** An "Arbitrary Driver Properties" field allows the user to manually enter key-value pairs that will be passed directly to the driver. However, because all vendor-defined fields are non-secure, these key-value pairs will be logged in plain text and persisted in easily-inspectable XML in Tableau workbooks, datasources and Prep flows. Many driver properties are considered sensitive, and we cannot enforce that users will not enter these sensitive key-value pairs, therefore we consider "Arbitrary Driver Properties" fields a security vulnerability.
+
+We recommend the following workarounds instead of an "Arbitrary Driver Properties" field:
+- To unblock users needing to set non-sensitive driver properties, add them as separate fields on the Advanced tab using [Connection Dialogs V2 framework](({{ site.baseurl }}/docs/mcd))
+- For JDBC, Customers can set driver properties using [JDBC Properties files](https://kb.tableau.com/articles/howto/Customizing-JDBC-Connections)
+
+# Driver Vulnerabilities
+
+The Tableau Exchange does not host drivers, and the responsibility of ensuring the driver is secure falls onto the driver authors.
+
+However, for the connectors that are hosted in Tableau Online, Tableau will need to host the driver in our environments. In these cases, the driver will be scanned for security vulnerabilities, including out-of-date and vulnerable third-party libraries.
+
+# JDBC Connectors not using connection-properties component
+
+While ODBC connectors only have a connection-builder script that builds the connection string, JDBC has a connection-builder script that builds the JDBC URL and a connection-properties script that passed properties directly to the driver.
+
+**The JDBC URL will be logged in plain text by Tableau in the std_jprotocolserver.txt file**. This means that anything added to the JDBC URL in the connection-builder script will be logged, including username and password if the connector incorrectly handles these fields (despite password being a secure field). To avoid this, make sure all authentication-related attributes are sent to the driver as properties in the connection-properties script, and not appended to the JDBC URL in the connection-builders script.
+

--- a/docs/security-considerations.md
+++ b/docs/security-considerations.md
@@ -32,7 +32,7 @@ We recommend the following workarounds instead of an "Arbitrary Driver Propertie
 
 The Tableau Exchange does not host drivers, and the responsibility of ensuring the driver is secure falls onto the driver authors.
 
-There is an additional process for connectors that are hosted in Tableau Online. Tableau will need to host the driver in our environments so, the driver will be scanned for security vulnerabilities, including out-of-date and vulnerable third-party libraries.
+There is an additional process for connectors that are hosted in Tableau Online. Tableau will need to host the driver in our environments, so the driver will be scanned for security vulnerabilities, including out-of-date and vulnerable third-party libraries.
 
 # JDBC Connectors not using connection-properties component
 

--- a/docs/security-considerations.md
+++ b/docs/security-considerations.md
@@ -18,13 +18,13 @@ At the moment, the only field that can be marked secure is password. This means 
 Examples of problematic UI fields that will be rejected:
 - Proxy Password
 - OAuth secrets (Use the official [Tableau OAuth flow](({{ site.baseurl }}/docs/oauth)) instead)
-- **Arbitrary JDBC Properties** (See following section)
+- **Freeform Driver Properties** (See following section)
 
-## Arbitrary Driver Properties
+## Freeform Driver Properties
 
-**Arbitrary Driver Properties fields are not supported in the Connector SDK, and connectors using them will not be approved for the Tableau Exchange.** An "Arbitrary Driver Properties" field allows the user to manually enter key-value pairs that will be passed directly to the driver. However, because all vendor-defined fields are non-secure, these key-value pairs will be logged in plain text and persisted in easily-inspectable XML in Tableau workbooks, datasources and Prep flows. Many driver properties are considered sensitive, and we cannot enforce that users will not enter these sensitive key-value pairs, therefore we consider "Arbitrary Driver Properties" fields a security vulnerability.
+**Freeform Driver Properties fields are not supported in the Connector SDK, and connectors using them will not be approved for the Tableau Exchange.** A "Freeform Driver Properties" field allows the user to manually enter key-value pairs that will be passed directly to the driver. However, because all vendor-defined fields are non-secure, these key-value pairs will be logged in plain text and persisted in easily-inspectable XML in Tableau workbooks, datasources and Prep flows. Many driver properties are considered sensitive, and we cannot enforce that users will not enter these sensitive key-value pairs, therefore we consider "Freeform Driver Properties" fields a security vulnerability.
 
-We recommend the following workarounds instead of an "Arbitrary Driver Properties" field:
+We recommend the following workarounds instead of an "Freeform Driver Properties" field:
 - To unblock users needing to set non-sensitive driver properties, add them as separate fields on the Advanced tab using [Connection Dialogs V2 framework](({{ site.baseurl }}/docs/mcd))
 - For JDBC, Customers can set driver properties using [JDBC Properties files](https://kb.tableau.com/articles/howto/Customizing-JDBC-Connections)
 

--- a/docs/security-considerations.md
+++ b/docs/security-considerations.md
@@ -2,7 +2,7 @@
 title: Security Considerations
 ---
 
-Connectors built with the Connector SDK handle authentication and customer data, and if handled incorrectly can cause security vulnerabilities and leakage of sensitive data.
+Connectors built with the Connector SDK handle authentication and customer data, and handling these incorrectly can cause security vulnerabilities and leakage of sensitive data.
 
 During the connector review for the Tableau Exchange, the connector will go through a security review. Failing to address these security concerns will mean that the connector will not be approved for the Exchange until the concerns are addressed.
 
@@ -11,9 +11,9 @@ We will also pull any connector from the Tableau Exchange that we find a securit
 
 # Secure Attributes on the Connection Dialog
 
-The Connector SDK allows the connection dialog to be customized, using platform-defined fields as well as the creation of new fields, vendor-specific fields. It is important to note that these fields, with the exception of the built-in password field, are not secure. **The values of every non-secure UI field on the connection dialog will be logged in plain text by Tableau as well as persisted in easily-inspectable XML in Tableau workbooks, datasources and Prep flows..**
+The Connector SDK allows the connection dialog to be customized, using platform-defined fields as well as the creation of new, vendor-specific fields. It is important to note that these fields, with the exception of the built-in password field, are not secure. **The values of every non-secure UI field on the connection dialog will be logged in plain text by Tableau as well as persisted in easily-inspectable XML in Tableau workbooks, datasources and Prep flows.**
 
-At the moment, the only field that can be marked secure is password. This means that the values customers enter vendor-specific fields **cannot contain secrets, credentials or personally identifiable information (PII),** and connectors with such fields will not be approved for the Tableau Exchange. This is a known limitation of the SDK, and we are looking at ways to mitigate it in the long term.
+At the moment, the only field that can be marked secure is password. This means that the values customers enter for vendor-specific fields **must not contain secrets, credentials or personally identifiable information (PII),** and connectors with such fields will not be approved for the Tableau Exchange. This is a known limitation of the SDK, and we are looking at ways to mitigate it in the long term.
 
 Examples of problematic UI fields that will be rejected:
 - Proxy Password
@@ -36,7 +36,7 @@ However, for the connectors that are hosted in Tableau Online, Tableau will need
 
 # JDBC Connectors not using connection-properties component
 
-While ODBC connectors only have a connection-builder script that builds the connection string, JDBC has a connection-builder script that builds the JDBC URL and a connection-properties script that passed properties directly to the driver.
+While ODBC connectors only have a connection-builder script that builds the connection string, JDBC has a connection-builder script that builds the JDBC URL and a connection-properties script that passes properties directly to the driver.
 
 **The JDBC URL will be logged in plain text by Tableau in the std_jprotocolserver.txt file**. This means that anything added to the JDBC URL in the connection-builder script will be logged, including username and password if the connector incorrectly handles these fields (despite password being a secure field). To avoid this, make sure all authentication-related attributes are sent to the driver as properties in the connection-properties script, and not appended to the JDBC URL in the connection-builders script.
 


### PR DESCRIPTION
First stab at adding the Security Considerations page. We want to document the common security reasons we reject connectors from the Exchange.
