### PR TITLE
Document shared taco directory

### DIFF
--- a/docs/run-taco.md
+++ b/docs/run-taco.md
@@ -6,11 +6,19 @@ Note: the below is intended for connector developers. Customer-facing documentat
 
 # Load order and class name collisions
 
+## Tableau 2022.2 and above
+If a connector has the same class as a connector that has already been registered, Tableau will load the connector with the highest connector version number (the `plugin-version` attribute in the connector manifest).
+
+If both connectors have the same version, the newer connector will be rejected. This means that connectors loaded first have precedence when two connectors share the same class name.
+
+## Tableau versions older than 2022.2
 If a connector has the same class as a connector that has already been registered, the new connector will be rejected. This means that connectors loaded first have precedence when two connectors share the same class name.
 
+## Load order
 Tableau loads connectors by directory in the following order:
 1. Built-in Tableau connectors
-1. Connectors located in "My Tableau Repository/Connectors"
+1. Connectors located in ``C:\Program Files\Tableau\Connectors` (Windows) or `/opt/tableau/connectors` (Linux)
+1. Connectors located in `My Tableau Repository/Connectors`
 1. (Optional) Connectors in the dev path specified by `-DConnectPluginsPath`
 
 # Run Your Packaged Connector (TACO file)
@@ -33,10 +41,17 @@ Starting in 2019.4, you can load packaged connectors (otherwise known as TACO fi
 ### Option 1 (Preferred)
 For each machine:
 1. Drop your `.taco` file into the following directory:
+    - Windows: `C:\Program Files\Tableau\Connectors`
+    - Linux: `/opt/tableau/connectors`
+1. Restart Tableau Server
+
+### Option 2
+For each machine:
+1. Drop your `.taco` file into the following directory:
     - `[Tableau_Server_Installation_Directory]/data/tabsvc/vizqlserver/Connectors`
 1. To enable your connector for Prep, you also need to add your taco to the following locations:
     - Tableau Prep Conductor: `[Tableau_Server_Installation_Directory]/data/tabsvc/flowprocessor/Connectors`
-    - Tableau Flow Web Authoring: `[Tableau_Server_Installation_Directory]/data/tabsvc/flowqueryservice/Connectors`
+    - Tableau Flow Web Authoring: `[Tableau_Server_Installation_Directory]/data/tabsvc/flowqueryservice/Connectors` or `[Tableau_Server_Installation_Directory]/data/tabsvc/flowminerva/Connectors/`, depending on which directory exists
 1. Restart your server.
 
 ### Option 2 (For in-development connectors)

--- a/docs/run-taco.md
+++ b/docs/run-taco.md
@@ -6,15 +6,8 @@ Note: the below is intended for connector developers. Customer-facing documentat
 
 # Load order and class name collisions
 
-## Tableau 2022.2 and above
-If a connector has the same class as a connector that has already been registered, Tableau will load the connector with the highest connector version number (the `plugin-version` attribute in the connector manifest).
-
-If both connectors have the same version, the newer connector will be rejected. This means that connectors loaded first have precedence when two connectors share the same class name.
-
-## Tableau versions older than 2022.2
 If a connector has the same class as a connector that has already been registered, the new connector will be rejected. This means that connectors loaded first have precedence when two connectors share the same class name.
 
-## Load order
 Tableau loads connectors by directory in the following order:
 1. Built-in Tableau connectors
 1. Connectors located in ``C:\Program Files\Tableau\Connectors` (Windows) or `/opt/tableau/connectors` (Linux)

--- a/docs/templates/tableau-server.md
+++ b/docs/templates/tableau-server.md
@@ -4,9 +4,8 @@ title: Tableau Server Installation Instructions Template
 
 1. Download the Connector file (.taco).
 2. Move the .taco file here:
-   -  Tableau Server: `[Tableau_Server_Installation_Directory]/data/tabsvc/vizqlserver/Connectors`
-   -  Tableau Prep Conductor: `[Tableau_Server_Installation_Directory]/data/tabsvc/flowprocessor/Connectors`
-   -  Tableau Flow Web Authoring: `[Tableau_Server_Installation_Directory]/data/tabsvc/flowqueryservice/Connectors`
+    - Windows: `C:\Program Files\Tableau\Connectors`
+    - Linux: `/opt/tableau/connectors`
 1. For a multi-node Tableau server, copy the Connector file (.taco) in the correct folder for each server node.
 3. Start Tableau and under **Connect**, select the `[Connector Name]` connector. (**Note**: You will be prompted if the driver is not yet installed.)
 4. Go to the [Driver Download](https://www.driver-download-link-here.com) page.


### PR DESCRIPTION
- Document Shared Taco directory as an option for Server. Label it as our preferred option.
- Properly document minerva directory for old way of installing on Server
- Update the installation templates for Server.
