### PR TITLE
Update dialect XSD to include 'DBDATE' in RemoteType-ST

### DIFF
--- a/validation/tdd_latest.xsd
+++ b/validation/tdd_latest.xsd
@@ -353,7 +353,7 @@ as passed-in parameters.
       <xs:enumeration value="WSTR"/>
       <xs:enumeration value="NUMERIC"/>
       <xs:enumeration value="UDT"/>
-      <xs:enumeration value="DATE"/>
+      <xs:enumeration value="DBDATE"/>
       <xs:enumeration value="TIME"/>
       <xs:enumeration value="TIMESTAMP"/>
     </xs:restriction>


### PR DESCRIPTION
- 'DBDATE' value was missing as a valid value in RemoteType-ST
- 'DATE' value was listed twice in RemoteType-ST
- update second 'DATE' to 'DBDATE' to allow support for DBTYPE_DBDATE