### PR TITLE
Story 1324999: Warn users when server is not present as required attribute

### DIFF
--- a/connector-packager/connector_packager/xsd_validator.py
+++ b/connector-packager/connector_packager/xsd_validator.py
@@ -210,6 +210,7 @@ def validate_file_specific_rules_connection_fields(file_to_test: ConnectorFile, 
             if field_name in field_names:
                 xml_violations_buffer.append("A field with the field name = " + field_name +
                                                 " already exists. Cannot have multiple fields with the same name.")
+                                                
 
                 return False
             if field_name == 'instanceurl':
@@ -354,11 +355,19 @@ def warn_file_specific_rules_tdr(path_to_file: Path):
         return
 
     authentication_attr_exists = False
+    server_attr_exists = False
     for attr in attribute_list.iter('attr'):
         if attr.text == 'authentication':
             authentication_attr_exists = True
-            break
+
+        if attr.text == 'server':
+            server_attr_exists = True
+            
 
     if not authentication_attr_exists:
         logger.warning("Warning: 'authentication' attribute is missing from "
                        "<connection-normalizer>/<required-attributes>/<attribute-list> in " + str(path_to_file) + ".")
+
+    if not server_attr_exists:
+            logger.warning("Warning: 'server' attribute is missing from "
+                        "<connection-normalizer>/<required-attributes>/<attribute-list> in " + str(path_to_file) + ".")

--- a/connector-packager/connector_packager/xsd_validator.py
+++ b/connector-packager/connector_packager/xsd_validator.py
@@ -211,7 +211,6 @@ def validate_file_specific_rules_connection_fields(file_to_test: ConnectorFile, 
                 xml_violations_buffer.append("A field with the field name = " + field_name +
                                                 " already exists. Cannot have multiple fields with the same name.")
                                                 
-
                 return False
             if field_name == 'instanceurl':
                 used_for_oauth = False
@@ -363,7 +362,6 @@ def warn_file_specific_rules_tdr(path_to_file: Path):
         if attr.text == 'server':
             server_attr_exists = True
             
-
     if not authentication_attr_exists:
         logger.warning("Warning: 'authentication' attribute is missing from "
                        "<connection-normalizer>/<required-attributes>/<attribute-list> in " + str(path_to_file) + ".")

--- a/connector-packager/tests/test_resources/server_attribute/connection_fields_with_no_server.xml
+++ b/connector-packager/tests/test_resources/server_attribute/connection_fields_with_no_server.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<connection-fields>
+
+  <field name="port" label="Port" value-type="string" category="endpoint" default-value="5432" />
+
+  <field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="auth-user-pass" />
+
+  <field name="username" label="Username" value-type="string" category="authentication" />
+
+  <field name="password" label="Password" value-type="string" category="authentication" secure="true" />
+
+</connection-fields>

--- a/connector-packager/tests/test_resources/server_attribute/connection_fields_with_server.xml
+++ b/connector-packager/tests/test_resources/server_attribute/connection_fields_with_server.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<connection-fields>
+  <field name="server" label="Server" value-type="string" category="endpoint" >
+    <validation-rule reg-exp="^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$"/>
+  </field>
+
+  <field name="port" label="Port" value-type="string" category="endpoint" default-value="5432" />
+
+  <field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="auth-user-pass" />
+
+  <field name="username" label="Username" value-type="string" category="authentication" />
+
+  <field name="password" label="Password" value-type="string" category="authentication" secure="true" />
+
+</connection-fields>

--- a/connector-packager/tests/test_resources/server_attribute/no_required_attributes_list.tdr
+++ b/connector-packager/tests/test_resources/server_attribute/no_required_attributes_list.tdr
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<tdr class='postgres_odbc'>
+  <connection-resolver>
+    <connection-builder>
+      <script file='connectionBuilder.js'/>
+    </connection-builder>
+  </connection-resolver>
+</tdr>

--- a/connector-packager/tests/test_resources/server_attribute/with_server.tdr
+++ b/connector-packager/tests/test_resources/server_attribute/with_server.tdr
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<tdr class='postgres_odbc'>
+  <connection-resolver>
+    <connection-builder>
+      <script file='connectionBuilder.js'/>
+    </connection-builder>
+    <connection-normalizer>
+      <required-attributes>
+        <attribute-list>
+          <attr>class</attr>
+          <attr>server</attr>
+          <attr>port</attr>
+          <attr>dbname</attr>
+          <attr>authentication</attr>
+          <attr>username</attr>
+          <attr>password</attr>
+        </attribute-list>
+      </required-attributes>
+    </connection-normalizer>
+  </connection-resolver>
+</tdr>

--- a/connector-packager/tests/test_resources/server_attribute/without_server.tdr
+++ b/connector-packager/tests/test_resources/server_attribute/without_server.tdr
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<tdr class='postgres_odbc'>
+  <connection-resolver>
+    <connection-builder>
+      <script file='connectionBuilder.js'/>
+    </connection-builder>
+    <connection-normalizer>
+      <required-attributes>
+        <attribute-list>
+          <attr>class</attr>
+          <attr>port</attr>
+          <attr>dbname</attr>
+          <attr>authentication</attr>
+          <attr>username</attr>
+          <attr>password</attr>
+        </attribute-list>
+      </required-attributes>
+    </connection-normalizer>
+  </connection-resolver>
+</tdr>

--- a/connector-packager/tests/test_xsd_validator.py
+++ b/connector-packager/tests/test_xsd_validator.py
@@ -332,3 +332,37 @@ class TestXSDValidator(unittest.TestCase):
         properties.is_jdbc = True
         self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer, properties),
                         "required connection-properties found and marked as invalid")
