### PR TITLE
@W-12314727 - [OAuth-Service][Plugins] Default Instance URL support for SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Tableau Connector SDK Changelog
+## 2023-04-20
+### Changed
+- Update `oauth_config.xsd` to include `defaultInstanceUrl` field and update `min-version-tableau` to be 2023.3 if present
 ## 2022-12-16
 ### Changed
 - Convert database impersonation sample to Connection Dialog V2     

--- a/connector-packager/connector_packager/jar_jdk_packager.py
+++ b/connector-packager/connector_packager/jar_jdk_packager.py
@@ -58,7 +58,11 @@ def get_min_support_version(file_list: List[ConnectorFile], cur_min_version_tabl
             # Check to see if we're using oauthConfigId, which needs 2021.4+
             pluginOAuthConfigRoot = ET.parse(input_dir / connector_file.file_name).getroot()
             oauthConfigId = pluginOAuthConfigRoot.find('.//oauthConfigId')
-            if (oauthConfigId is not None and 2021.4 > float(min_version_tableau)):
+            defaultInstanceUrl = pluginOAuthConfigRoot.find('.//defaultInstanceUrl')
+            if (defaultInstanceUrl is not None and 2023.3 > float(min_version_tableau)):
+                min_version_tableau = "2023.3"
+                reasons.append("Connector uses defaultInstanceUrl field, which was added in the 2023.3 release")
+            elif (oauthConfigId is not None and 2021.4 > float(min_version_tableau)):
                 min_version_tableau = "2021.4"
                 reasons.append("Connector contains an oauthConfigId field, which was added in the 2021.4 release")
             elif 2021.1 > float(min_version_tableau):

--- a/connector-packager/tests/test_jar_packager.py
+++ b/connector-packager/tests/test_jar_packager.py
@@ -16,6 +16,7 @@ MANIFEST_FILE_NAME = "manifest.xml"
 VERSION_2020_3 = "2020.3"
 VERSION_2021_1 = "2021.1"
 VERSION_2021_4 = "2021.4"
+VERSION_2023_3 = "2023.3"
 VERSION_FUTURE = "2525.1"
 VERSION_THREE_PART = "2021.1.3"
 
@@ -322,6 +323,39 @@ class TestJarPackager(unittest.TestCase):
         self.assertEqual(p.wait(), 0, "can not extract oauth-config-copy.xml from taco")
         path_to_extracted_oauth_config = dest_dir / "oauth-config-copy.xml"
         self.assertTrue(os.path.isfile(path_to_extracted_oauth_config), "extracted oauth-config-copy.xml file doesn't exist")
+
+        if dest_dir.exists():
+            shutil.rmtree(dest_dir)
+
+    def test_jdk_create_jar_oauth_with_default_instance_url(self):
+        files_list = [
+            ConnectorFile("manifest.xml", "manifest"),
+            ConnectorFile("connectionFields.xml", "connection-fields"),
+            ConnectorFile("connectionMetadata.xml", "connection-metadata"),
+            ConnectorFile("connectionBuilder.js", "script"),
+            ConnectorFile("dialect.xml", "dialect"),
+            ConnectorFile("connectionResolver.xml", "connection-resolver"),
+            ConnectorFile("connectionProperties.js", "script"),
+            ConnectorFile("oauth-config-with-default-instance-url.xml", "oauth-config")]
+        source_dir = TEST_FOLDER / Path("oauth_connector")
+        dest_dir = TEST_FOLDER / Path("packaged-connector-by-jdk/")
+        package_name = "test_oauth.taco"
+
+        jdk_create_jar(source_dir, files_list, package_name, dest_dir)
+
+        path_to_test_file = dest_dir / Path(package_name)
+        self.assertTrue(os.path.isfile(path_to_test_file), "taco file doesn't exist")
+
+        # test min support tableau version is stamped
+        args = ["jar", "xf", package_name, MANIFEST_FILE_NAME]
+        p = subprocess.Popen(args, cwd=os.path.abspath(dest_dir))
+        self.assertEqual(p.wait(), 0, "can not extract manfifest file from taco")
+        path_to_extracted_manifest = dest_dir / MANIFEST_FILE_NAME
+        self.assertTrue(os.path.isfile(path_to_extracted_manifest), "extracted manifest file doesn't exist")
+
+        manifest = ET.parse(path_to_extracted_manifest)
+        self.assertEqual(manifest.getroot().get("min-version-tableau"),
+                         VERSION_2023_3, "wrong min-version-tableau attr or doesn't exist")
 
         if dest_dir.exists():
             shutil.rmtree(dest_dir)

--- a/connector-packager/tests/test_resources/oauth_connector/oauth-config-with-default-instance-url.xml
+++ b/connector-packager/tests/test_resources/oauth_connector/oauth-config-with-default-instance-url.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<pluginOAuthConfig>
+    <dbclass>test_oauth</dbclass>
+
+    <oauthConfigId>oauthConfigid</oauthConfigId>
+    <clientIdDesktop>******</clientIdDesktop>
+    <clientSecretDesktop>******</clientSecretDesktop>
+    <redirectUrisDesktop>http://localhost:55555/Callback</redirectUrisDesktop>
+
+    <authUri>/oauth2/v2.0/authorize</authUri>
+    <tokenUri>/oauth2/v2.0/token</tokenUri>
+
+    <defaultInstanceUrl>https://login.instanceurl.com</defaultInstanceUrl>
+
+    <scopes>openid</scopes>
+    <scopes>email</scopes>
+    <scopes>profile</scopes>
+    <scopes>offline_access</scopes>
+
+</pluginOAuthConfig>

--- a/connector-packager/tests/test_resources/oauth_default_instance_url/invalid/oauth-config.xml
+++ b/connector-packager/tests/test_resources/oauth_default_instance_url/invalid/oauth-config.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<pluginOAuthConfig>
+    <dbclass>test_oauth</dbclass>
+
+    <clientIdDesktop>******</clientIdDesktop>
+    <clientSecretDesktop>******</clientSecretDesktop>
+    <redirectUrisDesktop>http://localhost:55555/Callback</redirectUrisDesktop>
+    <defaultInstanceUrl>https://login.instanceurl.com</defaultInstanceUrl>
+
+    <authUri>/oauth2/v2.0/authorize</authUri>
+    <tokenUri>/oauth2/v2.0/token</tokenUri>
+
+    <scopes>openid</scopes>
+    <scopes>email</scopes>
+    <scopes>profile</scopes>
+    <scopes>offline_access</scopes>
+
+</pluginOAuthConfig>

--- a/connector-packager/tests/test_resources/oauth_default_instance_url/valid/oauth-config.xml
+++ b/connector-packager/tests/test_resources/oauth_default_instance_url/valid/oauth-config.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<pluginOAuthConfig>
+    <dbclass>test_oauth</dbclass>
+
+    <clientIdDesktop>******</clientIdDesktop>
+    <clientSecretDesktop>******</clientSecretDesktop>
+    <redirectUrisDesktop>http://localhost:55555/Callback</redirectUrisDesktop>
+
+    <authUri>/oauth2/v2.0/authorize</authUri>
+    <tokenUri>/oauth2/v2.0/token</tokenUri>
+
+    <defaultInstanceUrl>https://login.instanceurl.com</defaultInstanceUrl>
+
+    <scopes>openid</scopes>
+    <scopes>email</scopes>
+    <scopes>profile</scopes>
+    <scopes>offline_access</scopes>
+
+</pluginOAuthConfig>

--- a/connector-packager/tests/test_xsd_validator.py
+++ b/connector-packager/tests/test_xsd_validator.py
@@ -402,3 +402,25 @@ class TestXSDValidator(unittest.TestCase):
         test_file = TEST_FOLDER / "multiple_oauth_config/test_manifest_files/manifest_2_config.xml"
         self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
                          "3 OAuth Config Fields are marked as invalid")
