### PR TITLE
Fix incomplete Tableau server instructions

### DIFF
--- a/docs/run-taco.md
+++ b/docs/run-taco.md
@@ -22,8 +22,11 @@ Starting in 2019.4, you can load packaged connectors (otherwise known as TACO fi
 ## Run a packaged connector in Tableau Server
 ### Option 1
 For each machine:
-1. Drop your `.taco` file into [Your Tableau Server Install Directory]/data/tabsvc/vizqlserver/Connectors. On a default install, this will be in the ProgramData folder. For example:
-`C:\ProgramData\Tableau\Tableau Server\data\tabsvc\vizqlserver\Connectors`
+1. Drop your `.taco` file into the following directoy:
+    - `[Tableau_Server_Installation_Directory]/data/tabsvc/vizqlserver/Connectors`
+1. To enable your connector for Prep, you also need to add your taco to the following locations:
+    - Tableau Prep Conductor: `[Tableau_Server_Installation_Directory]/data/tabsvc/flowprocessor/Connectors`
+    - Tableau Flow Web Authoring: `[Tableau_Server_Installation_Directory]/data/tabsvc/flowqueryservice/Connectors`
 1. Restart your server.
 
 

--- a/docs/run-taco.md
+++ b/docs/run-taco.md
@@ -16,18 +16,26 @@ Tableau loads connectors by directory in the following order:
 Starting in 2019.4, you can load packaged connectors (otherwise known as TACO files). To use a connector in earlier Tableau versions, or to run an unpackaged connector, see [Run Your "Under Development" Connector]({{ site.baseurl }}/docs/run-taco#run-your-under-development-connector) below.
 
 ## Run a packaged connector in Tableau Desktop
-1. Copy your packaged connector file (with a .taco filename extension) into your My Tableau Repository/Connectors directory.
+1. Copy the .taco file into your My Tableau Repository/Connectors directory.
+    - Windows: `C:\Users\\[Windows User]\Documents\My Tableau Repository\Connectors`
+    - macOS: `/Users/[user]/Documents/My Tableau Repository/Connectors`
 1. Launch Tableau Desktop.
 
 ## Run a packaged connector in Tableau Server
 ### Option 1
 For each machine:
-1. Drop your `.taco` file into the following directoy:
+1. Drop your `.taco` file into the following directory:
     - `[Tableau_Server_Installation_Directory]/data/tabsvc/vizqlserver/Connectors`
 1. To enable your connector for Prep, you also need to add your taco to the following locations:
     - Tableau Prep Conductor: `[Tableau_Server_Installation_Directory]/data/tabsvc/flowprocessor/Connectors`
     - Tableau Flow Web Authoring: `[Tableau_Server_Installation_Directory]/data/tabsvc/flowqueryservice/Connectors`
 1. Restart your server.
+
+## Run a packaged connector in Tableau Prep Builder
+1. Copy the .taco file to your My Tableau Prep Repository\Connectors directory:
+    - Windows: `C:\Users\\[Windows User]\Documents\My Tableau Prep Repository\Connectors`
+    - macOS: `/Users/[user]/Documents/My Tableau Prep Repository/Connectors`
+1. Launch Tableau Prep Builder.
 
 
 ### Option 2

--- a/docs/run-taco.md
+++ b/docs/run-taco.md
@@ -2,6 +2,8 @@
 title: Run Your Connector
 ---
 
+Note: the below is intended for connector developers. Customer-facing documentation is available [here](https://help.tableau.com/current/pro/desktop/en-us/examples_connector_sdk.htm).
+
 # Load order and class name collisions
 
 If a connector has the same class as a connector that has already been registered, the new connector will be rejected. This means that connectors loaded first have precedence when two connectors share the same class name.
@@ -21,8 +23,14 @@ Starting in 2019.4, you can load packaged connectors (otherwise known as TACO fi
     - macOS: `/Users/[user]/Documents/My Tableau Repository/Connectors`
 1. Launch Tableau Desktop.
 
+## Run a packaged connector in Tableau Prep Builder
+1. Copy the .taco file to your My Tableau Prep Repository\Connectors directory:
+    - Windows: `C:\Users\\[Windows User]\Documents\My Tableau Prep Repository\Connectors`
+    - macOS: `/Users/[user]/Documents/My Tableau Prep Repository/Connectors`
+1. Launch Tableau Prep Builder.
+
 ## Run a packaged connector in Tableau Server
-### Option 1
+### Option 1 (Preferred)
 For each machine:
 1. Drop your `.taco` file into the following directory:
     - `[Tableau_Server_Installation_Directory]/data/tabsvc/vizqlserver/Connectors`
@@ -31,14 +39,7 @@ For each machine:
     - Tableau Flow Web Authoring: `[Tableau_Server_Installation_Directory]/data/tabsvc/flowqueryservice/Connectors`
 1. Restart your server.
 
-## Run a packaged connector in Tableau Prep Builder
-1. Copy the .taco file to your My Tableau Prep Repository\Connectors directory:
-    - Windows: `C:\Users\\[Windows User]\Documents\My Tableau Prep Repository\Connectors`
-    - macOS: `/Users/[user]/Documents/My Tableau Prep Repository/Connectors`
-1. Launch Tableau Prep Builder.
-
-
-### Option 2
+### Option 2 (For in-development connectors)
 1. Create a directory for Tableau connectors. This needs to be the same path on each machine, and on the same drive as the server is installed on. For example:
 `C:\tableau_connectors`
 1. Copy your packaged connector file (with a .taco filename extension) into  the folder your created on each node.

--- a/docs/templates/tableau-server.md
+++ b/docs/templates/tableau-server.md
@@ -3,7 +3,8 @@ title: Tableau Server Installation Instructions Template
 ---
 
 1. Download the Connector file (.taco).
-2. Move the .taco file here: 
+2. Move the .taco file here:
+   -  Tableau Server: `[Tableau_Server_Installation_Directory]/data/tabsvc/vizqlserver/Connectors`
    -  Tableau Prep Conductor: `[Tableau_Server_Installation_Directory]/data/tabsvc/flowprocessor/Connectors`
    -  Tableau Flow Web Authoring: `[Tableau_Server_Installation_Directory]/data/tabsvc/flowqueryservice/Connectors`
 1. For a multi-node Tableau server, copy the Connector file (.taco) in the correct folder for each server node.


### PR DESCRIPTION
The "Run Your Connector" page did not have the Prep instructions, and the templates did not have the directory for general Tableau, just Prep. (My fault, based on my review feedback.) Adding them both, and trying to unify the formatting a bit.