+
+    def test_warn_server_attribute(self):
+        file_to_test = ConnectorFile("connectionResolver.tdr", "connection-resolver")
+        
+        print("\nTest no warning when server is in required attributes list.")
+        test_tdr_file = TEST_FOLDER / "server_attribute/with_server.tdr"
+        with self.assertLogs('packager_logger', level='WARNING') as cm:
+            # Log a dummy message so that the log will exist.
+            logging.getLogger('packager_logger').warning('dummy message')
+            warn_file_specific_rules(file_to_test, test_tdr_file)
+
+        self.assertEqual(len(cm.output), 1)
+        self.assertNotIn("'server' attribute is missing", cm.output[0],
+                         "\"'server' attribute is missing\" found in warning message")
+
+        print("Test no warning when required attributes list is not specified.")
+        test_tdr_file = TEST_FOLDER / "server_attribute/no_required_attributes_list.tdr"
+        with self.assertLogs('packager_logger', level='WARNING') as cm:
+            # Log a dummy message so that the log will exist.
+            logging.getLogger('packager_logger').warning('dummy message')
+            warn_file_specific_rules(file_to_test, test_tdr_file)
+
+        self.assertEqual(len(cm.output), 1)
+        self.assertNotIn("'server' attribute is missing", cm.output[0],
+                         "\"'server' attribute is missing\" found in warning message")
+
+        print("Test warning when server attribute is not in required attributes list.")
+        test_tdr_file = TEST_FOLDER / "server_attribute/without_server.tdr"
+        with self.assertLogs('packager_logger', level='WARNING') as cm:
+            warn_file_specific_rules(file_to_test, test_tdr_file)
+
+        self.assertEqual(len(cm.output), 1)
+        self.assertIn("'server' attribute is missing", cm.output[0],
+                      "\"'server' attribute is missing\" not found in warning message")

--- a/connector-packager/tests/test_xsd_validator.py
+++ b/connector-packager/tests/test_xsd_validator.py
@@ -335,7 +335,7 @@ class TestXSDValidator(unittest.TestCase):
 
     def test_warn_server_attribute(self):
         file_to_test = ConnectorFile("connectionResolver.tdr", "connection-resolver")
-        
+
         print("\nTest no warning when server is in required attributes list.")
         test_tdr_file = TEST_FOLDER / "server_attribute/with_server.tdr"
         with self.assertLogs('packager_logger', level='WARNING') as cm:


### PR DESCRIPTION
[SDK] Packager to enforce 'server' as a required attribute
- Added the packager to warn users when 'server' is not present in the attribute list 
- Added tests to check this the code functions as intended. 