### PR TITLE
Add table of contents to doc pages

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2,6 +2,10 @@
 title: Connector API Reference
 ---
 
+**In this section**
+
+* TOC
+{:toc}
 ## Connection Resolver \*.tdr
 
 Defines the connection to your data source.
@@ -168,7 +172,7 @@ Returns the Tableau product name. This value should not be used for conditional 
 
     String GetProductVersion();
 
-Returns the Tableau version as a string in Version.MaintenanceRelease format. This value should not be used for conditional logic within the connector. Available in Tableau 2022.1 and newer. Example value: `2022.1.3` 
+Returns the Tableau version as a string in Version.MaintenanceRelease format. This value should not be used for conditional logic within the connector. Available in Tableau 2022.1 and newer. Example value: `2022.1.3`
 
     String GetPlatform();
 

--- a/docs/auth-modes.md
+++ b/docs/auth-modes.md
@@ -2,6 +2,12 @@
 title: Authentication Modes
 ---
 
+**In this section**
+
+* TOC
+{:toc}
+
+## Overview
 The authentication mode influences how and when a user is prompted to enter data source credentials. The primary scenarios where authentication occurs:
 
 - Creating a connection with the connection dialog

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -2,58 +2,50 @@
 title: Capabilities
 ---
 
-Use Tableau capabilities to customize and tune your connector behavior. 
+Use Tableau capabilities to customize and tune your connector behavior.
 
