### PR TITLE
@W-12971224: [OAuth][SDK] Add `configLabel` field to Connector SDK

### DIFF
--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -102,6 +102,7 @@ The OAuth Config file ([XSD](https://github.com/tableau/connector-plugin-sdk/blo
 | ----  | ------- | --------- | ----------- | ----------- |
 | dbclass | String | The connector class which this OAuth config applies to. | Yes | The dbclass must be same with as the `class` attribute in manifest.xml |
 | oauthConfigId | String | Unique ID for this OAuth config | Recommended | *New in Tableau 2023.1.* This is a required attribute if there are multiple OAuth configs defined for a connector. **When using an external/custom config this must begin with the prefix "custom_".** |
+| configLabel | String | Label that is used as a display to users in place of the oauthConfigId. | No | *New in Tableau 2023.2.* This must only contain alphanumeric characters, "_", "-", and spaces in order to be considered valid. |
 | clientIdDesktop | String | Client ID you registered for Tableau Desktop | No | This is not considered a secret and will be stored in plain text |
 | clientSecretDesktop | String | Client Secret you registered for Tableau Desktop | No | This is not considered a secret and will be stored in plain text |
 | redirectUrisDesktop | String[] | Redirect Urls for Desktop | No | Only required when `OAUTH_CAP_FIXED_PORT_IN_CALLBACK_URL` is set to true. This will configure the URL for the authorization response browser redirect. See [redirectUrisDesktop Format](#redirecturisdesktop-format) below for the URL format. This element can be specified multiple times, one for each port. Example: http://localhost:55557/Callback |


### PR DESCRIPTION
Add `configLabel` field to supported OAuth Config fields in the OAuth docs.
