### PR TITLE
Fix a bug that the actual and expected values are missing in test_results_combined.csv.

### DIFF
--- a/tdvt/tdvt/tdvt_core.py
+++ b/tdvt/tdvt/tdvt_core.py
@@ -641,14 +641,14 @@ def return_csv_dialect(is_perf_run: bool = False):
 
 def get_csv_header_data(all_test_results, is_perf_run: bool) -> List[str]:
     if is_perf_run:
-        csv_header = PERFLAB_CSV_HEADERS
+        csv_header = PERFLAB_CSV_HEADERS.copy()
     else:
         tuple_limit_str = '(' + str(TUPLE_DISPLAY_LIMIT) + ')tuples'
         actual_tuples_header = 'Actual ' + tuple_limit_str
         expected_tuples_header = 'Expected ' + tuple_limit_str
         # Suite is the datasource name (ie mydb).
         # Test Set is the grouping that defines related tests. run tdvt --list mydb to see them.
-        csv_header = DEFAULT_CSV_HEADERS
+        csv_header = DEFAULT_CSV_HEADERS.copy()
         csv_header.extend([actual_tuples_header, expected_tuples_header])
         results_values = list(all_test_results.values())
         if results_values:

--- a/tdvt/tdvt/tdvt_core.py
+++ b/tdvt/tdvt/tdvt_core.py
@@ -641,7 +641,7 @@ def return_csv_dialect(is_perf_run: bool = False):
 
 def get_csv_header_data(all_test_results, is_perf_run: bool) -> List[str]:
     if is_perf_run:
-        csv_header = PERFLAB_CSV_HEADERS.copy()
+        csv_header = PERFLAB_CSV_HEADERS
     else:
         tuple_limit_str = '(' + str(TUPLE_DISPLAY_LIMIT) + ')tuples'
         actual_tuples_header = 'Actual ' + tuple_limit_str


### PR DESCRIPTION
Currently the generated test_results_combined.csv is missing values in the "Actual (100)tuples" and "Expected (100)tuples" columns.

There is a bug in [`get_csv_header_data`](https://github.com/tableau/connector-plugin-sdk/blob/b2db407e52309d9a7f50d81e738fa9554e7d9c8c/tdvt/tdvt/tdvt_core.py#L642). If we call this function multiple times, the returned string list changes: we continuously extend `[actual_tuples_header, actual_tuples_header]` to the list. This is because [here](https://github.com/tableau/connector-plugin-sdk/blob/b2db407e52309d9a7f50d81e738fa9554e7d9c8c/tdvt/tdvt/tdvt_core.py#L651) is not a value copy but a reference assignment.

If the csv file's header has duplicate column names, the csv.DictReader [parses](https://github.com/tableau/connector-plugin-sdk/blob/b2db407e52309d9a7f50d81e738fa9554e7d9c8c/tdvt/tdvt/tdvt.py#L54) the values for the column as empty.

Tested this PR by running the TDVT test and verifying the values are not missing in test_results_combined.csv.