-- [Metadata](#metadata)
-- [Temporary Tables](#temporary-tables)
-- [String Splits](#string-splits)
-- [Initial SQL](#initial-sql)
-- [Query](#query)
-- [JDBC](#jdbc)
-- [ODBC](#odbc)
-- [Stored Procedures](#stored-procedures)
-- [Isolation Level](#isolation-level)
-- [Uncommon](#uncommon)
+* TOC
+{:toc}
 
 **Read the table**
 
-Entry | Description 
--|- 
+Entry | Description
+-|-
 &ndash; | There is no default or recommended value for this capability. If you use this capability, you need to verify that the value you use is correct for your database.
 ? | You need to verify that the value you use is correct for your database.
 **<span style="color:red">Red</span>** | The recommended value is different than the default value.
 
 ## Metadata
 
-Capability | Description | Default | Recommended 
+Capability | Description | Default | Recommended
 -|-|-|-
-CAP_FAST_METADATA | Set to 'yes' if you have small to moderate size schemas. This capability controls whether Tableau should enumerate all of the objects immediately when you connect. Set the value to “yes” to enable this capability for better performance when creating connections. Disable this capability to allow search for specific schemas or tables instead of retrieving all objects. You can search for all objects by using an empty string. | yes | yes 
-CAP_QUERY_TOP_0_METADATA | Set to 'yes' if the data source can handle a "TOP 0" request for retrieving metadata | no | **<span style="color:red">?</span>**    
-CAP_QUERY_WHERE_FALSE_METADATA | Set to 'yes' if the data source can handle a "WHERE \<false\>" predicate for retrieving metadata | &ndash; | **<span style="color:red">?</span>** 
+CAP_FAST_METADATA | Set to 'yes' if you have small to moderate size schemas. This capability controls whether Tableau should enumerate all of the objects immediately when you connect. Set the value to “yes” to enable this capability for better performance when creating connections. Disable this capability to allow search for specific schemas or tables instead of retrieving all objects. You can search for all objects by using an empty string. | yes | yes
+CAP_QUERY_TOP_0_METADATA | Set to 'yes' if the data source can handle a "TOP 0" request for retrieving metadata | no | **<span style="color:red">?</span>**
+CAP_QUERY_WHERE_FALSE_METADATA | Set to 'yes' if the data source can handle a "WHERE \<false\>" predicate for retrieving metadata | &ndash; | **<span style="color:red">?</span>**
 
 ## Temporary Tables
 
 Capability | Description | Default | Recommended
 -|-|-|-
-CAP_CREATE_TEMP_TABLES | Set to 'yes' if Tableau can create temporary tables needed for certain complex or optimized queries. Set to 'no' if creating temporary tables is not supported. See also: CAP_SELECT_INTO. | &ndash; | **<span style="color:red">?</span>**  
-CAP_INDEX_TEMP_TABLES | Set to 'yes' if data source supports creation of indexes on temp tables database | &ndash; | &ndash; 
+CAP_CREATE_TEMP_TABLES | Set to 'yes' if Tableau can create temporary tables needed for certain complex or optimized queries. Set to 'no' if creating temporary tables is not supported. See also: CAP_SELECT_INTO. | &ndash; | **<span style="color:red">?</span>**
+CAP_INDEX_TEMP_TABLES | Set to 'yes' if data source supports creation of indexes on temp tables database | &ndash; | &ndash;
 CAP_QUERY_USE_TEMP_TABLE_NAMES_AS_SUBQUERY_ALIASES | Set to 'yes' if Tableau must use generated temporary table names for aliases of subqueries because they might end up implemented as temporary tables | no | no
-CAP_SELECT_INTO | Set to 'yes' if Tableau can create a table on the fly from the resultset of another query. See also: CAP_CREATE_TEMP_TABLES. | &ndash; | **<span style="color:red">?</span>**   
-CAP_SELECT_TOP_INTO | Set to 'yes' if Tableau can use a TOP or LIMIT row-limiting clause when creating a table from a query resultset. | &ndash; | **<span style="color:red">?</span>**   
+CAP_SELECT_INTO | Set to 'yes' if Tableau can create a table on the fly from the resultset of another query. See also: CAP_CREATE_TEMP_TABLES. | &ndash; | **<span style="color:red">?</span>**
+CAP_SELECT_TOP_INTO | Set to 'yes' if Tableau can use a TOP or LIMIT row-limiting clause when creating a table from a query resultset. | &ndash; | **<span style="color:red">?</span>**
 CAP_ODBC_METADATA_FORCE_UTF8_TEMP_TABLE_COLUMN_SIZE | Set to 'yes' if when creating temp tables specify the size of varchar columns in bytes. | &ndash; | &ndash;
-CAP_TEMP_TABLES_NOT_SESSION_SCOPED | Set to 'yes' if this data source uses regular tables to simulate temp tables. Temporary table creation is still controlled by CAP_CREATE_TEMP_TABLE or CAP_SELECT_INTO | &ndash; | &ndash; 
-CAP_SUPPRESS_TEMP_TABLE_CHECKS | Set to 'yes' to skip the connection time check that determines if the user has permission to create temp tables. | no | no 
+CAP_TEMP_TABLES_NOT_SESSION_SCOPED | Set to 'yes' if this data source uses regular tables to simulate temp tables. Temporary table creation is still controlled by CAP_CREATE_TEMP_TABLE or CAP_SELECT_INTO | &ndash; | &ndash;
+CAP_SUPPRESS_TEMP_TABLE_CHECKS | Set to 'yes' to skip the connection time check that determines if the user has permission to create temp tables. | no | no
 
-## String Splits 
+## String Splits
 
-Capability | Description | Default | Recommended 
+Capability | Description | Default | Recommended
 -|-|-|-
-CAP_SUPPORTS_SPLIT_FROM_LEFT | Set to 'yes' if data source supports splitting a string from the left | &ndash; | **<span style="color:red">yes</span>**  
-CAP_SUPPORTS_SPLIT_FROM_RIGHT | Set to 'yes' if data source supports splitting a string from the right | &ndash; | **<span style="color:red">?</span>**  
+CAP_SUPPORTS_SPLIT_FROM_LEFT | Set to 'yes' if data source supports splitting a string from the left | &ndash; | **<span style="color:red">yes</span>**
+CAP_SUPPORTS_SPLIT_FROM_RIGHT | Set to 'yes' if data source supports splitting a string from the right | &ndash; | **<span style="color:red">?</span>**
 
-## Initial SQL 
+## Initial SQL
 
-Capability | Description | Default | Recommended 
+Capability | Description | Default | Recommended
 -|-|-|-
 CAP_SUPPORTS_INITIAL_SQL | Set to 'yes' to enable Initial SQL on the connection dialog. Available in Tableau 2020.3 and newer. | &ndash; | **<span style="color:red">yes</span>**
 
@@ -62,217 +54,217 @@ CAP_SUPPORTS_INITIAL_SQL | Set to 'yes' to enable Initial SQL on the connection 
 Capability | Description | Default | Recommended
 -|-|-|-
 CAP_QUERY_AGG_NO_BOOLEXPR | Set to 'yes' to transform boolean expressions to integers for arguments to aggregates. Available in Tableau 2020.2 and newer. | &ndash; | &ndash;
-CAP_QUERY_ALLOW_JOIN_REORDER | Set to 'yes' to use query optimization to reduce database work with some inner and equality joins. | yes | yes 
-CAP_QUERY_ALLOW_PARTIAL_AGGREGATION | Tableau can minimize data movement (and boost performance) in federated join scenarios by performing as much aggregation as possible in remote databases before shipping the data back. This can introduce additional groupbys on the fields used in the join condition. If the join is on a string field, not all data sources handle the additional groupbys on strings efficiently, leading to a rapid degradation in performance the more join key fields are used. | yes | yes 
-CAP_QUERY_BOOL_IDENTIFIER_TO_LOGICAL | Set to 'yes' if the dialect can handle WHEN [bit column] THEN or does it need something like WHEN [column] = 1 THEN. | &ndash; | &ndash; 
-CAP_QUERY_BOOLEXPR_TO_INTEXPR | Set to 'yes' if data source does not support booleans natively in a result set. Set to 'no' if booleans are supported natively. | &ndash; | **<span style="color:red">?</span>**   
-CAP_QUERY_CASE_MATCHES_NULL | Set to 'yes' if CASE can match a null in a valued CASE expression | no | no 
+CAP_QUERY_ALLOW_JOIN_REORDER | Set to 'yes' to use query optimization to reduce database work with some inner and equality joins. | yes | yes
+CAP_QUERY_ALLOW_PARTIAL_AGGREGATION | Tableau can minimize data movement (and boost performance) in federated join scenarios by performing as much aggregation as possible in remote databases before shipping the data back. This can introduce additional groupbys on the fields used in the join condition. If the join is on a string field, not all data sources handle the additional groupbys on strings efficiently, leading to a rapid degradation in performance the more join key fields are used. | yes | yes
+CAP_QUERY_BOOL_IDENTIFIER_TO_LOGICAL | Set to 'yes' if the dialect can handle WHEN [bit column] THEN or does it need something like WHEN [column] = 1 THEN. | &ndash; | &ndash;
+CAP_QUERY_BOOLEXPR_TO_INTEXPR | Set to 'yes' if data source does not support booleans natively in a result set. Set to 'no' if booleans are supported natively. | &ndash; | **<span style="color:red">?</span>**
+CAP_QUERY_CASE_MATCHES_NULL | Set to 'yes' if CASE can match a null in a valued CASE expression | no | no
 CAP_QUERY_CASE_OUT_NO_BOOL_OPS | Set to 'yes' if CASE outputs cannot contain boolean operators like AND/OR/NOT. Available in Tableau 2020.2 and newer. | &ndash; | &ndash;
-CAP_QUERY_CASE_PROMOTES_CHAR | Set to 'no' if CASE cannot promote character types? | yes | yes 
+CAP_QUERY_CASE_PROMOTES_CHAR | Set to 'no' if CASE cannot promote character types? | yes | yes
 CAP_QUERY_CAST_MONEY_AS_NUMERIC | Set to 'yes' to cast money as numeric. Available in Tableau 2021.1 and newer. | &ndash; | &ndash;
 CAP_QUERY_FROM_REQUIRES_ALIAS | Set to 'yes' if the FROM clause must provide an alias for the given table. | &ndash; | &ndash;
 CAP_QUERY_FULLJOIN_IND | Set to 'yes' to support full joins with Is-Not-Distinct semantics. | &ndash; | &ndash;
 CAP_QUERY_GROUP_ALLOW_DUPLICATES | Set to 'no' if SQL queries cannot contain duplicate expressions in the GROUP BY clause (this is uncommon). | yes | yes
-CAP_QUERY_GROUP_BY_ALIAS | Set to 'yes' if SQL queries with aggregations can reference the grouping columns by their corresponding alias in the SELECT list, for example, GROUP BY "none_ShipCountry_nk". | no | no 
-CAP_QUERY_GROUP_BY_BOOL | Set to 'yes' if the database can group by a raw boolean. Set to 'no' if booleans should be cast to an INT. Can also influence booleans in the SELECT clause. | no | **<span style="color:red">yes</span>** 
-CAP_QUERY_GROUP_BY_DEGREE | Set to 'yes' if SQL queries with aggregations can reference the grouping columns by the ordinal position of each column, for example, GROUP BY 2, 5. See also: CAP_QUERY_SORT_BY_DEGREE | no | **<span style="color:red">yes</span>**  
-CAP_QUERY_HAVING_REQUIRES_GROUP_BY | Set to 'yes' if Tableau must use an artificial grouping field for any query that has a HAVING clause but no grouping columns. | &ndash; | **<span style="color:red">?</span>** 
-CAP_QUERY_HAVING_UNSUPPORTED | Set to 'yes' if the SQL syntax for HAVING is unsupported. Sometimes Tableau can work around this using subqueries. See also: CAP_QUERY_SUBQUERIES. | &ndash; | &ndash; 
-CAP_QUERY_INCLUDE_GROUP_BY_COLUMNS_IN_SELECT | Set to 'yes' to require all GROUP BY expressions to also appear in the SELECT expression list. | &ndash; | &ndash; 
-CAP_QUERY_INCLUDE_HAVING_COLUMNS_IN_SELECT | Set to 'yes' if the HAVING columns are always needed in the SELECT clause | &ndash; | &ndash; 
-CAP_QUERY_INITIAL_SQL_SPLIT_STATEMENTS | Set to 'yes' if the data source requires multiple statements issued as separate queries for Initial SQL | &ndash; | **<span style="color:red">?</span>**  
-CAP_QUERY_INOUT_JOINS | Set to 'no' if the connection cannot handle the joins needed for IN/OUT set calculations | yes | yes 
-CAP_QUERY_JOIN_ACROSS_SCHEMAS | Set to 'yes' if SQL queries can express joins between tables located in different schemas. | no | **<span style="color:red">?</span>** 
+CAP_QUERY_GROUP_BY_ALIAS | Set to 'yes' if SQL queries with aggregations can reference the grouping columns by their corresponding alias in the SELECT list, for example, GROUP BY "none_ShipCountry_nk". | no | no
+CAP_QUERY_GROUP_BY_BOOL | Set to 'yes' if the database can group by a raw boolean. Set to 'no' if booleans should be cast to an INT. Can also influence booleans in the SELECT clause. | no | **<span style="color:red">yes</span>**
+CAP_QUERY_GROUP_BY_DEGREE | Set to 'yes' if SQL queries with aggregations can reference the grouping columns by the ordinal position of each column, for example, GROUP BY 2, 5. See also: CAP_QUERY_SORT_BY_DEGREE | no | **<span style="color:red">yes</span>**
+CAP_QUERY_HAVING_REQUIRES_GROUP_BY | Set to 'yes' if Tableau must use an artificial grouping field for any query that has a HAVING clause but no grouping columns. | &ndash; | **<span style="color:red">?</span>**
+CAP_QUERY_HAVING_UNSUPPORTED | Set to 'yes' if the SQL syntax for HAVING is unsupported. Sometimes Tableau can work around this using subqueries. See also: CAP_QUERY_SUBQUERIES. | &ndash; | &ndash;
+CAP_QUERY_INCLUDE_GROUP_BY_COLUMNS_IN_SELECT | Set to 'yes' to require all GROUP BY expressions to also appear in the SELECT expression list. | &ndash; | &ndash;
+CAP_QUERY_INCLUDE_HAVING_COLUMNS_IN_SELECT | Set to 'yes' if the HAVING columns are always needed in the SELECT clause | &ndash; | &ndash;
+CAP_QUERY_INITIAL_SQL_SPLIT_STATEMENTS | Set to 'yes' if the data source requires multiple statements issued as separate queries for Initial SQL | &ndash; | **<span style="color:red">?</span>**
+CAP_QUERY_INOUT_JOINS | Set to 'no' if the connection cannot handle the joins needed for IN/OUT set calculations | yes | yes
+CAP_QUERY_JOIN_ACROSS_SCHEMAS | Set to 'yes' if SQL queries can express joins between tables located in different schemas. | no | **<span style="color:red">?</span>**
 CAP_QUERY_JOIN_MISMATCHED_VARCHAR_WIDTHS | Set to 'yes' if join predicates have different widths for VARCHAR columns | yes | **<span style="color:red">?</span>**
 CAP_QUERY_JOIN_PREDICATE_REQUIRES_SCOPE | Set to 'yes' if join predicates must be enclosed in parens | yes | yes
 CAP_QUERY_JOIN_PUSH_DOWN_CONDITION_EXPRESSIONS | Set to 'yes' if the data source cannot handle complex expressions in join conditions (anything more complex than an identifier): JOIN ON [id]=[id] vs JOIN ON UPPER([State])=[State] | &ndash; | &ndash;
-CAP_QUERY_JOIN_REQUIRES_SCOPE | Set to 'yes' if SQL queries must scope each join clause within parentheses to ensure a proper order of evaluation. | &ndash; | &ndash; 
-CAP_QUERY_JOIN_REQUIRES_SUBQUERY | Set to ‘yes’ to force join expressions involving more than two tables to be composed with subqueries. | &ndash; | &ndash; 
+CAP_QUERY_JOIN_REQUIRES_SCOPE | Set to 'yes' if SQL queries must scope each join clause within parentheses to ensure a proper order of evaluation. | &ndash; | &ndash;
+CAP_QUERY_JOIN_REQUIRES_SUBQUERY | Set to ‘yes’ to force join expressions involving more than two tables to be composed with subqueries. | &ndash; | &ndash;
 CAP_QUERY_NAKED_JOINS | Set to 'yes' if Tableau needs to wrap the base relation to join filters | yes | yes
 CAP_QUERY_OUTER_JOIN_CONDITION_NO_TRIVIAL | Set to 'yes' to rewrite empty outer join conditions to non-trivial conditions. Available in Tableau 2020.1 and newer. | &ndash; | &ndash;
 CAP_QUERY_SCALAR_SELECTS_ALL_IN_GROUP_BYS | Set to 'yes' if all scalar selects must be in an aggregated query's GROUP BY clause | &ndash; | &ndash;
 CAP_QUERY_SCALAR_SELECTS_SOME_IN_GROUP_BYS | Set to 'yes' if some scalar selects must be in an aggregated query's GROUP BY clause. Available in Tableau 2020.2 and newer. | &ndash; | &ndash;
-CAP_QUERY_SELECT_ALIASES_SORTED | Set to 'yes' if Tableau must impose a deterministic order on the SELECT expressions (sorted by alias) to ensure that query results can be properly matched with each field in the Tableau visualization. This is only required for data sources that do not preserve the aliases of the SELECT expressions when returning metadata with the query results. | no | no  
-CAP_QUERY_SORT_BY | Set to 'yes' to enable the 'Field' option in the Sort menu | no | **<span style="color:red">yes</span>**  
-CAP_QUERY_SORT_BY_DEGREE | Set to 'yes' if SQL queries can reference the sorting columns by the ordinal position of each column, for example, ORDER BY 2, 5. See also: CAP_QUERY_GROUP_BY_DEGREE. | yes | **<span style="color:red">?</span>** 
-CAP_QUERY_SORT_BY_NON_NUMERIC | Set to 'no' if data source cannot sort by non-numeric values | yes | yes 
-CAP_QUERY_SUBQUERIES | Set to 'yes' if the data source supports subqueries. | &ndash; | **<span style="color:red">yes</span>** 
-CAP_QUERY_SUBQUERIES_WITH_TOP | Set to 'yes' if the data source supports a TOP or LIMIT row-limiting clause within a subquery. | yes | **<span style="color:red">?</span>**  
-CAP_QUERY_SUBQUERY_QUERY_CONTEXT | Set to 'yes' to force Tableau to use a subquery for context filters instead of a temporary table or locally cached results. | yes | yes 
-CAP_QUERY_SUPPORT_EMPTY_GROUPBY | Set to 'yes' if data source supports empty group by clause | &ndash; | &ndash; 
+CAP_QUERY_SELECT_ALIASES_SORTED | Set to 'yes' if Tableau must impose a deterministic order on the SELECT expressions (sorted by alias) to ensure that query results can be properly matched with each field in the Tableau visualization. This is only required for data sources that do not preserve the aliases of the SELECT expressions when returning metadata with the query results. | no | no
+CAP_QUERY_SORT_BY | Set to 'yes' to enable the 'Field' option in the Sort menu | no | **<span style="color:red">yes</span>**
+CAP_QUERY_SORT_BY_DEGREE | Set to 'yes' if SQL queries can reference the sorting columns by the ordinal position of each column, for example, ORDER BY 2, 5. See also: CAP_QUERY_GROUP_BY_DEGREE. | yes | **<span style="color:red">?</span>**
+CAP_QUERY_SORT_BY_NON_NUMERIC | Set to 'no' if data source cannot sort by non-numeric values | yes | yes
+CAP_QUERY_SUBQUERIES | Set to 'yes' if the data source supports subqueries. | &ndash; | **<span style="color:red">yes</span>**
+CAP_QUERY_SUBQUERIES_WITH_TOP | Set to 'yes' if the data source supports a TOP or LIMIT row-limiting clause within a subquery. | yes | **<span style="color:red">?</span>**
+CAP_QUERY_SUBQUERY_QUERY_CONTEXT | Set to 'yes' to force Tableau to use a subquery for context filters instead of a temporary table or locally cached results. | yes | yes
+CAP_QUERY_SUPPORT_EMPTY_GROUPBY | Set to 'yes' if data source supports empty group by clause | &ndash; | &ndash;
 CAP_QUERY_SUPPORTS_UNIQUE_IDENTIFIER | Set to 'yes' if data source supports uniqueidentifier data type. Available in Tableau 2020.1 and newer. | &ndash; | &ndash;
-CAP_QUERY_TIME_REQUIRES_CAST | Set to 'yes' if the time columns must be cast to timestamp/datetime. This capability applies to ODBC connectors. | &ndash; | &ndash; 
+CAP_QUERY_TIME_REQUIRES_CAST | Set to 'yes' if the time columns must be cast to timestamp/datetime. This capability applies to ODBC connectors. | &ndash; | &ndash;
 CAP_QUERY_TOP_0 | Set to 'no' if the server cannot handle a "TOP 0" request | yes | yes
-CAP_QUERY_TOP_N | Set to 'yes' if the data source supports any form of row-limiting clause. The exact forms supported are described below. | no | **<span style="color:red">yes</span>** 
-CAP_QUERY_TOP_PERCENT | Set to 'yes' if TOP supports percent | no | **<span style="color:red">?</span>** 
-CAP_QUERY_TOP_SAMPLE | Set to 'yes' if TOP supports sampling rows | no | **<span style="color:red">?</span>**  
-CAP_QUERY_TOP_SAMPLE_FAST | Set to 'yes' if TOP with sampling is faster than TOP | no | no 
-CAP_QUERY_TOP_SAMPLE_PERCENT | Set to 'yes' if TOP supports sampling by percentages | no | **<span style="color:red">?</span>**  
+CAP_QUERY_TOP_N | Set to 'yes' if the data source supports any form of row-limiting clause. The exact forms supported are described below. | no | **<span style="color:red">yes</span>**
+CAP_QUERY_TOP_PERCENT | Set to 'yes' if TOP supports percent | no | **<span style="color:red">?</span>**
+CAP_QUERY_TOP_SAMPLE | Set to 'yes' if TOP supports sampling rows | no | **<span style="color:red">?</span>**
+CAP_QUERY_TOP_SAMPLE_FAST | Set to 'yes' if TOP with sampling is faster than TOP | no | no
+CAP_QUERY_TOP_SAMPLE_PERCENT | Set to 'yes' if TOP supports sampling by percentages | no | **<span style="color:red">?</span>**
 CAP_QUERY_USE_DOMAIN_EXCEPT_OPTIMIZATION | When the number of selected items in a filter is greater than half the total number of items in the domain, save the excluded items instead of the included items to save space. Available in Tableau 2022.2 and newer. | yes | yes
 CAP_QUERY_USE_DOMAIN_RANGES_OPTIMIZATION | Set to 'no' if domain ranges cannot be used to optimize set functions. | yes | yes
 CAP_QUERY_USE_DOMAIN_RANGES_OPTIMIZATION_STRINGS | Set to ‘yes’ if domain ranges should be used to optimize set functions for string data. Available in Tableau 2022.2 and newer. | no | no
-CAP_QUERY_USE_QUERY_FUSION | Set to ‘no’ to prevent Tableau from combining multiple individual queries into a single combined query. Turn off this capability for performance tuning or if the database is unable to process large queries.  | yes | yes 
-CAP_QUERY_WRAP_SUBQUERY_WITH_TOP | Set to 'yes' if the server can handle a subquery wrapped with only a TOP clause | no | no 
+CAP_QUERY_USE_QUERY_FUSION | Set to ‘no’ to prevent Tableau from combining multiple individual queries into a single combined query. Turn off this capability for performance tuning or if the database is unable to process large queries.  | yes | yes
+CAP_QUERY_WRAP_SUBQUERY_WITH_TOP | Set to 'yes' if the server can handle a subquery wrapped with only a TOP clause | no | no
 
 
-## JDBC 
+## JDBC
 
-Capability | Description | Default | Recommended 
+Capability | Description | Default | Recommended
 -|-|-|-
-CAP_JDBC_BIND_BIGDECIMAL_STRING | Set to 'yes' to bind bigdecimal as string for JDBC. Available in Tableau 2020.1 and newer. | &ndash; | &ndash; 
-CAP_JDBC_BIND_DETECT_ALIAS_CASE_FOLDING | Set to 'yes' to allow Tableau to detect and recover from a JDBC data source that reports the field names in a result set using only upper-case or lower-case characters, instead of the expected field names.  | &ndash;  | &ndash; 
+CAP_JDBC_BIND_BIGDECIMAL_STRING | Set to 'yes' to bind bigdecimal as string for JDBC. Available in Tableau 2020.1 and newer. | &ndash; | &ndash;
+CAP_JDBC_BIND_DETECT_ALIAS_CASE_FOLDING | Set to 'yes' to allow Tableau to detect and recover from a JDBC data source that reports the field names in a result set using only upper-case or lower-case characters, instead of the expected field names.  | &ndash;  | &ndash;
 CAP_JDBC_BIND_SPATIAL_AS_WKB | Set to 'yes' to use WKB for spatial types serialization. Available in Tableau 2020.4 and newer. | &ndash; | &ndash;
 CAP_JDBC_CONVERT_WKB_HEX_STRING | Set to 'yes' to convert a hex string to regular WKB. Available in Tableau 2020.4 and newer. | &ndash; | &ndash;
-CAP_JDBC_EXPORT_BIND_BOOL_AS_INTEGER  | Set to 'yes' to bind Tableau booleans to integer for data insertion. Available in Tableau 2020.2 and newer. | &ndash; | &ndash; 
-CAP_JDBC_EXPORT_DATA_BATCH | Set to 'no' to disable the use of JDBC batch operations for data insert. | yes | yes 
+CAP_JDBC_EXPORT_BIND_BOOL_AS_INTEGER  | Set to 'yes' to bind Tableau booleans to integer for data insertion. Available in Tableau 2020.2 and newer. | &ndash; | &ndash;
+CAP_JDBC_EXPORT_DATA_BATCH | Set to 'no' to disable the use of JDBC batch operations for data insert. | yes | yes
 CAP_JDBC_INSERT_COERCE_INT_TO_BOOL | Set to 'yes' to convert integer type to boolean only when the column type and source type are different. Available in Tableau 2021.2 and newer. | &ndash; | &ndash;
 CAP_JDBC_MAX_STRING_LENGTH_MEDIUM | Set to 'yes' to use 512 character string length limit. Default is 16K. Available in Tableau 2020.4 and newer. | &ndash; | &ndash;
-CAP_JDBC_METADATA_GET_INDEX_INFO | Set to 'no' to disable reading index info | yes | yes  
+CAP_JDBC_METADATA_GET_INDEX_INFO | Set to 'no' to disable reading index info | yes | yes
 CAP_JDBC_METADATA_IGNORE_NULLABILITY | Set to 'yes' to ignore column nullability retrieved from query metadata and always set it to true for all columns in the query result. Available in Tableau 2020.4 and newer. | &ndash; | &ndash;
 CAP_JDBC_METADATA_NUMERIC_DEFAULT_PREC_SCALE_DOUBLE | Set to 'yes' to use precision=17 and no scale for numeric with undefined precision/scale. Available in Tableau 2020.4 and newer. | &ndash; | &ndash;
-CAP_JDBC_METADATA_READ_FOREIGNKEYS | Set to 'no' to disable reading foreign key metadata | yes | yes   
-CAP_JDBC_METADATA_READ_PRIMARYKEYS | Set to 'no' to disable reading primary key metadata | yes | yes 
+CAP_JDBC_METADATA_READ_FOREIGNKEYS | Set to 'no' to disable reading foreign key metadata | yes | yes
+CAP_JDBC_METADATA_READ_PRIMARYKEYS | Set to 'no' to disable reading primary key metadata | yes | yes
 CAP_JDBC_METADATA_USE_RESULTSET_FOR_TABLE | Set to 'yes' to get column metadata from the result set of a select * query. Available in Tableau 2020.4 and newer. | &ndash; | &ndash;
 CAP_JDBC_METADATA_SUPPRESS_PREPARED_QUERY | If CAP_JDBC_METADATA_USE_RESULTSET_FOR_TABLE is enabled, set this capability to 'yes' to disable preparing the query used for reading the table metadata. We will execute the query wrapped with a where-false clause. | &ndash; | &ndash;
-CAP_JDBC_PARAMETER_METADATA_REQUIRES_EXECUTE | Set to 'yes' if retrieving parameter metadata for inserts requires execution of an empty batch. Available in Tableau 2020.2 and newer. | &ndash; | &ndash; 
+CAP_JDBC_PARAMETER_METADATA_REQUIRES_EXECUTE | Set to 'yes' if retrieving parameter metadata for inserts requires execution of an empty batch. Available in Tableau 2020.2 and newer. | &ndash; | &ndash;
 CAP_JDBC_QUERY_ASYNC | Set to 'yes' to run queries on another thread. | &ndash; | **<span style="color:red">yes</span>**
 CAP_JDBC_QUERY_CANCEL | Set to 'yes' if driver can cancel queries. Requires CAP_JDBC_QUERY_ASYNC to be set. | yes | yes
 CAP_JDBC_QUERY_DISABLE_AUTO_COMMIT | Set to 'yes' to disable the default auto-commit mode when running query. Available in Tableau 2020.4 and newer. | &ndash; | &ndash;
 CAP_JDBC_QUERY_FORCE_PREPARE | Set to 'yes' to always prepare the query before execution. Available in Tableau 2020.4 and newer. | &ndash; | &ndash;
 CAP_JDBC_SUPPRESS_EMPTY_CATALOG_NAME | Set to 'yes' to ignore missing catalog. | &ndash; | &ndash;
 CAP_JDBC_SUPPRESS_EMPTY_SCHEMA_NAME | Set to 'yes' to ignore missing schema. Available in Tableau 2022.2 and newer. | &ndash; | &ndash;
-CAP_JDBC_SUPPRESS_ENUMERATE_DATABASES | Set to 'yes' to disable database enumeration. | &ndash; | &ndash; 
-CAP_JDBC_SUPPRESS_ENUMERATE_SCHEMAS | Set to 'yes' to disable schema enumeration. | &ndash; | &ndash; 
-CAP_JDBC_SUPPRESS_ENUMERATE_TABLES | Set to 'yes' to disable table enumeration. | &ndash; | &ndash; 
+CAP_JDBC_SUPPRESS_ENUMERATE_DATABASES | Set to 'yes' to disable database enumeration. | &ndash; | &ndash;
+CAP_JDBC_SUPPRESS_ENUMERATE_SCHEMAS | Set to 'yes' to disable schema enumeration. | &ndash; | &ndash;
+CAP_JDBC_SUPPRESS_ENUMERATE_TABLES | Set to 'yes' to disable table enumeration. | &ndash; | &ndash;
 CAP_JDBC_SET_CLIENT_INFO | Enable the JDBC setClientInfo API to pass trace information to the database. Available in Tableau 2021.2 and newer for on-premises Tableau Server. Needs additional configuration see documentation. | &ndash; | &ndash;
-CAP_JDBC_TRIM_STRING_PADDING | Set to 'yes' to trim trailing whitespace from string columns that have been added by the driver. Available in Tableau 2020.1 and newer. | &ndash; | &ndash; 
+CAP_JDBC_TRIM_STRING_PADDING | Set to 'yes' to trim trailing whitespace from string columns that have been added by the driver. Available in Tableau 2020.1 and newer. | &ndash; | &ndash;
 CAP_JDBC_USE_ADAPTIVE_FETCH_SIZE | Set to 'yes' to use ResultSet metadata to determine optimal fetch size. May require CAP_JDBC_QUERY_FORCE_PREPARE to be enabled to work properly. Available in Tableau 2020.4 and newer. | yes | &ndash;
 CAP_JDBC_USE_SINGLE_ROW_FETCH | Set to 'yes' to use single row fetch. May require CAP_JDBC_QUERY_FORCE_PREPARE. Available in Tableau 2020.4 and newer. | &ndash; | &ndash;
 
-## ODBC 
+## ODBC
 
-Capability | Description | Default | Recommended 
+Capability | Description | Default | Recommended
 -|-|-|-
-CAP_ODBC_BIND_BOOL_AS_WCHAR_01LITERAL | Set to 'yes' to bind a Boolean data type as a WCHAR containing values '0' or '1'. | &ndash; | &ndash; 
-CAP_ODBC_BIND_BOOL_AS_WCHAR_TFLITERAL | Set to 'yes' to bind a Boolean data type as WCHAR containing values 't' or 'f'. | &ndash; | &ndash; 
-CAP_ODBC_BIND_DETECT_ALIAS_CASE_FOLDING | Set to 'yes' to allow Tableau to detect and recover from an ODBC data source that reports the field names in a result set using only upper-case or lower-case characters, instead of the expected field names. | &ndash; | &ndash; 
-CAP_ODBC_BIND_FORCE_DATE_AS_CHAR | Set to 'yes' to force the Tableau native ODBC protocol to bind date values as CHAR. | &ndash; | &ndash; 
-CAP_ODBC_BIND_FORCE_DATETIME_AS_CHAR | Set to 'yes' to force the Tableau native ODBC protocol to bind datetime values as CHAR. | &ndash; | &ndash; 
-CAP_ODBC_BIND_FORCE_MAX_STRING_BUFFERS | Set to 'yes' to force the Tableau native ODBC protocol to use maximum-sized buffers (1 MB) for strings instead of the size described by metadata. | &ndash; | &ndash; 
-CAP_ODBC_BIND_FORCE_MEDIUM_STRING_BUFFERS | Set to 'yes' to force the Tableau native ODBC protocol to use medium-sized buffers (1 K) for strings instead of the size described by metadata. | &ndash; | &ndash; 
-CAP_ODBC_BIND_FORCE_SIGNED | Set to 'yes' to force binding integers as signed. | &ndash; | &ndash; 
-CAP_ODBC_BIND_FORCE_SMALL_STRING_BUFFERS | Set to 'yes' to force the Tableau native ODBC protocol to use small buffers for strings instead of the size described by metadata. | &ndash; | &ndash; 
-CAP_ODBC_BIND_PRESERVE_BOM | Set to 'yes' to preserve BOM when present in strings. Hive will return BOM and treat strings containing it as distinct entities. | &ndash; | &ndash; 
+CAP_ODBC_BIND_BOOL_AS_WCHAR_01LITERAL | Set to 'yes' to bind a Boolean data type as a WCHAR containing values '0' or '1'. | &ndash; | &ndash;
+CAP_ODBC_BIND_BOOL_AS_WCHAR_TFLITERAL | Set to 'yes' to bind a Boolean data type as WCHAR containing values 't' or 'f'. | &ndash; | &ndash;
+CAP_ODBC_BIND_DETECT_ALIAS_CASE_FOLDING | Set to 'yes' to allow Tableau to detect and recover from an ODBC data source that reports the field names in a result set using only upper-case or lower-case characters, instead of the expected field names. | &ndash; | &ndash;
+CAP_ODBC_BIND_FORCE_DATE_AS_CHAR | Set to 'yes' to force the Tableau native ODBC protocol to bind date values as CHAR. | &ndash; | &ndash;
+CAP_ODBC_BIND_FORCE_DATETIME_AS_CHAR | Set to 'yes' to force the Tableau native ODBC protocol to bind datetime values as CHAR. | &ndash; | &ndash;
+CAP_ODBC_BIND_FORCE_MAX_STRING_BUFFERS | Set to 'yes' to force the Tableau native ODBC protocol to use maximum-sized buffers (1 MB) for strings instead of the size described by metadata. | &ndash; | &ndash;
+CAP_ODBC_BIND_FORCE_MEDIUM_STRING_BUFFERS | Set to 'yes' to force the Tableau native ODBC protocol to use medium-sized buffers (1 K) for strings instead of the size described by metadata. | &ndash; | &ndash;
+CAP_ODBC_BIND_FORCE_SIGNED | Set to 'yes' to force binding integers as signed. | &ndash; | &ndash;
+CAP_ODBC_BIND_FORCE_SMALL_STRING_BUFFERS | Set to 'yes' to force the Tableau native ODBC protocol to use small buffers for strings instead of the size described by metadata. | &ndash; | &ndash;
+CAP_ODBC_BIND_PRESERVE_BOM | Set to 'yes' to preserve BOM when present in strings. Hive will return BOM and treat strings containing it as distinct entities. | &ndash; | &ndash;
 CAP_ODBC_BIND_SKIP_LOCAL_DATATYPE_UNKNOWN | Set to 'yes' to prevent the native ODBC Protocol from binding to columns having local data type DataType::Unknown in the expected metadata | &ndash; | &ndash;
-CAP_ODBC_BIND_SPATIAL_AS_WKT | Set to 'yes' to force binding Spatial data as WKT (Well Known Text) | &ndash; | &ndash; 
-CAP_ODBC_BIND_SUPPRESS_COERCE_TO_STRING | Set to 'yes' to prevent the Tableau native ODBC protocol from binding non-string data as strings (that is, requesting driver conversion). | &ndash; | &ndash; 
-CAP_ODBC_BIND_SUPPRESS_INT64 | Set to 'yes' to prevent the Tableau native ODBC protocol from using 64-bit integers for large numeric data. | &ndash; | &ndash; 
-CAP_ODBC_BIND_SUPPRESS_PREFERRED_CHAR | Set to 'yes' to prevent the Tableau native ODBC protocol from preferring a character type that differs from the driver default. | &ndash; | &ndash; 
-CAP_ODBC_BIND_SUPPRESS_PREFERRED_TYPES | Set to 'yes' to prevent the Tableau native ODBC protocol from binding any data according to its preferred wire types. With this capability set, Tableau will only bind according to the data types described by the ODBC driver via metadata. | &ndash; | &ndash; 
-CAP_ODBC_BIND_SUPPRESS_WIDE_CHAR | Set to 'yes' to prevent the Tableau native ODBC protocol from binding strings a WCHAR. Instead they will be bound as single-byte CHAR arrays, and processed locally for any UTF-8 characters contained within. | &ndash; | &ndash; 
-CAP_ODBC_CONNECTION_STATE_VERIFY_FAST | Set to ‘yes’ to check if a connection is broken with a fast ODBC API call. | yes | yes 
-CAP_ODBC_CONNECTION_STATE_VERIFY_PROBE | Set to ‘yes’ to check if a connection is broken with a forced probe. | no | no 
-CAP_ODBC_CONNECTION_STATE_VERIFY_PROBE_IF_STALE | Set to ‘yes’ to check if a connection is broken with a forced probe only if it is "stale" (that is, unused for about 30 minutes). | yes | yes 
-CAP_ODBC_CONNECTION_STATE_VERIFY_PROBE_PREPARED_QUERY | Set to ‘yes’ to check if a connection is broken using a prepared query. | yes | yes 
-CAP_ODBC_CURSOR_DYNAMIC | Set to 'yes' to force the Tableau native ODBC protocol to set the cursor type for all statements to Dynamic (scrollable, detects added/removed/modified rows). | &ndash; | &ndash; 
-CAP_ODBC_CURSOR_FORWARD_ONLY | Set to 'yes' to force the Tableau native ODBC protocol to set the cursor type for all statements to Forward-only (non-scrollable). | &ndash; | **<span style="color:red">?</span>** 
-CAP_ODBC_CURSOR_KEYSET_DRIVEN | Set to 'yes' to force the Tableau native ODBC protocol to set the cursor type for all statements to Keyset-driven (scrollable, detects changes to values within a row). | &ndash; | &ndash; 
-CAP_ODBC_CURSOR_STATIC | Set to 'yes' to force Tableau to set the cursor type for all statements to Static (scrollable, does not detect changes). | &ndash; | &ndash; 
+CAP_ODBC_BIND_SPATIAL_AS_WKT | Set to 'yes' to force binding Spatial data as WKT (Well Known Text) | &ndash; | &ndash;
+CAP_ODBC_BIND_SUPPRESS_COERCE_TO_STRING | Set to 'yes' to prevent the Tableau native ODBC protocol from binding non-string data as strings (that is, requesting driver conversion). | &ndash; | &ndash;
+CAP_ODBC_BIND_SUPPRESS_INT64 | Set to 'yes' to prevent the Tableau native ODBC protocol from using 64-bit integers for large numeric data. | &ndash; | &ndash;
+CAP_ODBC_BIND_SUPPRESS_PREFERRED_CHAR | Set to 'yes' to prevent the Tableau native ODBC protocol from preferring a character type that differs from the driver default. | &ndash; | &ndash;
+CAP_ODBC_BIND_SUPPRESS_PREFERRED_TYPES | Set to 'yes' to prevent the Tableau native ODBC protocol from binding any data according to its preferred wire types. With this capability set, Tableau will only bind according to the data types described by the ODBC driver via metadata. | &ndash; | &ndash;
+CAP_ODBC_BIND_SUPPRESS_WIDE_CHAR | Set to 'yes' to prevent the Tableau native ODBC protocol from binding strings a WCHAR. Instead they will be bound as single-byte CHAR arrays, and processed locally for any UTF-8 characters contained within. | &ndash; | &ndash;
+CAP_ODBC_CONNECTION_STATE_VERIFY_FAST | Set to ‘yes’ to check if a connection is broken with a fast ODBC API call. | yes | yes
+CAP_ODBC_CONNECTION_STATE_VERIFY_PROBE | Set to ‘yes’ to check if a connection is broken with a forced probe. | no | no
+CAP_ODBC_CONNECTION_STATE_VERIFY_PROBE_IF_STALE | Set to ‘yes’ to check if a connection is broken with a forced probe only if it is "stale" (that is, unused for about 30 minutes). | yes | yes
+CAP_ODBC_CONNECTION_STATE_VERIFY_PROBE_PREPARED_QUERY | Set to ‘yes’ to check if a connection is broken using a prepared query. | yes | yes
+CAP_ODBC_CURSOR_DYNAMIC | Set to 'yes' to force the Tableau native ODBC protocol to set the cursor type for all statements to Dynamic (scrollable, detects added/removed/modified rows). | &ndash; | &ndash;
+CAP_ODBC_CURSOR_FORWARD_ONLY | Set to 'yes' to force the Tableau native ODBC protocol to set the cursor type for all statements to Forward-only (non-scrollable). | &ndash; | **<span style="color:red">?</span>**
+CAP_ODBC_CURSOR_KEYSET_DRIVEN | Set to 'yes' to force the Tableau native ODBC protocol to set the cursor type for all statements to Keyset-driven (scrollable, detects changes to values within a row). | &ndash; | &ndash;
+CAP_ODBC_CURSOR_STATIC | Set to 'yes' to force Tableau to set the cursor type for all statements to Static (scrollable, does not detect changes). | &ndash; | &ndash;
 CAP_ODBC_ENABLE_AUTO_IPD | Set to 'yes' to enable automatic population of the IPD if supported by driver. Available in Tableau 2020.3 and newer. | &ndash; | &ndash;
-CAP_ODBC_ERROR_IGNORE_FALSE_ALARM | Set to 'yes' to allow the Tableau native ODBC protocol to ignore SQL_ERROR conditions where SQLSTATE is '00000' (meaning "no error"). | &ndash; | &ndash; 
-CAP_ODBC_ERROR_IGNORE_SQLNODATA_FOR_COMMAND_QUERIES | Set to 'yes' to ignore when SQLExecDirect returns SQL_NO_DATA even when data is not expected back | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_ALLOW_CHAR_UTF8 | Set to 'yes' to allow the use of single-byte char data type for binding Unicode strings as UTF-8. | no | no 
-CAP_ODBC_EXPORT_BIND_FORCE_TARGET_METADATA | Set to 'yes' to force binding for export based on all of the metadata from the target table instead of the ODBC metadata for the parameterized insert statement. | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_BIND_PREFER_TARGET_METADATA | Set to 'yes' to prefer binding for export based on specific types of metadata from the target table instead of the ODBC metadata for the parameterized insert statement. | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_BUFFERS_RESIZABLE | Set to 'yes' to allow export buffers to be reallocated after the first batch to improve performance. | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_BUFFERS_SIZE_FIXED | Set to 'yes' to ignore the width of a single row when computing the total rows to insert at a time. | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_BUFFERS_SIZE_LIMIT_512KB | Set to 'yes' to limit export buffers to 512 KB. This is an uncommon setting. | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_BUFFERS_SIZE_MASSIVE | Set to 'yes' to force the use of large buffers for insert. If CAP_ODBC_EXPORT_BUFFERS_RESIZABLE is not set or disabled, a fixed row count is used. | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_BUFFERS_SIZE_MEDIUM | Set to 'yes' to force the use of medium-sized buffers for insert. If CAP_ODBC_EXPORT_BUFFERS_RESIZABLE is not set or disabled, a fixed row count is used. | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_BUFFERS_SIZE_SMALL | Set to 'yes' to force the use of small buffers for insert. If CAP_ODBC_EXPORT_BUFFERS_RESIZABLE is not set or disabled, a fixed row count is used. | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_CONTINUE_ON_ERROR | Set to 'yes' to continue data insert despite errors. Some data sources report warnings as errors. | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_DATA_BULK | Set to 'yes' to allow the use of ODBC bulk operations for data insert. | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_DATA_BULK_VIA_INSERT | Set to 'yes' to allow the use of ODBC bulk operations based on 'INSERT INTO' parameterized queries. | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_DATA_BULK_VIA_ROWSET | Set to 'yes' to allow the use of ODBC bulk operations based on a rowset cursor. | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_FORCE_INDICATE_NTS | Set to 'yes' to force the use of indicator buffers for identifying null-terminated strings (NTS). | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_FORCE_SINGLE_ROW_BINDING | Set to 'yes' to force the use of a single row for binding export buffers to insert data. | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_FORCE_SINGLE_ROW_BINDING_WITH_TIMESTAMPS | Set to 'yes' to force the use of a single row for binding export buffers when dealing with timestamp data. This is required for some versions of Teradata. | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_FORCE_STRING_WIDTH_FROM_SOURCE | Set to 'yes' to force the use of the source string width (from Tableau metadata), overriding the destination string width (from insert parameter metadata). | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_FORCE_STRING_WIDTH_USING_OCTET_LENGTH | Set to 'yes' to force the use of the source string width from the octet length. | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_SUPPRESS_STRING_WIDTH_VALIDATION | Set to 'yes' to suppress validating that the target string width can accommodate the widest source strings. | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_TRANSACTIONS_COMMIT_BATCH_MASSIVE | Set to ‘yes’ to commit in massive batches of INSERT statements (~100,000). This may be useful with single-row export binding. | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_TRANSACTIONS_COMMIT_BATCH_MEDIUM | Set to 'yes' to commit in medium-sized batches of INSERT statements (~50). A single statement may be bound to multiple records. | yes | yes 
-CAP_ODBC_EXPORT_TRANSACTIONS_COMMIT_BATCH_SMALL | Set to 'yes' to commit in small batches of INSERT statements (~5). A single statement may be bound to multiple records. | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_TRANSACTIONS_COMMIT_BYTES_MASSIVE | Set to 'yes' to commit in massive batches of data (~100 MB). | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_TRANSACTIONS_COMMIT_BYTES_MEDIUM | Set to 'yes' to commit in medium batches of data (~10 MB). | yes | yes 
-CAP_ODBC_EXPORT_TRANSACTIONS_COMMIT_BYTES_SMALL | Set to 'yes' to commit in small batches of data (~1 MB). | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_TRANSACTIONS_COMMIT_EACH_STATEMENT | Set to 'yes' to commit after executing each INSERT statement. A single statement may be bound to multiple records. | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_TRANSACTIONS_COMMIT_INTERVAL_LONG | Set to 'yes' to commit in long intervals of elapsed time (~100 seconds). | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_TRANSACTIONS_COMMIT_INTERVAL_MEDIUM | Set to 'yes' to commit in medium intervals of elapsed time (~10 seconds). | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_TRANSACTIONS_COMMIT_INTERVAL_SHORT | Set to 'yes' to commit in short intervals of elapsed time (~1 seconds). | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_TRANSACTIONS_COMMIT_ONCE_WHEN_COMPLETE | Set to 'yes' to commit only once at the end after the export is complete. | &ndash; | &ndash; 
-CAP_ODBC_EXPORT_TRANSLATE_DATA_PARALLEL | Set to 'yes' to use parallel loops to translate Tableau DataValues to wire buffers on export. | yes | yes 
-CAP_ODBC_FETCH_ABORT_FORCE_CANCEL_STATEMENT | Set to 'yes' to cancel the statement handle upon interrupting SQLFetch with a cancel exception. | &ndash; | &ndash; 
-CAP_ODBC_FETCH_BUFFERS_RESIZABLE | Set to 'yes' to allow buffers to be reallocated after fetch to improve performance or handle data truncation. | &ndash; | &ndash; 
-CAP_ODBC_FETCH_BUFFERS_SIZE_FIXED | Set to 'yes' to ignore the width of a single row when computing the total rows to fetch. | &ndash; | &ndash; 
-CAP_ODBC_FETCH_BUFFERS_SIZE_MASSIVE | Set to 'yes' to force the use of large buffers. If CAP_ODBC_FETCH_BUFFERS_SIZE_FIXED is enabled, a fixed row count is used. | &ndash; | &ndash; 
-CAP_ODBC_FETCH_BUFFERS_SIZE_MEDIUM | Set to 'yes' to force the use of medium-sized buffers. If CAP_ODBC_FETCH_BUFFERS_SIZE_FIXED is enabled, a fixed row count is used. | &ndash; | &ndash; 
-CAP_ODBC_FETCH_BUFFERS_SIZE_SMALL | Set to 'yes' to force the use of small buffers. If CAP_ODBC_FETCH_BUFFERS_SIZE_FIXED is enabled, a fixed row count is used. | &ndash; | &ndash; 
-CAP_ODBC_FETCH_CONTINUE_ON_ERROR | Set to 'yes' to allow the Tableau native ODBC protocol to continue resultset fetch despite errors (some data sources report warnings as errors). | &ndash; | &ndash; 
-CAP_ODBC_FETCH_IGNORE_FRACTIONAL_SECONDS | Set to 'yes' to allow the Tableau native ODBC protocol to ignore the fractional seconds component of a time value when fetching query result set data. This is useful when working with data sources that do not follow the ODBC specification for fractional seconds, which must be represented as billionths of a second. | &ndash; | &ndash; 
-CAP_ODBC_FETCH_RESIZE_BUFFERS | Set to 'yes' to allow the Tableau native ODBC protocol to automatically resize buffers and fetch again if data truncation occurred. | &ndash; | &ndash; 
-CAP_ODBC_FORCE_SINGLE_ROW_BINDING | Set to 'yes' to force the Tableau native ODBC protocol to use a single row for result set transfers instead of the more efficient bulk-fetch. | &ndash; | &ndash; 
-CAP_ODBC_IMPORT_ERASE_BUFFERS | Set to 'yes' to reset the contents of data buffers before fetching each block. | &ndash; | &ndash; 
-CAP_ODBC_IMPORT_TRANSLATE_DATA_PARALLEL | Set to 'no' to disable decoding data locally in parallel. | yes | yes 
-CAP_ODBC_IMPORT_TRANSLATE_DATA_PARALLEL_SMALL | Set to 'yes' to use a small degree of parallelism when using CAP_ODBC_IMPORT_TRANSLATE_DATA_PARALLEL. Available in Tableau 2020.4 and newer. | &ndash; | &ndash; 
-CAP_ODBC_IMPORT_TRANSLATE_DATA_PARALLEL_MEDIUM | Set to 'yes' to use a medium degree of parallelism when using CAP_ODBC_IMPORT_TRANSLATE_DATA_PARALLEL. Available in Tableau 2020.4 and newer. | &ndash; | &ndash; 
-CAP_ODBC_IMPORT_TRANSLATE_DATA_PARALLEL_LARGE | Set to 'yes' to use a large degree of parallelism when using CAP_ODBC_IMPORT_TRANSLATE_DATA_PARALLEL. Available in Tableau 2020.4 and newer. | &ndash; | &ndash; 
-CAP_ODBC_IMPORT_TRANSLATE_DATA_PARALLEL_XL | Set to 'yes' to use an extra-large degree of parallelism when using CAP_ODBC_IMPORT_TRANSLATE_DATA_PARALLEL. Available in Tableau 2020.4 and newer. | &ndash; | &ndash; 
-CAP_ODBC_METADATA_FORCE_LENGTH_AS_PRECISION | Set to 'yes' to force the Tableau native ODBC protocol to use the column "length" as the numeric precision. This is an uncommon setting. | &ndash; | &ndash; 
-CAP_ODBC_METADATA_FORCE_NUM_PREC_RADIX_10 | Set to 'yes' to force the Tableau native ODBC protocol to assume the numeric precision is reported in base-10 digits. This is an uncommon setting. | &ndash; | &ndash; 
-CAP_ODBC_METADATA_FORCE_UNKNOWN_AS_STRING | Set to 'yes' to force the Native ODBC Protocol to treat unknown data types as string instead of ignoring the associated column. | &ndash; | &ndash; 
-CAP_ODBC_METADATA_FORCE_UTF8_IDENTIFIERS | Set to 'yes' to force the protocol to treat identifiers as UTF-8 when communicating with the driver. | &ndash; | &ndash; 
-CAP_ODBC_METADATA_SKIP_DESC_TYPE_NAME | Set to 'yes' to remove the check for the SQL_DESC_TYPE_NAME attribute with the SQLColAttribute API. | &ndash; | &ndash; 
-CAP_ODBC_METADATA_STRING_LENGTH_UNKNOWN | Set to 'yes' to prevent Tableau from allocating memory based on the driver-reported string length, which may not be known or reported properly. Instead, Tableau will use a fixed-sized string length, and will reallocate as needed to handle string data that is too large for the fixed-size buffer. | &ndash; | &ndash; 
-CAP_ODBC_METADATA_STRING_TRUST_OCTET_LENGTH | Set to 'yes' to use the octet length reported by the driver for strings instead of computing it from the number of characters. | &ndash; | &ndash; 
-CAP_ODBC_METADATA_SUPPRESS_EXECUTED_QUERY | Set to 'yes' to prevent Tableau from executing a query as a means of reading metadata. While Tableau typically includes a row-limiting clause in such metadata queries (for example, 'LIMIT', or 'WHERE 1=0'), this may not help when used with a Custom SQL connection for database systems with poor query optimizers. Note that this capability may prevent Tableau from determining the connection metadata properly. | &ndash; | &ndash; 
-CAP_ODBC_METADATA_SUPPRESS_PREPARED_QUERY | Set to 'yes' to prevent Tableau from using a prepared query as a means of reading metadata. A prepared query is often the fastest way to accurately read metadata. However, not all database systems are capable of reporting metadata for a prepared query without actually executing the query. Note that certain metadata -- for example from connections using Custom SQL -- cannot be retrieved if this capability and CAP_ODBC_METADATA_SUPPRESS_EXECUTED_QUERY are both set. | &ndash; | &ndash; 
-CAP_ODBC_METADATA_SUPPRESS_READ_IDENTITY_COLUMNS | Set to 'no' to prevent reading identity column metadata | yes | yes 
-CAP_ODBC_METADATA_SUPPRESS_SELECT_STAR | Set to 'yes' to prevent reading metadata using a 'select *' query. | &ndash; | &ndash; 
-CAP_ODBC_METADATA_SUPPRESS_SQLCOLUMNS_API | Set to 'yes' to prevent Tableau from using older, less accurate API for reading metadata from ODBC data sources. Setting this capability allows Tableau to read metadata by issuing a full 'select *' query, which is expensive but may enable connectivity for extremely limited or unstable data sources. | &ndash; | &ndash; 
-CAP_ODBC_METADATA_SUPPRESS_SQLFOREIGNKEYS_API | Set to 'yes' to prevent Tableau from attempting to read metadata describing foreign key constraints. Despite the simple nature of this ODBC API, some drivers may have unstable behavior or produce inaccurate results. Setting this capability may force Tableau to generate less efficient queries involving multi-table joins. | &ndash; | &ndash; 
-CAP_ODBC_METADATA_SUPPRESS_SQLPRIMARYKEYS_API | Set to 'yes' to prevent Tableau from reading primary key metadata using the SQLPrimaryKeys API or an equivalent query. | &ndash; | &ndash; 
-CAP_ODBC_METADATA_SUPPRESS_SQLSTATISTICS_API | Set to 'yes' to prevent reading unique constraints and table cardinality estimates using the SQLStatistics API or an equivalent query. | yes | yes 
-CAP_ODBC_REBIND_SKIP_UNBIND | Set to 'yes' to force the Tableau native ODBC protocol to rebind a column directly and skip unbinding, which reduces ODBC API calls when resizing buffers to refetch truncated data. | &ndash; | &ndash; 
+CAP_ODBC_ERROR_IGNORE_FALSE_ALARM | Set to 'yes' to allow the Tableau native ODBC protocol to ignore SQL_ERROR conditions where SQLSTATE is '00000' (meaning "no error"). | &ndash; | &ndash;
+CAP_ODBC_ERROR_IGNORE_SQLNODATA_FOR_COMMAND_QUERIES | Set to 'yes' to ignore when SQLExecDirect returns SQL_NO_DATA even when data is not expected back | &ndash; | &ndash;
+CAP_ODBC_EXPORT_ALLOW_CHAR_UTF8 | Set to 'yes' to allow the use of single-byte char data type for binding Unicode strings as UTF-8. | no | no
+CAP_ODBC_EXPORT_BIND_FORCE_TARGET_METADATA | Set to 'yes' to force binding for export based on all of the metadata from the target table instead of the ODBC metadata for the parameterized insert statement. | &ndash; | &ndash;
+CAP_ODBC_EXPORT_BIND_PREFER_TARGET_METADATA | Set to 'yes' to prefer binding for export based on specific types of metadata from the target table instead of the ODBC metadata for the parameterized insert statement. | &ndash; | &ndash;
+CAP_ODBC_EXPORT_BUFFERS_RESIZABLE | Set to 'yes' to allow export buffers to be reallocated after the first batch to improve performance. | &ndash; | &ndash;
+CAP_ODBC_EXPORT_BUFFERS_SIZE_FIXED | Set to 'yes' to ignore the width of a single row when computing the total rows to insert at a time. | &ndash; | &ndash;
+CAP_ODBC_EXPORT_BUFFERS_SIZE_LIMIT_512KB | Set to 'yes' to limit export buffers to 512 KB. This is an uncommon setting. | &ndash; | &ndash;
+CAP_ODBC_EXPORT_BUFFERS_SIZE_MASSIVE | Set to 'yes' to force the use of large buffers for insert. If CAP_ODBC_EXPORT_BUFFERS_RESIZABLE is not set or disabled, a fixed row count is used. | &ndash; | &ndash;
+CAP_ODBC_EXPORT_BUFFERS_SIZE_MEDIUM | Set to 'yes' to force the use of medium-sized buffers for insert. If CAP_ODBC_EXPORT_BUFFERS_RESIZABLE is not set or disabled, a fixed row count is used. | &ndash; | &ndash;
+CAP_ODBC_EXPORT_BUFFERS_SIZE_SMALL | Set to 'yes' to force the use of small buffers for insert. If CAP_ODBC_EXPORT_BUFFERS_RESIZABLE is not set or disabled, a fixed row count is used. | &ndash; | &ndash;
+CAP_ODBC_EXPORT_CONTINUE_ON_ERROR | Set to 'yes' to continue data insert despite errors. Some data sources report warnings as errors. | &ndash; | &ndash;
+CAP_ODBC_EXPORT_DATA_BULK | Set to 'yes' to allow the use of ODBC bulk operations for data insert. | &ndash; | &ndash;
+CAP_ODBC_EXPORT_DATA_BULK_VIA_INSERT | Set to 'yes' to allow the use of ODBC bulk operations based on 'INSERT INTO' parameterized queries. | &ndash; | &ndash;
+CAP_ODBC_EXPORT_DATA_BULK_VIA_ROWSET | Set to 'yes' to allow the use of ODBC bulk operations based on a rowset cursor. | &ndash; | &ndash;
+CAP_ODBC_EXPORT_FORCE_INDICATE_NTS | Set to 'yes' to force the use of indicator buffers for identifying null-terminated strings (NTS). | &ndash; | &ndash;
+CAP_ODBC_EXPORT_FORCE_SINGLE_ROW_BINDING | Set to 'yes' to force the use of a single row for binding export buffers to insert data. | &ndash; | &ndash;
+CAP_ODBC_EXPORT_FORCE_SINGLE_ROW_BINDING_WITH_TIMESTAMPS | Set to 'yes' to force the use of a single row for binding export buffers when dealing with timestamp data. This is required for some versions of Teradata. | &ndash; | &ndash;
+CAP_ODBC_EXPORT_FORCE_STRING_WIDTH_FROM_SOURCE | Set to 'yes' to force the use of the source string width (from Tableau metadata), overriding the destination string width (from insert parameter metadata). | &ndash; | &ndash;
+CAP_ODBC_EXPORT_FORCE_STRING_WIDTH_USING_OCTET_LENGTH | Set to 'yes' to force the use of the source string width from the octet length. | &ndash; | &ndash;
+CAP_ODBC_EXPORT_SUPPRESS_STRING_WIDTH_VALIDATION | Set to 'yes' to suppress validating that the target string width can accommodate the widest source strings. | &ndash; | &ndash;
+CAP_ODBC_EXPORT_TRANSACTIONS_COMMIT_BATCH_MASSIVE | Set to ‘yes’ to commit in massive batches of INSERT statements (~100,000). This may be useful with single-row export binding. | &ndash; | &ndash;
+CAP_ODBC_EXPORT_TRANSACTIONS_COMMIT_BATCH_MEDIUM | Set to 'yes' to commit in medium-sized batches of INSERT statements (~50). A single statement may be bound to multiple records. | yes | yes
+CAP_ODBC_EXPORT_TRANSACTIONS_COMMIT_BATCH_SMALL | Set to 'yes' to commit in small batches of INSERT statements (~5). A single statement may be bound to multiple records. | &ndash; | &ndash;
+CAP_ODBC_EXPORT_TRANSACTIONS_COMMIT_BYTES_MASSIVE | Set to 'yes' to commit in massive batches of data (~100 MB). | &ndash; | &ndash;
+CAP_ODBC_EXPORT_TRANSACTIONS_COMMIT_BYTES_MEDIUM | Set to 'yes' to commit in medium batches of data (~10 MB). | yes | yes
+CAP_ODBC_EXPORT_TRANSACTIONS_COMMIT_BYTES_SMALL | Set to 'yes' to commit in small batches of data (~1 MB). | &ndash; | &ndash;
+CAP_ODBC_EXPORT_TRANSACTIONS_COMMIT_EACH_STATEMENT | Set to 'yes' to commit after executing each INSERT statement. A single statement may be bound to multiple records. | &ndash; | &ndash;
+CAP_ODBC_EXPORT_TRANSACTIONS_COMMIT_INTERVAL_LONG | Set to 'yes' to commit in long intervals of elapsed time (~100 seconds). | &ndash; | &ndash;
+CAP_ODBC_EXPORT_TRANSACTIONS_COMMIT_INTERVAL_MEDIUM | Set to 'yes' to commit in medium intervals of elapsed time (~10 seconds). | &ndash; | &ndash;
+CAP_ODBC_EXPORT_TRANSACTIONS_COMMIT_INTERVAL_SHORT | Set to 'yes' to commit in short intervals of elapsed time (~1 seconds). | &ndash; | &ndash;
+CAP_ODBC_EXPORT_TRANSACTIONS_COMMIT_ONCE_WHEN_COMPLETE | Set to 'yes' to commit only once at the end after the export is complete. | &ndash; | &ndash;
+CAP_ODBC_EXPORT_TRANSLATE_DATA_PARALLEL | Set to 'yes' to use parallel loops to translate Tableau DataValues to wire buffers on export. | yes | yes
+CAP_ODBC_FETCH_ABORT_FORCE_CANCEL_STATEMENT | Set to 'yes' to cancel the statement handle upon interrupting SQLFetch with a cancel exception. | &ndash; | &ndash;
+CAP_ODBC_FETCH_BUFFERS_RESIZABLE | Set to 'yes' to allow buffers to be reallocated after fetch to improve performance or handle data truncation. | &ndash; | &ndash;
+CAP_ODBC_FETCH_BUFFERS_SIZE_FIXED | Set to 'yes' to ignore the width of a single row when computing the total rows to fetch. | &ndash; | &ndash;
+CAP_ODBC_FETCH_BUFFERS_SIZE_MASSIVE | Set to 'yes' to force the use of large buffers. If CAP_ODBC_FETCH_BUFFERS_SIZE_FIXED is enabled, a fixed row count is used. | &ndash; | &ndash;
+CAP_ODBC_FETCH_BUFFERS_SIZE_MEDIUM | Set to 'yes' to force the use of medium-sized buffers. If CAP_ODBC_FETCH_BUFFERS_SIZE_FIXED is enabled, a fixed row count is used. | &ndash; | &ndash;
+CAP_ODBC_FETCH_BUFFERS_SIZE_SMALL | Set to 'yes' to force the use of small buffers. If CAP_ODBC_FETCH_BUFFERS_SIZE_FIXED is enabled, a fixed row count is used. | &ndash; | &ndash;
+CAP_ODBC_FETCH_CONTINUE_ON_ERROR | Set to 'yes' to allow the Tableau native ODBC protocol to continue resultset fetch despite errors (some data sources report warnings as errors). | &ndash; | &ndash;
+CAP_ODBC_FETCH_IGNORE_FRACTIONAL_SECONDS | Set to 'yes' to allow the Tableau native ODBC protocol to ignore the fractional seconds component of a time value when fetching query result set data. This is useful when working with data sources that do not follow the ODBC specification for fractional seconds, which must be represented as billionths of a second. | &ndash; | &ndash;
+CAP_ODBC_FETCH_RESIZE_BUFFERS | Set to 'yes' to allow the Tableau native ODBC protocol to automatically resize buffers and fetch again if data truncation occurred. | &ndash; | &ndash;
+CAP_ODBC_FORCE_SINGLE_ROW_BINDING | Set to 'yes' to force the Tableau native ODBC protocol to use a single row for result set transfers instead of the more efficient bulk-fetch. | &ndash; | &ndash;
+CAP_ODBC_IMPORT_ERASE_BUFFERS | Set to 'yes' to reset the contents of data buffers before fetching each block. | &ndash; | &ndash;
+CAP_ODBC_IMPORT_TRANSLATE_DATA_PARALLEL | Set to 'no' to disable decoding data locally in parallel. | yes | yes
+CAP_ODBC_IMPORT_TRANSLATE_DATA_PARALLEL_SMALL | Set to 'yes' to use a small degree of parallelism when using CAP_ODBC_IMPORT_TRANSLATE_DATA_PARALLEL. Available in Tableau 2020.4 and newer. | &ndash; | &ndash;
+CAP_ODBC_IMPORT_TRANSLATE_DATA_PARALLEL_MEDIUM | Set to 'yes' to use a medium degree of parallelism when using CAP_ODBC_IMPORT_TRANSLATE_DATA_PARALLEL. Available in Tableau 2020.4 and newer. | &ndash; | &ndash;
+CAP_ODBC_IMPORT_TRANSLATE_DATA_PARALLEL_LARGE | Set to 'yes' to use a large degree of parallelism when using CAP_ODBC_IMPORT_TRANSLATE_DATA_PARALLEL. Available in Tableau 2020.4 and newer. | &ndash; | &ndash;
+CAP_ODBC_IMPORT_TRANSLATE_DATA_PARALLEL_XL | Set to 'yes' to use an extra-large degree of parallelism when using CAP_ODBC_IMPORT_TRANSLATE_DATA_PARALLEL. Available in Tableau 2020.4 and newer. | &ndash; | &ndash;
+CAP_ODBC_METADATA_FORCE_LENGTH_AS_PRECISION | Set to 'yes' to force the Tableau native ODBC protocol to use the column "length" as the numeric precision. This is an uncommon setting. | &ndash; | &ndash;
+CAP_ODBC_METADATA_FORCE_NUM_PREC_RADIX_10 | Set to 'yes' to force the Tableau native ODBC protocol to assume the numeric precision is reported in base-10 digits. This is an uncommon setting. | &ndash; | &ndash;
+CAP_ODBC_METADATA_FORCE_UNKNOWN_AS_STRING | Set to 'yes' to force the Native ODBC Protocol to treat unknown data types as string instead of ignoring the associated column. | &ndash; | &ndash;
+CAP_ODBC_METADATA_FORCE_UTF8_IDENTIFIERS | Set to 'yes' to force the protocol to treat identifiers as UTF-8 when communicating with the driver. | &ndash; | &ndash;
+CAP_ODBC_METADATA_SKIP_DESC_TYPE_NAME | Set to 'yes' to remove the check for the SQL_DESC_TYPE_NAME attribute with the SQLColAttribute API. | &ndash; | &ndash;
+CAP_ODBC_METADATA_STRING_LENGTH_UNKNOWN | Set to 'yes' to prevent Tableau from allocating memory based on the driver-reported string length, which may not be known or reported properly. Instead, Tableau will use a fixed-sized string length, and will reallocate as needed to handle string data that is too large for the fixed-size buffer. | &ndash; | &ndash;
+CAP_ODBC_METADATA_STRING_TRUST_OCTET_LENGTH | Set to 'yes' to use the octet length reported by the driver for strings instead of computing it from the number of characters. | &ndash; | &ndash;
+CAP_ODBC_METADATA_SUPPRESS_EXECUTED_QUERY | Set to 'yes' to prevent Tableau from executing a query as a means of reading metadata. While Tableau typically includes a row-limiting clause in such metadata queries (for example, 'LIMIT', or 'WHERE 1=0'), this may not help when used with a Custom SQL connection for database systems with poor query optimizers. Note that this capability may prevent Tableau from determining the connection metadata properly. | &ndash; | &ndash;
+CAP_ODBC_METADATA_SUPPRESS_PREPARED_QUERY | Set to 'yes' to prevent Tableau from using a prepared query as a means of reading metadata. A prepared query is often the fastest way to accurately read metadata. However, not all database systems are capable of reporting metadata for a prepared query without actually executing the query. Note that certain metadata -- for example from connections using Custom SQL -- cannot be retrieved if this capability and CAP_ODBC_METADATA_SUPPRESS_EXECUTED_QUERY are both set. | &ndash; | &ndash;
+CAP_ODBC_METADATA_SUPPRESS_READ_IDENTITY_COLUMNS | Set to 'no' to prevent reading identity column metadata | yes | yes
+CAP_ODBC_METADATA_SUPPRESS_SELECT_STAR | Set to 'yes' to prevent reading metadata using a 'select *' query. | &ndash; | &ndash;
+CAP_ODBC_METADATA_SUPPRESS_SQLCOLUMNS_API | Set to 'yes' to prevent Tableau from using older, less accurate API for reading metadata from ODBC data sources. Setting this capability allows Tableau to read metadata by issuing a full 'select *' query, which is expensive but may enable connectivity for extremely limited or unstable data sources. | &ndash; | &ndash;
+CAP_ODBC_METADATA_SUPPRESS_SQLFOREIGNKEYS_API | Set to 'yes' to prevent Tableau from attempting to read metadata describing foreign key constraints. Despite the simple nature of this ODBC API, some drivers may have unstable behavior or produce inaccurate results. Setting this capability may force Tableau to generate less efficient queries involving multi-table joins. | &ndash; | &ndash;
+CAP_ODBC_METADATA_SUPPRESS_SQLPRIMARYKEYS_API | Set to 'yes' to prevent Tableau from reading primary key metadata using the SQLPrimaryKeys API or an equivalent query. | &ndash; | &ndash;
+CAP_ODBC_METADATA_SUPPRESS_SQLSTATISTICS_API | Set to 'yes' to prevent reading unique constraints and table cardinality estimates using the SQLStatistics API or an equivalent query. | yes | yes
+CAP_ODBC_REBIND_SKIP_UNBIND | Set to 'yes' to force the Tableau native ODBC protocol to rebind a column directly and skip unbinding, which reduces ODBC API calls when resizing buffers to refetch truncated data. | &ndash; | &ndash;
 CAP_ODBC_SUPPORTS_LONG_DATA_BULK | Set to 'yes' if driver can fetch multiple long-data rows at a time. | no | no |
-CAP_ODBC_SUPPORTS_LONG_DATA_ORDERED | Set to 'yes' if driver requires long-data columns to come after non-long-data ones | no | no | 
+CAP_ODBC_SUPPORTS_LONG_DATA_ORDERED | Set to 'yes' if driver requires long-data columns to come after non-long-data ones | no | no |
 CAP_ODBC_SUPPRESS_CATALOG_NAME | Set 'yes' to suppress passing catalog name for SQLTables, SQLPrimaryKeys, SQLForeignKeys, SQLStatistics calls | &ndash; | &ndash;
 CAP_ODBC_SUPPRESS_ENUMERATE_SCHEMA_WITHOUT_CATALOG | Set 'yes' to suppress enumerating schemas without a valid catalog. | &ndash; | &ndash;
-CAP_ODBC_SUPPRESS_INFO_SCHEMA_SCHEMAS | Set to 'yes' to prevent schemas from "information_schema" schema from being returned by EnumerateSchemas | &ndash; | &ndash; 
-CAP_ODBC_SUPPRESS_INFO_SCHEMA_TABLES | Set to 'yes' to prevent tables from "information_schema" schema from being returned by EnumerateTables | &ndash; | &ndash; 
-CAP_ODBC_SUPPRESS_PG_TEMP_SCHEMA_TABLES | Set to 'yes' to prevent tables from "pg_temp" schema from being returned by EnumerateTables | &ndash; | &ndash;  
-CAP_ODBC_SUPPRESS_PREPARED_QUERY_FOR_ALL_COMMAND_QUERIES | Set to 'yes' to execute all commands directly (that is, no prepared statement). | &ndash; | &ndash; 
-CAP_ODBC_SUPPRESS_PREPARED_QUERY_FOR_DDL_COMMAND_QUERIES | Set to 'yes' to execute DDL commands (for example, CREATE TABLE) directly (that is, no prepared statement). | &ndash; | &ndash; 
-CAP_ODBC_SUPPRESS_PREPARED_QUERY_FOR_DML_COMMAND_QUERIES | Set to 'yes' to execute DML commands (for example, INSERT INTO) directly (i.e, no prepared statement). | &ndash; | &ndash; 
+CAP_ODBC_SUPPRESS_INFO_SCHEMA_SCHEMAS | Set to 'yes' to prevent schemas from "information_schema" schema from being returned by EnumerateSchemas | &ndash; | &ndash;
+CAP_ODBC_SUPPRESS_INFO_SCHEMA_TABLES | Set to 'yes' to prevent tables from "information_schema" schema from being returned by EnumerateTables | &ndash; | &ndash;
+CAP_ODBC_SUPPRESS_PG_TEMP_SCHEMA_TABLES | Set to 'yes' to prevent tables from "pg_temp" schema from being returned by EnumerateTables | &ndash; | &ndash;
+CAP_ODBC_SUPPRESS_PREPARED_QUERY_FOR_ALL_COMMAND_QUERIES | Set to 'yes' to execute all commands directly (that is, no prepared statement). | &ndash; | &ndash;
+CAP_ODBC_SUPPRESS_PREPARED_QUERY_FOR_DDL_COMMAND_QUERIES | Set to 'yes' to execute DDL commands (for example, CREATE TABLE) directly (that is, no prepared statement). | &ndash; | &ndash;
+CAP_ODBC_SUPPRESS_PREPARED_QUERY_FOR_DML_COMMAND_QUERIES | Set to 'yes' to execute DML commands (for example, INSERT INTO) directly (i.e, no prepared statement). | &ndash; | &ndash;
 CAP_ODBC_SUPPRESS_PREPARED_QUERY_FOR_NON_COMMAND_QUERIES | Set to 'yes' to execute all non-command queries directly (no prepared statement). | &ndash; | &ndash;
-CAP_ODBC_TRANSACTIONS_COMMIT_INVALIDATES_PREPARED_QUERY | Set to ‘yes’ to indicate that a transaction will invalidate all prepared statements and close any open cursors. | &ndash; | &ndash; 
-CAP_ODBC_TRANSACTIONS_SUPPRESS_EXPLICIT_COMMIT | Set to 'yes' to prevent the Native ODBC Protocol from explicitly managing transactions. | &ndash; | &ndash; 
-CAP_ODBC_TRIM_CHAR_LEAVE_PADDING | Set to 'yes' to leave whitespace padding at the end of a character or text data type. Most data sources will trim this whitespace automatically, but the behavior depends on the driver. | &ndash; | &ndash; 
-CAP_ODBC_TRIM_VARCHAR_PADDING | Set to 'yes' to force the Tableau native ODBC protocol to trim trailing whitespace from VARCHAR columns which the driver has erroneously padded. | &ndash; | &ndash; 
-CAP_ODBC_UNBIND_AUTO | Set to 'yes' to force the Tableau native ODBC protocol to unbind and deallocate columns automatically, which can reduce ODBC API calls. | &ndash; | &ndash; 
-CAP_ODBC_UNBIND_BATCH | Set to 'yes' to force the Tableau native ODBC protocol to unbind and deallocate columns in a single batch operation, which can reduce ODBC API calls. | &ndash; | &ndash; 
-CAP_ODBC_UNBIND_EACH | Set to 'yes' to force the Tableau native ODBC protocol to unbind and deallocate columns individually, which may improve stability. | yes | yes 
-CAP_ODBC_UNBIND_PARAMETERS_BATCH | Set to ‘yes’ to unbind all parameters in a single batch operation. | yes | yes 
+CAP_ODBC_TRANSACTIONS_COMMIT_INVALIDATES_PREPARED_QUERY | Set to ‘yes’ to indicate that a transaction will invalidate all prepared statements and close any open cursors. | &ndash; | &ndash;
+CAP_ODBC_TRANSACTIONS_SUPPRESS_EXPLICIT_COMMIT | Set to 'yes' to prevent the Native ODBC Protocol from explicitly managing transactions. | &ndash; | &ndash;
+CAP_ODBC_TRIM_CHAR_LEAVE_PADDING | Set to 'yes' to leave whitespace padding at the end of a character or text data type. Most data sources will trim this whitespace automatically, but the behavior depends on the driver. | &ndash; | &ndash;
+CAP_ODBC_TRIM_VARCHAR_PADDING | Set to 'yes' to force the Tableau native ODBC protocol to trim trailing whitespace from VARCHAR columns which the driver has erroneously padded. | &ndash; | &ndash;
+CAP_ODBC_UNBIND_AUTO | Set to 'yes' to force the Tableau native ODBC protocol to unbind and deallocate columns automatically, which can reduce ODBC API calls. | &ndash; | &ndash;
+CAP_ODBC_UNBIND_BATCH | Set to 'yes' to force the Tableau native ODBC protocol to unbind and deallocate columns in a single batch operation, which can reduce ODBC API calls. | &ndash; | &ndash;
+CAP_ODBC_UNBIND_EACH | Set to 'yes' to force the Tableau native ODBC protocol to unbind and deallocate columns individually, which may improve stability. | yes | yes
+CAP_ODBC_UNBIND_PARAMETERS_BATCH | Set to ‘yes’ to unbind all parameters in a single batch operation. | yes | yes
 
 ## Stored Procedures
 
-Capability | Description | Default | Recommended 
+Capability | Description | Default | Recommended
 -|-|-|-
 CAP_CONNECT_STORED_PROCEDURE | Set to 'yes' to allow support for connecting to a stored procedure. | &ndash; | &ndash;
-CAP_INSERT_TEMP_EXEC_STORED_PROCEDURE | Set to 'yes' to populate the temporary table from running query in the database | no | no  
+CAP_INSERT_TEMP_EXEC_STORED_PROCEDURE | Set to 'yes' to populate the temporary table from running query in the database | no | no
 CAP_JDBC_SUPPRESS_INFO_SCHEMA_STORED_PROCS | Set to 'yes' to prevent the INFORMATION.SCHEMA schema from being queried when enumerating stored procedures. | &ndash; | &ndash;
-CAP_ODBC_SUPPRESS_INFO_SCHEMA_STORED_PROCS | Set to 'yes' to prevent the INFORMATION.SCHEMA schema from being queried when enumerating stored procedures. | &ndash; | &ndash; 
-CAP_ODBC_SUPPRESS_SYS_SCHEMA_STORED_PROCS | Set to 'yes' to explicitly add the "SYS" schema to the schema exclusions when enumerating stored procedures. | &ndash; | &ndash; 
+CAP_ODBC_SUPPRESS_INFO_SCHEMA_STORED_PROCS | Set to 'yes' to prevent the INFORMATION.SCHEMA schema from being queried when enumerating stored procedures. | &ndash; | &ndash;
+CAP_ODBC_SUPPRESS_SYS_SCHEMA_STORED_PROCS | Set to 'yes' to explicitly add the "SYS" schema to the schema exclusions when enumerating stored procedures. | &ndash; | &ndash;
 CAP_STORED_PROCEDURE_PREFER_TEMP_TABLE | Set to 'yes' to use a temporary table to support remote queries over the stored procedure result set. | &ndash; | &ndash;
 CAP_STORED_PROCEDURE_REPAIR_TEMP_TABLE_STRINGS | Set to 'yes' to attempt to compute actual string widths if metadata indicates no width or non-positive width. | &ndash; | &ndash;
 CAP_STORED_PROCEDURE_TEMP_TABLE_FROM_BUFFER | Set to 'yes' to populate the temporary table from a result set buffered in entirety. | &ndash; | &ndash;
@@ -282,22 +274,22 @@ CAP_STORED_PROCEDURE_TEMP_TABLE_FROM_NEW_PROTOCOL | Set to ‘yes’ to populate
 
 Capability | Description | Default | Recommended
 -|-|-|-
-CAP_ISOLATION_LEVEL_READ_COMMITTED | Set to 'yes' to force the transaction isolation level to Read Committed if the data source supports it. Only one of the four transaction isolation levels should be set to 'yes'. See also: CAP_SET_ISOLATION_LEVEL_VIA_SQL, CAP_SET_ISOLATION_LEVEL_VIA_ODBC_API. | &ndash; | &ndash; 
-CAP_ISOLATION_LEVEL_READ_UNCOMMITTED | Set to 'yes' to force the transaction isolation level to Read Uncommitted if the data source supports it. Only one of the four transaction isolation levels should be set to 'yes'. This capability can improve speed by reducing lock contention, but may result in partial or inconsistent data in query results. See also: CAP_SET_ISOLATION_LEVEL_VIA_SQL, CAP_SET_ISOLATION_LEVEL_VIA_ODBC_API. | &ndash; | &ndash; 
-CAP_ISOLATION_LEVEL_REPEATABLE_READS | Set to 'yes' to force the transaction isolation level to Repeatable Reads if the data source supports it. Only one of the four transaction isolation levels should be set to 'yes'. See also: CAP_SET_ISOLATION_LEVEL_VIA_SQL, CAP_SET_ISOLATION_LEVEL_VIA_ODBC_API. | &ndash; | &ndash; 
-CAP_ISOLATION_LEVEL_SERIALIZABLE | Set to 'yes' to force the transaction isolation level to Serializable if the data source supports it. Only one of the four transaction isolation levels should be set to 'yes'. This is a very conservative setting that may improve stability at the expense of performance. See also: CAP_SET_ISOLATION_LEVEL_VIA_SQL, CAP_SET_ISOLATION_LEVEL_VIA_ODBC_API. | &ndash; | &ndash; 
-CAP_SET_ISOLATION_LEVEL_VIA_ODBC_API | Set to 'yes' to force Tableau to set the transaction isolation level for the data source using the ODBC API. CAP_SET_ISOLATION_LEVEL_VIA_ODBC_API must be set to 'yes' when any one of the four CAP_ISOLATION_LEVEL capabilities has been set to 'yes'. | &ndash; | &ndash; 
-CAP_SET_ISOLATION_LEVEL_VIA_SQL | Set to 'yes' to force Tableau to set the transaction isolation level for the data source using a SQL query. CAP_SET_ISOLATION_LEVEL_VIA_SQL must be set to 'yes' when any one of the four CAP_ISOLATION_LEVEL capabilities has been set to 'yes'. | &ndash; | &ndash; 
+CAP_ISOLATION_LEVEL_READ_COMMITTED | Set to 'yes' to force the transaction isolation level to Read Committed if the data source supports it. Only one of the four transaction isolation levels should be set to 'yes'. See also: CAP_SET_ISOLATION_LEVEL_VIA_SQL, CAP_SET_ISOLATION_LEVEL_VIA_ODBC_API. | &ndash; | &ndash;
+CAP_ISOLATION_LEVEL_READ_UNCOMMITTED | Set to 'yes' to force the transaction isolation level to Read Uncommitted if the data source supports it. Only one of the four transaction isolation levels should be set to 'yes'. This capability can improve speed by reducing lock contention, but may result in partial or inconsistent data in query results. See also: CAP_SET_ISOLATION_LEVEL_VIA_SQL, CAP_SET_ISOLATION_LEVEL_VIA_ODBC_API. | &ndash; | &ndash;
+CAP_ISOLATION_LEVEL_REPEATABLE_READS | Set to 'yes' to force the transaction isolation level to Repeatable Reads if the data source supports it. Only one of the four transaction isolation levels should be set to 'yes'. See also: CAP_SET_ISOLATION_LEVEL_VIA_SQL, CAP_SET_ISOLATION_LEVEL_VIA_ODBC_API. | &ndash; | &ndash;
+CAP_ISOLATION_LEVEL_SERIALIZABLE | Set to 'yes' to force the transaction isolation level to Serializable if the data source supports it. Only one of the four transaction isolation levels should be set to 'yes'. This is a very conservative setting that may improve stability at the expense of performance. See also: CAP_SET_ISOLATION_LEVEL_VIA_SQL, CAP_SET_ISOLATION_LEVEL_VIA_ODBC_API. | &ndash; | &ndash;
+CAP_SET_ISOLATION_LEVEL_VIA_ODBC_API | Set to 'yes' to force Tableau to set the transaction isolation level for the data source using the ODBC API. CAP_SET_ISOLATION_LEVEL_VIA_ODBC_API must be set to 'yes' when any one of the four CAP_ISOLATION_LEVEL capabilities has been set to 'yes'. | &ndash; | &ndash;
+CAP_SET_ISOLATION_LEVEL_VIA_SQL | Set to 'yes' to force Tableau to set the transaction isolation level for the data source using a SQL query. CAP_SET_ISOLATION_LEVEL_VIA_SQL must be set to 'yes' when any one of the four CAP_ISOLATION_LEVEL capabilities has been set to 'yes'. | &ndash; | &ndash;
 
 ## Uncommon
 
 Capability | Description | Default | Recommended
 -|-|-|-
-CAP_CONNECT_NO_CUSTOM_SQL | Set to 'yes' to disable the custom sql option. | &ndash; | &ndash; 
-CAP_EQUALITY_JOINS_ONLY | Set to 'yes' to restrict connector to only allow equality joins. Available in Tableau 2022.1 and newer. | &ndash; | &ndash;  
-CAP_EXTRACT_ONLY | Set to 'yes' to perform queries on extracted data only. | &ndash; | &ndash;  
-CAP_EXTRACT_ONLY_REFRESH  | Set to 'yes' to enable extracted data to be refreshed. | &ndash; | &ndash;  
-CAP_FORCE_CONNECTION_VERIFICATION | Set to 'yes' to verify connection status during initial connection by running a probe query. Available in Tableau 2022.2 and newer. | &ndash; | &ndash; 
-CAP_FORCE_COUNT_FOR_NUMBEROFRECORDS | Set to 'yes' to force these alternatives for calculating number of records: <br>1. COUNT(1) rather than SUM(1) <br>2. COUNT(const) * const rather than SUM(const) <br>Available in Tableau 2020.2 and newer. | &ndash; | &ndash;  
-CAP_SUPPRESS_GET_SERVER_TIME | Some data sources, such as Hive, are very slow at retrieving the server time.  | &ndash; | &ndash; 
-CAP_SUPPORTS_UNION | Set to 'no' if data source doesn't support UNION functionality. | yes | yes 
+CAP_CONNECT_NO_CUSTOM_SQL | Set to 'yes' to disable the custom sql option. | &ndash; | &ndash;
+CAP_EQUALITY_JOINS_ONLY | Set to 'yes' to restrict connector to only allow equality joins. Available in Tableau 2022.1 and newer. | &ndash; | &ndash;
+CAP_EXTRACT_ONLY | Set to 'yes' to perform queries on extracted data only. | &ndash; | &ndash;
+CAP_EXTRACT_ONLY_REFRESH  | Set to 'yes' to enable extracted data to be refreshed. | &ndash; | &ndash;
+CAP_FORCE_CONNECTION_VERIFICATION | Set to 'yes' to verify connection status during initial connection by running a probe query. Available in Tableau 2022.2 and newer. | &ndash; | &ndash;
+CAP_FORCE_COUNT_FOR_NUMBEROFRECORDS | Set to 'yes' to force these alternatives for calculating number of records: <br>1. COUNT(1) rather than SUM(1) <br>2. COUNT(const) * const rather than SUM(const) <br>Available in Tableau 2020.2 and newer. | &ndash; | &ndash;
+CAP_SUPPRESS_GET_SERVER_TIME | Some data sources, such as Hive, are very slow at retrieving the server time.  | &ndash; | &ndash;
+CAP_SUPPORTS_UNION | Set to 'no' if data source doesn't support UNION functionality. | yes | yes

--- a/docs/connection-dialog.md
+++ b/docs/connection-dialog.md
@@ -1,7 +1,12 @@
 ---
 title: Build the Connection Dialog
 ---
+**In this section**
 
+* TOC
+{:toc}
+
+## Overview
 The connection dialog prompts the user to enter connection and authentication information. That information is passed into the Connector Builder script to build the connection string. The dialog appears when creating a new connection or editing an existing connection and is used by both Tableau Desktop and Tableau Server.
 
 The connection dialog can be defined in two different ways:
@@ -106,15 +111,15 @@ Clearing the connection cache might be a necessary step in the development and t
 
 **For Windows**
 
-Using Regedit on Windows delete this folder from the registry: 
+Using Regedit on Windows delete this folder from the registry:
 `Computer\HKEY_CURRENT_USER\SOFTWARE\Tableau\Tableau <version>\ConnectionSettings\<connector_class>`
 
-**For Mac** 
+**For Mac**
 
  Follow the following commands
 `rm $HOME/Library/Preferences/com.tableau.Tableau-version.plist`
 
- Example: 
+ Example:
 `rm $HOME/Library/Preferences/com.tableau.Tableau-2022.2.plist`
 
-**Note:** Removing the `.plist` file remove the connection cache for all the connectors. 
+**Note:** Removing the `.plist` file remove the connection cache for all the connectors.

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,7 +1,12 @@
 ---
 title: Connector Design Considerations
 ---
+**In this section**
 
+* TOC
+{:toc}
+
+## Overview
 The choices you make when creating a connector can include which superclass and dialect to use, and how you want to tune your connection using Tableau capabilities.
 
 Also be sure to read the [Security Considerations]({{ site.baseurl }}/docs/security-considerations) page.

--- a/docs/dialect.md
+++ b/docs/dialect.md
@@ -1,7 +1,12 @@
 ---
 title: Create a Tableau Dialect Definition File
 ---
+**In this section**
 
+* TOC
+{:toc}
+
+## Overview
 A Tableau Dialect Definition file (.tdd) maps Tableau's query language to a database’s SQL. This is an XML file with a .tdd filename extension, and is one of the main components of a Tableau connector.
 
 You should create a dialect definition file whenever you need to make changes to an existing Tableau dialect or define an entirely new dialect. If your connector uses the same SQL dialect as the connector it’s based on, such as PostgreSQL, then a new  TDD file isn't necessary.
@@ -319,7 +324,7 @@ Example:
   See the temp table capabilities [here]({{ site.baseurl }}/docs/capabilities) for more details.
 
 ### Identifier Mangling:
-The identifier generation can include restrictions by character, casing and length. This is primarily used in table name mangling. 
+The identifier generation can include restrictions by character, casing and length. This is primarily used in table name mangling.
 
 **id-allowed-characters** <br/>
 Comprehensive list of characters which can be used in identifiers. Any character that isn't allowed is replaced with `_`. There is no restriction by default.

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -1,7 +1,12 @@
 ---
 title: Driver Requirements
 ---
+**In this section**
 
+* TOC
+{:toc}
+
+## Overview
 Connectors built with the Connector SDK use either an ODBC or a JDBC driver to communicate with the database.
 
 The Tableau Exchange requires using a JDBC driver.

--- a/docs/example.md
+++ b/docs/example.md
@@ -1,7 +1,12 @@
 ---
 title: Connector Example
 ---
+**In this section**
 
+* TOC
+{:toc}
+
+## Overview
 A Tableau connector is a set of files that describe the UI elements needed to collect user input for creating a connection to a data source, any dialect or customizations needed, a connection string builder, driver resolver, and the ODBC- or JDBC-based driver.
 
 Tableau connector files include:
@@ -80,7 +85,7 @@ The TDR file also contains the connection-normalizer and the driver-resolver sec
             <attr>dbname</attr>
             <attr>username</attr>
             <attr>password</attr>
-        </attribute-list>               
+        </attribute-list>
     </required-attributes>
 </connection-normalizer>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,12 @@
 ---
 title: Tableau Connector SDK
 ---
+**In this section**
+
+* TOC
+{:toc}
+
+## Overview
 Tableau has great connectivity that allows you to visualize data from virtually anywhere. Tableau includes dozens of connectors already, and also gives you the tools to build a new connector with the Tableau Connector SDK.
 
 With this SDK, you can create a connector that you can use to visualize your data from any database through an ODBC or JDBC driver.

--- a/docs/localize.md
+++ b/docs/localize.md
@@ -1,14 +1,19 @@
 ---
 title: Localize Your Connector
 ---
+**In this section**
 
+* TOC
+{:toc}
+
+## Overview
 Tableau products are localized in English (United States), English (United Kingdom), French (France), French (Canada), German, Brazilian Portuguese, Spanish, Korean, Japanese, simplified Chinese, and traditional Chinese.
 
 Connector SDK supports localizing connectors in these languages. You can localize the strings that display in the Tableau user interface, such as the connector name and the prompts in the connection dialog.
 
 For the best user experience with Tableau, we recommended that you include translation support in your connector.
 ## Specify localized strings
-You can specify localized strings using the <span style="font-family: courier new">@string/<string_id>/</span> tag. For example:    
+You can specify localized strings using the <span style="font-family: courier new">@string/<string_id>/</span> tag. For example:
   `@string/database_prompt/`
 
  You can use the tag anywhere a string is defined in the manifest.xml file or the Tableau Connection Dialog (.tcd) file.
@@ -35,7 +40,7 @@ You can add string translations to a connection dialog using resource files. Eac
   - *language* is a lowercase two-letter language code.
   - *region* is an uppercase two-letter region code.
 
-This list shows the resource filenames for the currently supported languages:  
+This list shows the resource filenames for the currently supported languages:
 ```
 resources-de_DE.xml
 resources-en_GB.xml
@@ -60,7 +65,7 @@ When you use any localized strings in your connector, you must include resources
 
 Here are examples of resources-en_US.xml (English/United States) and the corresponding resources-es_ES.xml (Spanish/Spain) resource files.
 
-__resources-en_US.xml__  
+__resources-en_US.xml__
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
@@ -68,7 +73,7 @@ __resources-en_US.xml__
   <string name="database_prompt">Database:</string>
 </resources>
 ```
-__resources-es_ES.xml__  
+__resources-es_ES.xml__
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <resources>

--- a/docs/log-entries.md
+++ b/docs/log-entries.md
@@ -1,28 +1,33 @@
 ---
 title: Signature Verification Log Entries
 ---
- 
-When the signature verification completes and the connector loads, entries are made to the logs. This page describes the log entries. 
+ **In this section**
+
+* TOC
+{:toc}
+
+## Overview
+When the signature verification completes and the connector loads, entries are made to the logs. This page describes the log entries.
 
 The log file is called log.txt and is located in the \My Tableau Repository\Logs folder.
- 
+
 ## Connector loads after the signature is verified
 
 ### Log entry examples
 
 #### .taco verified.
 
-The certificate used for signing is a valid and a trusted one, and the signature verification succeeded. Since the integrity and identity of the connector is verified, Tableau loads the connector. 
+The certificate used for signing is a valid and a trusted one, and the signature verification succeeded. Since the integrity and identity of the connector is verified, Tableau loads the connector.
 
-#### Signed by: CN=A, OU=B, O=C, L=D, ST=E, C=F 
+#### Signed by: CN=A, OU=B, O=C, L=D, ST=E, C=F
 
 This displays information about the connector .taco developer:
 
-   **CN=A** is the first and last name of the developer   
-   **OU=B** is the organizational unit   
-   **O=C** is the organization  
-   **L=D** is the organization's city  
-   **ST=E** is the organization's state  
+   **CN=A** is the first and last name of the developer
+   **OU=B** is the organizational unit
+   **O=C** is the organization
+   **L=D** is the organization's city
+   **ST=E** is the organization's state
    **C=F** is the organization's country
 
 ## Connector fails to load because the signature isn't verified
@@ -35,11 +40,11 @@ If this error dialog opens when you try to connect, it means that the connector 
 
 #### .taco is not signed.
 
-The connector hasn't been signed with a certificate. As a result, the integrity and the identity of the connector cannot be verified, and Tableau won't load the connector.taco package. 
+The connector hasn't been signed with a certificate. As a result, the integrity and the identity of the connector cannot be verified, and Tableau won't load the connector.taco package.
 
 #### There are unsigned files in the .taco.
 
-The connector.taco package has files that haven't been signed with a certificate. As a result, the integrity of the package file cannot be authenticated, and Tableau won't load the connector.taco. 
+The connector.taco package has files that haven't been signed with a certificate. As a result, the integrity of the package file cannot be authenticated, and Tableau won't load the connector.taco.
 
 #### The signer certificate chain is not validated.
 
@@ -47,21 +52,21 @@ The .taco package has been signed with a certificate, but the authenticity of th
 
 #### Failed to get trusted certificates from JRE keystore.
 
-Tableau was not able to load the trusted JRE keystore. This can happen if the JRE is not installed or the file "$PATH_TO_JRE\lib\security" (for example, "C:\Program Files (x86)\Java\jre1.8.0_221\lib\security") is not accessible 
+Tableau was not able to load the trusted JRE keystore. This can happen if the JRE is not installed or the file "$PATH_TO_JRE\lib\security" (for example, "C:\Program Files (x86)\Java\jre1.8.0_221\lib\security") is not accessible
 
 #### The signer certificate has expired.
 
-The certificate that the connector.taco developer used to sign the package is expired. Tableau doesn't rely on expired certificates because of security concerns. As a result, Tableau won't load the connector. To resolve this issue, contact the connector.taco developer. 
+The certificate that the connector.taco developer used to sign the package is expired. Tableau doesn't rely on expired certificates because of security concerns. As a result, Tableau won't load the connector. To resolve this issue, contact the connector.taco developer.
 
 #### The signer certificate is not yet valid.
 
-The certificate that the connector.taco developer used to sign the package is not yet valid and is meant to be used at a later date. Tableau doesn't rely on certificates not yet valid. As a result, Tableau won't load the connector. To resolve this issue, contact the connector.taco developer. 
- 
-## Import a certificate to the trusted keystore 
- 
+The certificate that the connector.taco developer used to sign the package is not yet valid and is meant to be used at a later date. Tableau doesn't rely on certificates not yet valid. As a result, Tableau won't load the connector. To resolve this issue, contact the connector.taco developer.
+
+## Import a certificate to the trusted keystore
+
 For signature verification, Tableau relies on public certificates being present in the JRE truststore.
 
-If the connector.taco developer uses a self-signed certificate or a certificate issued from a certificate authority that doesn't have its public certificate in the JRE truststore, the signed .taco package won't pass the signature verification process. As a result, Tableau won't load the connector. 
+If the connector.taco developer uses a self-signed certificate or a certificate issued from a certificate authority that doesn't have its public certificate in the JRE truststore, the signed .taco package won't pass the signature verification process. As a result, Tableau won't load the connector.
 
 If you trust the connector.taco developer, then you can import the public certificate provided by the connector.taco developer into the JRE truststore. After this is done, the certificate that the connector.taco developer used is trusted and the signature verification step passes if the connector.taco has not been tampered with, otherwise it will fail.
 
@@ -69,25 +74,25 @@ Follow these steps to add the certificate from the connector.taco developer to t
 
 1. Contact the connector.taco developer for the public certificate to be imported into the JRE truststore.
 
-1. Execute the following command:  
+1. Execute the following command:
 
    ```
-   keytool -importcert -file [path_public_certificate] -keystore [path_to_JRE_truststore] -alias [alias_name] 
+   keytool -importcert -file [path_public_certificate] -keystore [path_to_JRE_truststore] -alias [alias_name]
    ```
-   In the command above: 
+   In the command above:
 
-   **path_public_certificate** is the path to the public certificate provided by the connector.taco developer to be imported to the JRE truststore. 
- 
+   **path_public_certificate** is the path to the public certificate provided by the connector.taco developer to be imported to the JRE truststore.
+
    **path_to_JRE_truststore** is the path to the JRE truststore. The JRE truststore is located here by default:
 
       $PATH_TO_JRE\lib\security
 
-      For example: C:\Program Files (x86)\Java\jre1.8.0_221\lib\security 
- 
+      For example: C:\Program Files (x86)\Java\jre1.8.0_221\lib\security
+
    **alias_name** is any alias name that you want the certificate to be stored as.
 
- 
+
 1. On the prompt to enter the password, enter the password for the JRE truststore. The default password is `changeit`.
- 
-1. After running the command, when prompted if the certificate should be trusted, type in `yes`. 
+
+1. After running the command, when prompted if the certificate should be trusted, type in `yes`.
 

--- a/docs/manual-test.md
+++ b/docs/manual-test.md
@@ -3,6 +3,11 @@ title: Run Manual QA Tests
 ---
 After you create your connector and validate it using TDVT, run these manual quality assurance tests to confirm that your connector works as expected.
 
+**In this section**
+
+* TOC
+{:toc}
+
 ## Before you begin
 
 Be sure that you complete all the following steps before you begin the manual tests for your connector.

--- a/docs/mcd.md
+++ b/docs/mcd.md
@@ -5,7 +5,10 @@ title: Connection Dialog v2
 
 Connection Dialog v2 is a new feature that enables a more fully data-driven connection dialog for plugin connectors. Additionally, it provides some control over the metadata hierarchy elements--Database, Schema, and Table--both in the connection dialog and in the schema viewer, which the user sees after the connection is established.
 
+**In this section**
 
+* TOC
+{:toc}
 # How to Use Connection Dialog v2
 
 To use Connection Dialog v2, in the manifest replace `<connection-dialog>` with `<connection-fields>`, shown in the following example. The connector will fail to load if both elements appear in the manifest.

--- a/docs/metadata-enumeration.md
+++ b/docs/metadata-enumeration.md
@@ -2,7 +2,12 @@
 title: Metadata Enumeration
 ---
 
-Connection metadata refers to the set of APIs Tableau uses to model Catalog/Schema/Table hierarchy, as well as table column details like name, type and constraints. When connecting to a data source Tableau needs to start by enumerating the hierarchy and related entities. When selecting a table, or connecting to an existing saved connection, the column level info needs to be queried as well. 
+Connection metadata refers to the set of APIs Tableau uses to model Catalog/Schema/Table hierarchy, as well as table column details like name, type and constraints. When connecting to a data source Tableau needs to start by enumerating the hierarchy and related entities. When selecting a table, or connecting to an existing saved connection, the column level info needs to be queried as well.
+
+**In this section**
+
+* TOC
+{:toc}
 
 ## ODBC Metadata Enumeration
 ODBC capabilities determine the method Tableau uses to read ODBC metadata.  Note that the scenarios below are in order and the scenario that returns results first is used, all others are skipped. The detailed logs of reading ODBC metadata are logged with `SQLODBCProtocol::ReadMetadataImpl` keyword.  You should be able to find those log lines in tabprotosrv log file with `Debug` level logging.
@@ -46,7 +51,7 @@ For all Tableau connector capabilities, please refer to capabilities [documentat
 ## Catalog Hierarchy
 The Tableau platform refers to ODBC and JDBC Catalog as [Database](https://tableau.github.io/connector-plugin-sdk/docs/mcd#the-connection-metadata-file) in the SDK. It also uses the term Database by default in the product UI.
 
-Connectors do not call JDBC `setCatalog` or send a `USE <Catalog>` query. When the user selects Database it should be passed on the ODBC connection string or JDBC url/properties as appropriate. 
+Connectors do not call JDBC `setCatalog` or send a `USE <Catalog>` query. When the user selects Database it should be passed on the ODBC connection string or JDBC url/properties as appropriate.
 
 Tableau only sends Schema.Table queries, not the fully qualified table names, which is why passing the Database value as a part of the connection is required.  See Tableau product [documentation](https://help.tableau.com/current/pro/desktop/en-us/joining_tables.htm#crossdatabase-joins) for more details on the cross-database join scenario.
 

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -3,6 +3,11 @@ title: OAuth Authentication Support
 ---
 **IMPORTANT:** This feature is available in Tableau 2021.1 and newer.
 
+**In this section**
+
+* TOC
+{:toc}
+
 # How to enable OAuth for a plugin connector
 
 First check your database and driver documentation to make sure it supports OAuth. For a complete example please refer to https://github.com/tableau/connector-plugin-sdk/tree/master/samples/scenarios/snowflake_oauth.
@@ -227,7 +232,7 @@ Replace [your_dbclass] with the `dbclass` element registered in your oauthConfig
 Tableau Online is managed by Tableau. So, in order for a connector to work on Tableau Online, instructions to create a clientId, clientSecret, and redirect_uri will need to be provided.
 
 ## Site-Wide OAuth Clients
-Another way is through the site level OAuth client feature where the server admin for Tableau Server, or site admin for Tableau Online, will be able to register the OAuth client on a particular site. For example setting Azure AD OAuth client on a site: https://help.tableau.com/current/server/en-us/config_oauth_azure_ad.htm.  
+Another way is through the site level OAuth client feature where the server admin for Tableau Server, or site admin for Tableau Online, will be able to register the OAuth client on a particular site. For example setting Azure AD OAuth client on a site: https://help.tableau.com/current/server/en-us/config_oauth_azure_ad.htm.
 The OAuth clients will only be effective in the particular site, it did not require a restart and take precedence over the server-wide OAuth clients if any.
 
 | Server-Wide OAuth Clients  | Site-Wide OAuth Clients |

--- a/docs/package-sign.md
+++ b/docs/package-sign.md
@@ -4,9 +4,14 @@ title: Package and Sign Your Connector for Distribution 
 
 Packaging provides a convenient way to distribute your connector as a single .taco (Tableau Connector) file. Signing ensures that Tableau will load only .taco files that have been signed with a currently valid certificate, ensuring that they haven't been tampered with. Signing is done using the JDK and a certificate trusted by a root certificate authority (CA) that has been installed in your Java environment. When the certificate expires, Tableau will reject the .taco file unless there is a valid timestamp.
 
-Tableau Desktop verifies and loads signed connectors from a standard location (My Tableau Repository\\Connectors) or from a user supplied directory. 
+Tableau Desktop verifies and loads signed connectors from a standard location (My Tableau Repository\\Connectors) or from a user supplied directory.
 
 This document explains how to package and sign your connector using the Connector SDK. 
+
+**In this section**
+
+* TOC
+{:toc}
 
 ## Before you begin 
 
@@ -50,11 +55,11 @@ Here's one method to do that:
     `git clone https://github.com/tableau/connector-plugin-sdk.git`
 
 1.  Set up the virtual environment by going to the connector-packager folder and running `python –m venv .venv`.     
-For example: 
+For example:
     `C:\connector-plugin-sdk\connector-packager> python -m venv .venv`
     For more information about venv, see [venv – Creation of virtual environments](https://docs.python.org/3/library/venv.html) on the Python website.
 
-1.  Activate the virtual environment using the activate command. 
+1.  Activate the virtual environment using the activate command.
 For example, on Windows:
 `C:\connector-plugin-sdk\connector-packager>.\.venv\Scripts\activate`  
 Or, on Mac:
@@ -73,7 +78,7 @@ Or, on Linux:
 
 You must run the connector-packager tool from the connector-plugin-sdk/connector-packager/ directory. The packaged TACO file, by  default, will be generated within packaged-connector folder. There are several ways to run the tool:
 
--   To package the connector, run this command: 
+-   To package the connector, run this command:
  `python -m connector_packager.package [path_to_plugin_folder]`
 
 -   To validate that the XML files are valid without packaging the connector, run this command:

--- a/docs/run-taco.md
+++ b/docs/run-taco.md
@@ -4,6 +4,11 @@ title: Run Your Connector
 
 Note: the below is intended for connector developers. Customer-facing documentation is available [here](https://help.tableau.com/current/pro/desktop/en-us/examples_connector_sdk.htm).
 
+**In this section**
+
+* TOC
+{:toc}
+
 # Load order and class name collisions
 
 ## Tableau 2022.2 and newer

--- a/docs/security-considerations.md
+++ b/docs/security-considerations.md
@@ -8,6 +8,11 @@ During the connector review for the Tableau Exchange, the connector will go thro
 
 Tableau will also pull any connector from the Tableau Exchange that is found to have a security vulnerability. That vulnerability must be addressed before the connector can return to the Exchange.
 
+**In this section**
+
+* TOC
+{:toc}
+
 
 # Secure Attributes on the Connection Dialog
 

--- a/docs/tdvt-test-case.md
+++ b/docs/tdvt-test-case.md
@@ -2,6 +2,12 @@
 title: Fixing TDVT Test Failures
 ---
 
+**In this section**
+
+* TOC
+{:toc}
+
+## Overview
 How to leverage the results workbook is explained [step by step in our YouTube guide](https://youtu.be/rAgnnByJIJA) [[28:26](https://youtu.be/rAgnnByJIJA?t=1706)]. Running TDVT produces a CSV file with data on all the tests cases that were executed, and the best way to view data is, of course, in Tableau. We provide a [TDVT Results Workbook](https://github.com/tableau/connector-plugin-sdk/blob/master/tdvt/TDVT%20Results.twb) that gives you a high-level overview on how many tests passed in each category and gives you tools to drill down to individual test cases and see the expected values versus actual values, the sql statement that was sent to the database, and any errors Tableau reported while running the test.
 
 ![]({{ site.baseurl }}/assets/tdvt_results_dashboard.png)

--- a/docs/tdvt.md
+++ b/docs/tdvt.md
@@ -4,6 +4,10 @@ title: Test with TDVT Suite
 
 Tableau provides an automated testing tool called the Tableau Data source Verification Tool, or TDVT, to test Tableau connectivity with a database. TDVT runs tests that range from simple expressions to complex SQL.
 
+**In this section**
+
+* TOC
+{:toc}
 #### Check out our step-by-step guide to using TDVT:
 {% include youtubePlayer.html id="rAgnnByJIJA" %}
 
@@ -97,7 +101,7 @@ Note that tdvt_workspace should contain the following subdirectories: config, pl
    For example:
    `TAB_CLI_EXE_X64 = C:\Program Files\Tableau\Tableau 1234.1\bin\tabquerytool.exe`
 
-__Note:__ For setting up TDVT using Tableau Linux Server please click [here](/connector-plugin-sdk/docs/tdvt#running-tdvt-test-with-tabquerytoolsrv-in-linux-server). 
+__Note:__ For setting up TDVT using Tableau Linux Server please click [here](/connector-plugin-sdk/docs/tdvt#running-tdvt-test-with-tabquerytoolsrv-in-linux-server).
 
 
 
@@ -548,13 +552,13 @@ __The agg.countd expression test and the join.null.int logical tests are failing
 Check that your database is correctly returning column nullability information in the metadata. See [Design Considerations]({{ site.baseurl }}/docs/design) for more information.
 
 __Date string format varies according to OS date format settings__
-TDVT requires the OS locale be set to English/US so that the dates are formatted mm/dd/yyyy. 
+TDVT requires the OS locale be set to English/US so that the dates are formatted mm/dd/yyyy.
 
 ## Running TDVT test with tabquerytoolsrv in Linux Server
 You can run TDVT tests by configuring the setup file below to use `tabquerytoolsrv`. `tabquerytoolsrv` is located in `/opt/tableau/tableau_server/packages/bin.<version_code>/tabquerytoolsrv`, where <version_code> corresponds to the version of Tableau Server (ie 2022.3).
- Before being able to run TDVT tests using tabquerytoolsrv make sure that: 
+ Before being able to run TDVT tests using tabquerytoolsrv make sure that:
    - Your instance of the tableau server is running. Click [here](https://help.tableau.com/current/server/en-us/cli_start_tsm.htm) for more details.
-   - Your server license has been activated. Click [here](https://help.tableau.com/current/server/en-us/cli_licenses_tsm.htm) for more details. 
+   - Your server license has been activated. Click [here](https://help.tableau.com/current/server/en-us/cli_licenses_tsm.htm) for more details.
 
 Once the above steps are verified you should be able to run TDVT tests using `tabquerytoolsrv` by running the following command:
 Update the `tdvt_override.ini` file to use `tabquerytoolsrv`
@@ -563,7 +567,7 @@ Update the `tdvt_override.ini` file to use `tabquerytoolsrv`
    [DEFAULT]
    TAB_CLI_EXE_LINUX = /opt/tableau/tableau_server/packages/bin.<version_code>/tabquerytoolsrv
    ```
-Update the mydb.ini file to have `-DParamFile` which specifies the as a `CommandLineOverride`. 
+Update the mydb.ini file to have `-DParamFile` which specifies the as a `CommandLineOverride`.
 Example mydb.ini file
 
    ```ini
@@ -576,5 +580,5 @@ Example mydb.ini file
    ...
    ```
 
-You should be able to run the TDVT tests following the steps in [this]({{ site.baseurl }}/docs/tdvt) doc. 
+You should be able to run the TDVT tests following the steps in [this]({{ site.baseurl }}/docs/tdvt) doc.
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -4,6 +4,11 @@ title: Connection Dialog v1
 
 Connection Dialog v2 is the recommended pattern for new connectors. For more details see the [Connection Dialog v2]({{ site.baseurl }}/docs/mcd) page.
 
+**In this section**
+
+* TOC
+{:toc}
+
 ## Define Tableau Custom Dialog file elements
 
 The TCD file defines which UI elements display in the dialog.  The Connection Dialog V1 is a fixed list as defined by the file [XSD](https://github.com/tableau/connector-plugin-sdk/blob/master/validation/tcd_latest.xsd).


### PR DESCRIPTION
Adds table of contents to all relevant doc pages as a quick hackathon thing, using the format first used on this page: https://tableau.github.io/connector-plugin-sdk/docs/gallery-submission. Automatically generates the table of contents based on the headers in markdown, although markdown previews don't appear to work. 

This makes it easier to jump to a certain section, and makes it easier for us to send a direct link to a certain section when providing feedback during reviews.

Tested locally and confirmed the pages appear correct. 

Also, have VS Code set to automatically delete trailing whitespace when I save. Because I touched every page, the diffs also have a bunch of whitespace getting removed.