### PR TITLE
Remove TabExtension logic to fix perf logging

### DIFF
--- a/tdvt/tdvt/tabquery.py
+++ b/tdvt/tdvt/tabquery.py
@@ -39,15 +39,7 @@ def get_max_process_level_of_parallelization(desired_threads):
 
 
 def build_tabquery_command_line(work):
-    try:
-        sys.path.insert(0, get_extensions_dir())
-        from extend_tabquery import TabqueryCommandLineExtension
-        sys.path.pop(0)
-        tb = TabqueryCommandLineExtension()
-        logging.debug("Imported extension extend_tabquery")
-    except ImportError:
-        tb = TabqueryCommandLine()
-
+    tb = TabqueryCommandLine()
     cmdline = tb.build_tabquery_command_line(work)
     return cmdline
 

--- a/tdvt/test/tdvt_test.py
+++ b/tdvt/test/tdvt_test.py
@@ -353,24 +353,6 @@ class CommandLineTest(unittest.TestCase):
         cmd_line_str = ' '.join(cmd_line)
         self.assertTrue('--password-file' in cmd_line_str and 'password_test.password' in cmd_line_str)
 
-    def test_command_line_full_extension(self):
-
-        self.test_config.output_dir = 'my/output/dir'
-        self.test_config.d_override = '-DLogLevel=Debug'
-        self.test_config.tested_run_time_config.set_tabquery_paths("tabquerytool", "tabquerytool", "tabquerytool.exe")
-
-        work = tdvt_core.BatchQueueWork(self.test_config, self.test_set)
-        work.test_extension = True
-        cmd_line = build_tabquery_command_line_local(work)
-        cmd_line_str = ' '.join(cmd_line)
-        if sys.platform in ('win32', 'cygwin'):
-            expected = 'tabquerytool.exe --expression-file-list my/output/dir\mytest\\tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir\mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall -DInMemoryLogicalCacheDisable --test_arg my/output/dir'  # noqa: E501
-        elif sys.platform in ('darwin', 'linux'):
-            expected = 'tabquerytool --expression-file-list my/output/dir/mytest/tests.txt -d mytds.tds --combined --output-dir my/output/dir -DLogDir=my/output/dir/mytest -DOverride=ProtocolServerNewLog -DLogLevel=Debug -DLogicalQueryRewriteDisable=Funcall:RewriteConstantFuncall -DInMemoryLogicalCacheDisable --test_arg my/output/dir'  # noqa: E501
-        else:
-            self.skipTest("Unsupported test OS: {}".format(sys.platform))
-        self.assertEquals(cmd_line_str, expected)
-
     def test_command_line_no_expected(self):
         self.test_config.tested_run_time_config.set_tabquery_paths("tabquerytool", "tabquerytool", "tabquerytool.exe")
         work = tdvt_core.BatchQueueWork(self.test_config, self.test_set)


### PR DESCRIPTION
Change for internal consumption. Removes unit test for logic, too.