### PR TITLE
@W-12971224: [OAuth][SDK] Add `configLabel` field to Connector SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Tableau Connector SDK Changelog
+## 2023-04-10
+### Changed
+- Update `oauth_config.xsd` to include `configLabel` field and update `min-version-tableau` to be 2023.2 if present
 ## 2023-04-04
 ### Changed
 - Update `oauth_config.xsd` to include `instanceUrlSuffix` field and update `min-version-tableau` to be 2023.1 if present

--- a/connector-packager/connector_packager/jar_jdk_packager.py
+++ b/connector-packager/connector_packager/jar_jdk_packager.py
@@ -60,7 +60,11 @@ def get_min_support_version(file_list: List[ConnectorFile], cur_min_version_tabl
             
             oauthConfigId = pluginOAuthConfigRoot.find('.//oauthConfigId')
             instanceUrlSuffix = pluginOAuthConfigRoot.find('.//instanceUrlSuffix')
-            if (instanceUrlSuffix is not None and 2023.1 > float(min_version_tableau)):
+            configLabel = pluginOAuthConfigRoot.find('.//configLabel')
+            if (configLabel is not None and 2023.2 > float(min_version_tableau)):
+                min_version_tableau = "2023.2"
+                reasons.append("Connector uses configLabel field, which was added in the 2023.2 release")
+            elif (instanceUrlSuffix is not None and 2023.1 > float(min_version_tableau)):
                 min_version_tableau = "2023.1"
                 reasons.append("Connector uses instanceUrlSuffix field, which was added in the 2023.1 release")
             elif (oauthConfigId is not None and 2021.4 > float(min_version_tableau)):

--- a/connector-packager/tests/test_jar_packager.py
+++ b/connector-packager/tests/test_jar_packager.py
@@ -17,6 +17,7 @@ VERSION_2020_3 = "2020.3"
 VERSION_2021_1 = "2021.1"
 VERSION_2021_4 = "2021.4"
 VERSION_2023_1 = "2023.1"
+VERSION_2023_2 = "2023.2"
 VERSION_FUTURE = "2525.1"
 VERSION_THREE_PART = "2021.1.3"
 
@@ -356,6 +357,39 @@ class TestJarPackager(unittest.TestCase):
         manifest = ET.parse(path_to_extracted_manifest)
         self.assertEqual(manifest.getroot().get("min-version-tableau"),
                          VERSION_2023_1, "wrong min-version-tableau attr or doesn't exist")
+
+        if dest_dir.exists():
+            shutil.rmtree(dest_dir)
+
+    def test_jdk_create_jar_oauth_with_config_label(self):
+        files_list = [
+            ConnectorFile("manifest.xml", "manifest"),
+            ConnectorFile("connectionFields.xml", "connection-fields"),
+            ConnectorFile("connectionMetadata.xml", "connection-metadata"),
+            ConnectorFile("connectionBuilder.js", "script"),
+            ConnectorFile("dialect.xml", "dialect"),
+            ConnectorFile("connectionResolver.xml", "connection-resolver"),
+            ConnectorFile("connectionProperties.js", "script"),
+            ConnectorFile("oauth-config-with-label.xml", "oauth-config")]
+        source_dir = TEST_FOLDER / Path("oauth_connector")
+        dest_dir = TEST_FOLDER / Path("packaged-connector-by-jdk/")
+        package_name = "test_oauth.taco"
+
+        jdk_create_jar(source_dir, files_list, package_name, dest_dir)
+
+        path_to_test_file = dest_dir / Path(package_name)
+        self.assertTrue(os.path.isfile(path_to_test_file), "taco file doesn't exist")
+
+        # test min support tableau version is stamped
+        args = ["jar", "xf", package_name, MANIFEST_FILE_NAME]
+        p = subprocess.Popen(args, cwd=os.path.abspath(dest_dir))
+        self.assertEqual(p.wait(), 0, "can not extract manfifest file from taco")
+        path_to_extracted_manifest = dest_dir / MANIFEST_FILE_NAME
+        self.assertTrue(os.path.isfile(path_to_extracted_manifest), "extracted manifest file doesn't exist")
+
+        manifest = ET.parse(path_to_extracted_manifest)
+        self.assertEqual(manifest.getroot().get("min-version-tableau"),
+                         VERSION_2023_2, "wrong min-version-tableau attr or doesn't exist")
 
         if dest_dir.exists():
             shutil.rmtree(dest_dir)

--- a/connector-packager/tests/test_resources/oauth_config_label/invalid/oauth-config.xml
+++ b/connector-packager/tests/test_resources/oauth_config_label/invalid/oauth-config.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<pluginOAuthConfig>
+    <dbclass>test_oauth</dbclass>
+
+    <configLabel>Test OAuth Label</configLabel>
+    <oauthConfigId>oauthConfigid</oauthConfigId>
+    <clientIdDesktop>******</clientIdDesktop>
+    <clientSecretDesktop>******</clientSecretDesktop>
+    <redirectUrisDesktop>http://localhost:55555/Callback</redirectUrisDesktop>
+    <instanceUrlSuffix>/oidc</instanceUrlSuffix>
+
+    <authUri>/oauth2/v2.0/authorize</authUri>
+    <tokenUri>/oauth2/v2.0/token</tokenUri>
+
+    <scopes>openid</scopes>
+    <scopes>email</scopes>
+    <scopes>profile</scopes>
+    <scopes>offline_access</scopes>
+
+</pluginOAuthConfig>

--- a/connector-packager/tests/test_resources/oauth_config_label/valid/oauth-config.xml
+++ b/connector-packager/tests/test_resources/oauth_config_label/valid/oauth-config.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<pluginOAuthConfig>
+    <dbclass>test_oauth</dbclass>
+
+    <oauthConfigId>oauthConfigid</oauthConfigId>
+    <configLabel>Test OAuth Label</configLabel>
+    <clientIdDesktop>******</clientIdDesktop>
+    <clientSecretDesktop>******</clientSecretDesktop>
+    <redirectUrisDesktop>http://localhost:55555/Callback</redirectUrisDesktop>
+
+    <authUri>/oauth2/v2.0/authorize</authUri>
+    <tokenUri>/oauth2/v2.0/token</tokenUri>
+
+    <scopes>openid</scopes>
+    <scopes>email</scopes>
+    <scopes>profile</scopes>
+    <scopes>offline_access</scopes>
+
+</pluginOAuthConfig>

--- a/connector-packager/tests/test_resources/oauth_connector/oauth-config-with-label.xml
+++ b/connector-packager/tests/test_resources/oauth_connector/oauth-config-with-label.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<pluginOAuthConfig>
+    <dbclass>test_oauth</dbclass>
+
+    <oauthConfigId>oauthConfigid</oauthConfigId>
+    <configLabel>Test OAuth Label</configLabel>
+    <clientIdDesktop>******</clientIdDesktop>
+    <clientSecretDesktop>******</clientSecretDesktop>
+    <redirectUrisDesktop>http://localhost:55555/Callback</redirectUrisDesktop>
+
+    <authUri>/oauth2/v2.0/authorize</authUri>
+    <tokenUri>/oauth2/v2.0/token</tokenUri>
+
+    <scopes>openid</scopes>
+    <scopes>email</scopes>
+    <scopes>profile</scopes>
+    <scopes>offline_access</scopes>
+
+</pluginOAuthConfig>

--- a/connector-packager/tests/test_xsd_validator.py
+++ b/connector-packager/tests/test_xsd_validator.py
@@ -416,11 +416,33 @@ class TestXSDValidator(unittest.TestCase):
         xml_violations_buffer = []
 
         self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
-                        "oauthConfig should be able to have no oauthConfigId field")
+                        "oauthConfig should be able to have no instanceUrlSuffix field")
 
