### PR TITLE
Corrected the handling of the boolean options for Staples and CastCal…

### DIFF
--- a/tdvt/tdvt/config_gen/datasource_list.py
+++ b/tdvt/tdvt/config_gen/datasource_list.py
@@ -356,16 +356,14 @@ def load_test(config, test_dir=get_root_dir()):
                 logging.debug(e)
                 pass
         # Add smoke tests
-        elif sect.get('StaplesSmokeTestEnabled') == 'True' or sect.get('CalcsSmokeTestEnabled') == 'True':
+        elif connection_test in section:
             try:
                 all_ini_sections.remove(section)
-                if sect.get('StaplesSmokeTestEnabled') == 'True':
-                    test_config.add_logical_test('StaplesConnectionTest', STAPLES_TDS, sect.get(KEY_EXCLUSIONS, ''),
-                                                test_config.get_logical_test_path('logicaltests/setup/connection_test/setup.staples.*.'),  # noqa: E501
-                                                test_dir, get_password_file(sect), get_expected_message(sect), True,
-                                                get_is_test_enabled(sect, 'StaplesTestEnabled'), False)
-                if sect.get('CalcsSmokeTestEnabled') == 'True':
-                    test_config.add_expression_test('CastCalcsConnectionTest', CALCS_TDS, sect.get(KEY_EXCLUSIONS, ''),
+                test_config.add_logical_test('StaplesConnectionTest', STAPLES_TDS, sect.get(KEY_EXCLUSIONS, ''),
+                                             test_config.get_logical_test_path('logicaltests/setup/connection_test/setup.staples.*.'),  # noqa: E501
+                                             test_dir, get_password_file(sect), get_expected_message(sect), True,
+                                             get_is_test_enabled(sect, 'StaplesTestEnabled'), False)
+                test_config.add_expression_test('CastCalcsConnectionTest', CALCS_TDS, sect.get(KEY_EXCLUSIONS, ''),
                                                 get_expression_test_dir_path(sect, 'exprtests/pretest/connection_tests/calcs/'),  # noqa: E501
                                                 test_dir, get_password_file(sect), get_expected_message(sect), True,
                                                 get_is_test_enabled(sect, 'CastCalcsTestEnabled'), False)

--- a/tdvt/tdvt/config_gen/datasource_list.py
+++ b/tdvt/tdvt/config_gen/datasource_list.py
@@ -356,14 +356,16 @@ def load_test(config, test_dir=get_root_dir()):
                 logging.debug(e)
                 pass
         # Add smoke tests
-        elif connection_test in section:
+        elif sect.get('StaplesSmokeTestEnabled') == 'True' or sect.get('CalcsSmokeTestEnabled') == 'True':
             try:
                 all_ini_sections.remove(section)
-                test_config.add_logical_test('StaplesConnectionTest', STAPLES_TDS, sect.get(KEY_EXCLUSIONS, ''),
-                                             test_config.get_logical_test_path('logicaltests/setup/connection_test/setup.staples.*.'),  # noqa: E501
-                                             test_dir, get_password_file(sect), get_expected_message(sect), True,
-                                             get_is_test_enabled(sect, 'StaplesTestEnabled'), False)
-                test_config.add_expression_test('CastCalcsConnectionTest', CALCS_TDS, sect.get(KEY_EXCLUSIONS, ''),
+                if sect.get('StaplesSmokeTestEnabled') == 'True':
+                    test_config.add_logical_test('StaplesConnectionTest', STAPLES_TDS, sect.get(KEY_EXCLUSIONS, ''),
+                                                test_config.get_logical_test_path('logicaltests/setup/connection_test/setup.staples.*.'),  # noqa: E501
+                                                test_dir, get_password_file(sect), get_expected_message(sect), True,
+                                                get_is_test_enabled(sect, 'StaplesTestEnabled'), False)
+                if sect.get('CalcsSmokeTestEnabled') == 'True':
+                    test_config.add_expression_test('CastCalcsConnectionTest', CALCS_TDS, sect.get(KEY_EXCLUSIONS, ''),
                                                 get_expression_test_dir_path(sect, 'exprtests/pretest/connection_tests/calcs/'),  # noqa: E501
                                                 test_dir, get_password_file(sect), get_expected_message(sect), True,
                                                 get_is_test_enabled(sect, 'CastCalcsTestEnabled'), False)

--- a/tdvt/tdvt/test_results.py
+++ b/tdvt/tdvt/test_results.py
@@ -226,7 +226,7 @@ class TestResult(object):
                 return TestCaseResult('', 0, "", 0, '', TestErrorDisabledTest(), None, self.test_config, self.test_metadata)
             else:
                 return TestCaseResult('', str(test_case_count), "", test_case_count, '',
-                                      TestErrorDisabledTest(), None, self.test_config)
+                                      TestErrorDisabledTest(), None, self.test_config, self.test_metadata)
         elif self.test_set.test_is_skipped is True:
             if self.test_set.is_logical:
                 return TestCaseResult('', 0, "", 0, '', TestErrorSkippedTest(), None, self.test_config, self.test_metadata)


### PR DESCRIPTION
W-12315750 SDK][Github Issue 1014] [BUG] Exception: TestCaseResult.__init__() missing 1 required positional argument: 'test_metadata'

Configs with the ConnectionTests section will now be handled correctly. Previously the True & False were broken.

Closes #1014 