+        
+    def test_validate_default_instance_url(self):
+        test_file = TEST_FOLDER / "oauth_default_instance_url/valid/oauth-config.xml"
+        file_to_test = ConnectorFile("oauth-config.xml", "oauth-config")
+        xml_violations_buffer = []
+
+        self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
+                        "Valid XML file not marked as valid")
+
+        test_file = TEST_FOLDER / "oauth_connector/oauth-config.xml"
+        file_to_test = ConnectorFile("oauth-config.xml", "oauth-config")
+        xml_violations_buffer = []
+
+        self.assertTrue(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
+                        "oauthConfig should be able to have no defaultInstanceUrl field")
+
+        test_file = TEST_FOLDER / "oauth_default_instance_url/invalid/oauth-config.xml"
+        file_to_test = ConnectorFile("oauth-config.xml", "oauth-config")
+        xml_violations_buffer = []
+
+        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
+                         "The defaultInstanceUrl must be located after authUri and tokenUri.")

--- a/validation/oauth_config.xsd
+++ b/validation/oauth_config.xsd
@@ -35,6 +35,7 @@
       <xs:element type="xs:string" name="tokenUri"/>
       <xs:element type="xs:string" name="userInfoUri" maxOccurs="1" minOccurs="0"/>
       <xs:element type="xs:string" name="instanceUrlValidationRegex" maxOccurs="1" minOccurs="0"/>
+      <xs:element type="xs:string" name="defaultInstanceUrl" maxOccurs="1" minOccurs="0"/>
       <xs:element type="xs:string" name="scopes" maxOccurs="unbounded" minOccurs="1"/>
       <xs:element type="xs:string" name="requiredAuthAttrs" maxOccurs="unbounded" minOccurs="0"/>
       <xs:element type="xs:string" name="requiredRefreshAttrs" maxOccurs="unbounded" minOccurs="0"/>


### PR DESCRIPTION
Adds support for defaultInstanceUrl and sets minimum version to 2023.3 when present.

As we don't know what the versioning system looks like for tableau in the future, this might have to be changed to 246 or whatever is chosen...
