### PR TITLE
Fix broken links

### DIFF
--- a/docs/security-considerations.md
+++ b/docs/security-considerations.md
@@ -17,7 +17,7 @@ Currently the only field that can be marked secure is `password`. This means tha
 
 Examples of problematic UI fields that will be rejected:
 - Proxy Password
-- OAuth secrets (Use the official [Tableau OAuth flow](({{ site.baseurl }}/docs/oauth)) instead)
+- OAuth secrets (Use the official [Tableau OAuth flow]({{ site.baseurl }}/docs/oauth) instead)
 - **Freeform Driver Properties** (See following section)
 
 ## Freeform Driver Properties
@@ -25,8 +25,8 @@ Examples of problematic UI fields that will be rejected:
 **Freeform Driver Properties fields are not supported in the Connector SDK, and connectors using them will not be approved for the Tableau Exchange.** A "Freeform Driver Properties" field allows the user to manually enter key-value pairs that will be passed directly to the driver. However, because all vendor-defined fields are non-secure, these key-value pairs will be logged in plain text and persisted in easily-inspectable XML in Tableau workbooks, datasources and Prep flows. Many driver properties are considered sensitive, and we cannot enforce that users will not enter these sensitive key-value pairs, therefore we consider "Freeform Driver Properties" fields a security vulnerability.
 
 We recommend the following workarounds instead of an "Freeform Driver Properties" field:
-- To unblock users needing to set non-sensitive driver properties, add them as separate fields on the Advanced tab using [Connection Dialogs V2 framework](({{ site.baseurl }}/docs/mcd))
-- For JDBC, Customers can set driver properties using [JDBC Properties files](https://kb.tableau.com/articles/howto/Customizing-JDBC-Connections)
+- To unblock users needing to set non-sensitive driver properties, add them as separate fields on the Advanced tab using [Connection Dialogs V2 framework]({{ site.baseurl }}/docs/mcd)
+- For JDBC, Customers can set driver properties using [JDBC Properties files](https://help.tableau.com/current/pro/desktop/en-us/connect_customize.htm#use-a-properties-file-to-customize-a-jdbc-connection)
 
 # Driver Vulnerabilities
 


### PR DESCRIPTION
- Internal links had extra pair of parentheses
- Fix link to Tableau help page