-        test_file = TEST_FOLDER / "oauth_config_id/invalid/oauth-config.xml"
+        test_file = TEST_FOLDER / "oauth_instance_url_suffix/invalid/oauth-config.xml"
         file_to_test = ConnectorFile("oauth-config.xml", "oauth-config")
         xml_violations_buffer = []
 
         self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
                          "The instanceUrlSuffix must be located after authUri and tokenUri.")
+        
+    def test_validate_config_label(self):
+        test_file = TEST_FOLDER / "oauth_config_label/valid/oauth-config.xml"
+        file_to_test = ConnectorFile("oauth-config.xml", "oauth-config")
+        xml_violations_buffer = []
+
+        self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
+                        "Valid XML file not marked as valid")
+
+        test_file = TEST_FOLDER / "oauth_connector/oauth-config.xml"
+        file_to_test = ConnectorFile("oauth-config.xml", "oauth-config")
+        xml_violations_buffer = []
+
+        self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
+                        "oauthConfig should be able to have no configLabel field")
+
+        test_file = TEST_FOLDER / "oauth_config_label/invalid/oauth-config.xml"
+        file_to_test = ConnectorFile("oauth-config.xml", "oauth-config")
+        xml_violations_buffer = []
+
+        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
+                         "The configLabel field must be located after authUri and tokenUri.")

--- a/validation/oauth_config.xsd
+++ b/validation/oauth_config.xsd
@@ -26,6 +26,7 @@
     <xs:sequence>
       <xs:element type="xs:string" name="dbclass"/>
       <xs:element type="xs:string" name="oauthConfigId" maxOccurs="1" minOccurs="0"/>
+      <xs:element type="xs:string" name="configLabel" maxOccurs="1" minOccurs="0"/>
       <!--Allow registering oauth for server use only, mostly for connectorless OAuth-->
       <xs:element type="xs:string" name="clientIdDesktop" maxOccurs="1" minOccurs="0"/>
       <!--Some oauth provider allow native app using oauth without clientSecret-->


### PR DESCRIPTION
Add support for `configLabel` in the Connector Plugin SDK. 

The monolith changes were added in 2023.2 so this is only supported in 2023.2 and beyond.