### PR TITLE
Split OAuth docs into dev and general

### DIFF
--- a/docs/oauth-dev.md
+++ b/docs/oauth-dev.md
@@ -1,0 +1,121 @@
+---
+title: OAuth for Plugins
+---
+**IMPORTANT:** OAuth for plugins is available in Tableau 2021.1 and newer. Multi-IDP config for plugins is available starting in Tableau 2023.1.
+
+This document explains how to add OAuth to a connector. It's meant for developers. For an explanation of OAuth configuration and usage see [OAuth Config](./oauth.md).
+
+**In this section**
+
+* TOC
+{:toc}
+
+# How to Enable OAuth for a Plugin Connector
+
+First check your database and driver documentation to make sure it supports OAuth. 
+
+To enable OAuth for your connector add an `<oauth-config>` field in the manifest.xml and link to an oauthConfig.xml you created, described below.
+
+For a complete example please refer to https://github.com/tableau/connector-plugin-sdk/tree/master/samples/scenarios/snowflake_oauth.
+
+```xml
+  manifest.xml
+
+  <?xml version='1.0' encoding='utf-8' ?>
+  <connector-plugin class=...>
+    ...
+    <dialect file='dialect.tdd'/>
+    <oauth-config file='oauthConfigPing.xml'/>    <!-- add this to to define your OAuth Configs -->
+  </connector-plugin>
+```
+
+Starting in Tableau 2023.1, you can add multiple OAuth configs, embedded in the plugin. The end users may also provide external/custom OAuth configurations:
+- By installing the config files in the Tableau directory. See [Custom OAuth Config on Desktop](./oauth.md#custom-oauth-configs-on-desktop)
+- By uploading the config for a site level OAuth client. See [Create Site OAuth Client](./oauth.md#create-site-oauth-client-20231)
+
+However in both cases, at least one embedded config is still required. We are currently working to remove this requirement. See [issue 1108](https://github.com/tableau/connector-plugin-sdk/issues/1108).
+
+```xml
+  manifest.xml
+
+  <?xml version='1.0' encoding='utf-8' ?>
+
+  <connector-plugin class=...>
+    ...
+    <dialect file='dialect.tdd'/>
+    <oauth-config file='oauthConfigPing.xml'/>
+    <oauth-config file='oauthConfigOkta.xml'/>
+  </connector-plugin>
+```
+
+---
+In your *connectionFields.xml* file make sure to add an `authentication` field with a value equal to `oauth`. For example:
+
+## OAuth Only
+
+```xml
+    <field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="oauth" />
+```
+## Multiple Authentication Options
+```xml
+    <field name="authentication" label="Authentication" category="authentication" value-type="selection" default-value="auth-user-pass" >
+        <selection-group>
+            <option value="auth-user-pass" label="Username and Password"/>
+            <option value="oauth" label="OAuth"/>
+        </selection-group>
+    </field>
+```
+---
+In your *connectionProperties.js* file you need to use your connector specific logic to handle how to pass in OAuth attributes. Example:
+
+```js
+
+  if (authAttrValue == "oauth")
+  {
+      params["AUTHENTICATOR"] = "OAUTH";
+      params["TOKEN"] = attr["ACCESSTOKEN"];
+  }
+```
+---
+In your *connectionResolver.tdr* file, the following related OAuth attributes will be automatically included so you do not need to define them:
+- ACCESSTOKEN
+- REFRESHTOKEN
+- CLIENTID
+- CLIENTSECRET
+- access-token-issue-time
+- access-token-expires-in
+- oauth-client
+- id-token (optional)
+- instanceurl (optional)
+
+You still need to define other required attributes for your connector; `authentication` and `username` are currently required for OAuth connections so make sure to add them as well.
+
+```xml
+<required-attributes>
+    <attribute-list>
+        <attr>server</attr>
+        <attr>dbname</attr>
+        <attr>sslmode</attr>
+        <attr>authentication</attr>
+        <attr>username</attr>
+    </attribute-list>
+</required-attributes>
+```
+
+## Multiple Embedded OAuth Configs
+*Available starting in Tableau 2023.1*
+
+The plugin developer may add multiple embedded OAuth configs to the plugin starting in Tableau 2023.1. Each should have a new element `<oauthConfigId>`. This should be unique and is displayed in the UI. The user will be prompted to select from the available configurations when creating a connection.
+
+![Image](../assets/connection-dialog-oauth-configs.png)
+
+## Instance URL/Custom Domain
+Some IDPs have a single global endpoint, such as https://accounts.google.com/o/oauth2/. Others have different instances, for example Okta would have a different instance URL for each customer. If your authorization server or IDP has different instances, then either:
+- Enable OAUTH_CAP_SUPPORTS_CUSTOM_DOMAIN. This only works with embedded OAuth configs. The instance URL will be collected later from the end-user or the admin.
+- Create seperate custom OAuth configs for each instance. Custom OAuth config shouldn't set OAUTH_CAP_SUPPORTS_CUSTOM_DOMAIN, and should specify authUri, tokenUri, userInfoUri fields as absolute paths, which contains the instance URL.
+
+If OAUTH_CAP_SUPPORTS_CUSTOM_DOMAIN is enabled, then the URIs/URLs should use relative paths. For example:
+```xml
+<authUri>/oauth/authorize</authUri>
+<tokenUri>/oauth/token-request</tokenUri>
+```

--- a/docs/oauth-dev.md
+++ b/docs/oauth-dev.md
@@ -29,11 +29,7 @@ For a complete example please refer to https://github.com/tableau/connector-plug
   </connector-plugin>
 ```
 
-Starting in Tableau 2023.1, you can add multiple OAuth configs, embedded in the plugin. The end users may also provide external/custom OAuth configurations:
-- By installing the config files in the Tableau directory. See [Custom OAuth Config on Desktop](./oauth.md#custom-oauth-configs-on-desktop)
-- By uploading the config for a site level OAuth client. See [Create Site OAuth Client](./oauth.md#create-site-oauth-client-20231)
-
-However in both cases, at least one embedded config is still required. We are currently working to remove this requirement. See [issue 1108](https://github.com/tableau/connector-plugin-sdk/issues/1108).
+Starting in Tableau 2023.1, you can add [multiple embedded OAuth configs](#multiple-embedded-oauth-configs). The end users may also provide their own custom OAuth config.  However in both cases, at least one embedded config is still required. We are currently working to remove this requirement. See [issue 1108](https://github.com/tableau/connector-plugin-sdk/issues/1108).
 
 ```xml
   manifest.xml

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -18,11 +18,10 @@ This file configures a connector to run OAuth flows against a particular IDP. Th
 
 This file may be provided in the following ways:
 - Bundled in the connector package (only available to plugin authors)
-- Installing on a client machine for Tableau Desktop, Prep, or Bridge
-- Installing for a site on Tableau Cloud or Tableau Server
+- Installing on a client machine for Tableau Desktop, Prep, or Bridge. See [Custom OAuth Config on Desktop](./oauth.md#custom-oauth-configs-on-desktop)
+- Installing for a site on Tableau Cloud or Tableau Server. [Create Site OAuth Client](./oauth.md#create-site-oauth-client-20231)
 
-We refer to the first option as an "Embedded" config, and the second two as "Custom."
-
+We refer to the first option as an "Embedded" config, and the second two as "Custom." The latter two options are only available starting in Tableau 2023.1. Also before 2023.1 you can only embded a single OAuth Config.
 
 ## XML Elements
 

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -1,98 +1,28 @@
 ---
-title: OAuth Authentication Support
+title: OAuth Configuration and Usage
 ---
 **IMPORTANT:** OAuth for plugins is available in Tableau 2021.1 and newer. Multi-IDP config for plugins is available starting in Tableau 2023.1.
+
+This document explains how to configure and use OAuth. It's meant for admins and plugin developers. For information on adding OAuth to a connector plugin, see [OAuth Development](./oauth-dev.md).
+
+We have templates for common IDPs in the [samples](https://github.com/tableau/connector-plugin-sdk/tree/master/samples/components/oauth). In general, you should only need to substitute the desktop client ID and secret, and the URL of the IDP. However, there may be additional modifications needed to account for differences such as with PKCE and scopes.
 
 **In this section**
 
 * TOC
 {:toc}
 
-# How to Enable OAuth for a Plugin Connector
-
-First check your database and driver documentation to make sure it supports OAuth. For a complete example please refer to https://github.com/tableau/connector-plugin-sdk/tree/master/samples/scenarios/snowflake_oauth.
-
-To enable OAuth for your connector add an `<oauth-config>` field in the manifest.xml and link to an oauthConfig.xml you created, described below.
-
-```xml
-  manifest.xml
-
-  <?xml version='1.0' encoding='utf-8' ?>
-  <connector-plugin class=...>
-    ...
-    <dialect file='dialect.tdd'/>
-    <oauth-config file='oauthConfigPing.xml'/>    <!-- add this to to define your OAuth Configs -->
-  </connector-plugin>
-```
-
-Starting in Tableau 2023.1, you can add multiple OAuth configs, embedded in the plugin. The end users may also provide external/custom OAuth configurations:
-- By installing the config files in the Tableau directory. See [External OAuth Config on Desktop](#externalcustom-oauth-configs-on-desktop)
-- By uploading the config for a site level OAuth client. See [Create Site OAuth Client](#create-site-oauth-client-20231)
-
-However in both cases, at least one embedded config is still required.
-
-```xml
-  manifest.xml
-
-  <?xml version='1.0' encoding='utf-8' ?>
-
-  <connector-plugin class=...>
-    ...
-    <dialect file='dialect.tdd'/>
-    <oauth-config file='oauthConfigPing.xml'/>
-    <oauth-config file='oauthConfigOkta.xml'/>
-  </connector-plugin>
-```
-
----
-In your *connectionFields.xml* file make sure to add an `authentication` field with a value equal to `oauth`. For example:
-
-## OAuth Only
-
-```xml
-    <field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="oauth" />
-```
-## Multiple Authentication Options
-```xml
-    <field name="authentication" label="Authentication" category="authentication" value-type="selection" default-value="auth-user-pass" >
-        <selection-group>
-            <option value="auth-user-pass" label="Username and Password"/>
-            <option value="oauth" label="OAuth"/>
-        </selection-group>
-    </field>
-```
----
-In your *connectionProperties.js* file you need to use your connector specific logic to handle how to pass in OAuth attributes. Example:
-
-```js
-
-  if (authAttrValue == "oauth")
-  {
-      params["AUTHENTICATOR"] = "OAUTH";
-      params["TOKEN"] = attr["ACCESSTOKEN"];
-  }
-```
----
-In your *connectionResolver.tdr* file, the following related OAuth attributes will be automatically included so you do not need to define them:
-```ACCESSTOKEN, REFRESHTOKEN, access-token-issue-time, access-token-expires-in, CLIENTID, CLIENTSECRET, oauth-client, id-token (if any), instanceurl (if any)```
-You still need to define other required attributes for your connector; `authentication` and `username` are currently required for OAuth connections so make sure to add them as well.
-
-```xml
-<required-attributes>
-    <attribute-list>
-        <attr>server</attr>
-        <attr>dbname</attr>
-        <attr>sslmode</attr>
-        <attr>authentication</attr>
-        <attr>username</attr>
-    </attribute-list>
-</required-attributes>
-```
 # The OAuth Config File
 
-The OAuth Config file defines your connector's OAuth configuration and also provides the ability to customize how the OAuth flow should work.
+This file configures a connector to run OAuth flows against a particular IDP. The XML schema is defined here: [XSD](https://github.com/tableau/connector-plugin-sdk/blob/master/validation/oauth_config.xsd).
 
-The OAuth Config file ([XSD](https://github.com/tableau/connector-plugin-sdk/blob/master/validation/oauth_config.xsd)) is identified in the main plugin manifest using the `<oauth-config>` element. Here we discuss the structure of this file.
+This file may be provided in the following ways:
+- Bundled in the connector package (only available to plugin authors)
+- Installing on a client machine for Tableau Desktop, Prep, or Bridge
+- Installing for a site on Tableau Cloud or Tableau Server
+
+We refer to the first option as an "Embedded" config, and the second two as "Custom."
+
 
 ## XML Elements
 
@@ -101,7 +31,7 @@ The OAuth Config file ([XSD](https://github.com/tableau/connector-plugin-sdk/blo
 | Name  | Type | Meaning | Required | Notes |
 | ----  | ------- | --------- | ----------- | ----------- |
 | dbclass | String | The connector class which this OAuth config applies to. | Yes | The dbclass must be same with as the `class` attribute in manifest.xml |
-| oauthConfigId | String | Unique ID for this OAuth config | Recommended | *New in Tableau 2023.1.* This is a required attribute if there are multiple OAuth configs defined for a connector. **When using an external/custom config this must begin with the prefix "custom_".** |
+| oauthConfigId | String | Unique ID for this OAuth config | Recommended | *New in Tableau 2023.1.* This is a required attribute if there are multiple OAuth configs defined for a connector. **When using an custom config this must begin with the prefix "custom_".** |
 | configLabel | String | Label that is used as a display to users in place of the oauthConfigId. | No | *New in Tableau 2023.2.* This must only contain alphanumeric characters, "_", "-", and spaces in order to be considered valid. |
 | clientIdDesktop | String | Client ID you registered for Tableau Desktop | No | This is not considered a secret and will be stored in plain text |
 | clientSecretDesktop | String | Client Secret you registered for Tableau Desktop | Recommended | This is not considered a secret and will be stored in plain text |
@@ -146,7 +76,7 @@ This set of OAuth Config capabilities is not shared with the regular connector c
 
 | Capability Name  | Description | Default | Recommendation |
 | ----  | ------- | --------- | ----------- |
-| OAUTH_CAP_SUPPORTS_CUSTOM_DOMAIN | Enable this if your IDP has different URLs. The OAuth config will specify the relative paths for the URLs, and the end user will have to provide the IDP hostname when creating a new connection. **OAUTH_CAP_SUPPORTS_CUSTOM_DOMAIN only works for embedded OAuth config.** See [Instance URL/Custom Domain](#instance-urlcustom-domain) for more information. | false | - |
+| OAUTH_CAP_SUPPORTS_CUSTOM_DOMAIN | Enable this if your IDP has different URLs. The OAuth config will specify the relative paths for the URLs, and the end user will have to provide the IDP hostname when creating a new connection. **OAUTH_CAP_SUPPORTS_CUSTOM_DOMAIN only works for embedded OAuth config.** See [Instance URL/Custom Domain](./oauth-dev.md#instance-urlcustom-domain) for more information. | false | - |
 | OAUTH_CAP_REQUIRE_PKCE | Whether your OAuth provider supports PKCE, more details: https://oauth.net/2/pkce/ | false | true |
 | OAUTH_CAP_PKCE_REQUIRES_CODE_CHALLENGE_METHOD | Whether your OAuth provider PKCE requires code_challenging_method passed in. If set to true, we are using S256 by default. | false | true |
 | OAUTH_CAP_SUPPORTS_STATE | Used to protect against CSRF attacks, more details: https://auth0.com/docs/protocols/state-parameters | false | true |
@@ -172,16 +102,15 @@ This set of OAuth Config capabilities is not shared with the regular connector c
     <clientIdDesktop>client-id-1234</clientIdDesktop>
     <clientSecretDesktop>xyz-456-000</clientSecretDesktop>
 
-    <!-- Desktop redirectUri, only needed if your authorization server doesn't allow dynamic ports in localhost redirect. -->
+    <!-- Desktop redirectUri, only needed if your authorization server doesn't allow dynamic port ranges in localhost redirect. -->
     <redirectUrisDesktop>http://localhost:55556/Callback</redirectUrisDesktop>
     <redirectUrisDesktop>http://localhost:55557/Callback</redirectUrisDesktop>
     <redirectUrisDesktop>http://localhost:55558/Callback</redirectUrisDesktop>
     <redirectUrisDesktop>http://localhost:55559/Callback</redirectUrisDesktop>
     <redirectUrisDesktop>http://localhost:555510/Callback</redirectUrisDesktop>
 
-    <!-- authUri and tokenUri only contains the relative path since this example has OAUTH_CAP_SUPPORTS_CUSTOM_DOMAIN enabled. -->
-    <authUri>/oauth/authorize</authUri>
-    <tokenUri>/oauth/token-request</tokenUri>
+    <authUri>https://my.idp.com/oauth2/v1/authorize</authUri>
+    <tokenUri>https://my.idp.com/oauth/token-request</tokenUri>
 
     <instanceUrlValidationRegex>^https:\/\/(.+\.)?(supercloud\.(com|us|cn|de))(.*)</instanceUrlValidationRegex>
     <scopes>refresh_token</scopes>
@@ -236,22 +165,7 @@ This set of OAuth Config capabilities is not shared with the regular connector c
 
     <!-- No refreshTokenResponseMaps needed since it's the same as accessTokenResponseMaps -->
  </pluginOAuthConfig>
-
 ```
-
-## Instance URL/Custom Domain
-Some IDPs have a single global endpoint, such as https://accounts.google.com/o/oauth2/. Others have different instances, for example Okta would have a different instance URL for each customer. If your authorization server or IDP has different instances, then either:
-- Enable OAUTH_CAP_SUPPORTS_CUSTOM_DOMAIN. This only works with embedded OAuth configs. The instance URL will be collected later from the end-user or the admin.
-- Create seperate external/custom OAuth configs for each custom domain. External OAuth config shouldn't set OAUTH_CAP_SUPPORTS_CUSTOM_DOMAIN, and should specify authUri, tokenUri, userInfoUri fields as absolute paths, which contains the custom domain/instance URL.
-
-## Multiple Embedded OAuth Configs
-*\*Available starting in Tableau 2023.1*
-
-The plugin developer may add multiple embedded OAuth configs to the plugin starting in Tableau 2023.1. Each should have a new element `<oauthConfigId>`. This should be unique and is displayed in the UI. The user will be prompted to select from the available configurations when creating a connection.
-
-![Image](../assets/connection-dialog-oauth-configs.png)
-
-OAuth configs may also be specified independent of the plugin using site-level OAuth clients or by installing in the Tableau directory for desktop applications. See below for more information.
 
 # OAuth on Tableau Desktop/Tableau Prep
 Tableau Desktop uses a shared client ID and client secret which is embedded in the plugin. It also uses localhost callbacks to receive the authorization code response. The plugin developer (or whoever provides the OAuth config) must ensure that the localhost or loopback callback URLs are configured on the whitelist for the authorization server.
@@ -262,14 +176,14 @@ If the authorization server does not support this, then enable OAUTH_CAP_FIXED_P
 
 ### redirectUrisDesktop Format
 - Before Tableau 2023.1, the redirectUrisDesktop must be of the form `http://localhost:[portnumber]/Callback`. If you need to use loopback address other than localhost, you can enable OAUTH_CAP_SUPPORTS_HTTP_SCHEME_LOOPBACK_REDIRECT_URLS, but the `<redirectUrisDesktop>` should still specify localhost. The callback at runtime will be rewritten to something like http://127.0.0.1:55555/Callback.
-- Starting in Tableau 2023.1, You can use any valid loopback address like `http://localhost:[portnumber]/Callback`, `http://127.0.0.1:[portnumber]/Callback`(IPv4), `http://[::1]:[portnumber]/Callback`(IPv6). If you use loopback address other than localhost, enable OAUTH_CAP_SUPPORTS_HTTP_SCHEME_LOOPBACK_REDIRECT_URLS as well.
+- Starting in Tableau 2023.1, You can use any valid loopback address like `http://localhost:[portnumber]/Callback`, `http://127.0.0.1:[portnumber]/Callback` (IPv4), `http://[::1]:[portnumber]/Callback` (IPv6). If you use loopback address other than localhost, enable OAUTH_CAP_SUPPORTS_HTTP_SCHEME_LOOPBACK_REDIRECT_URLS as well.
 
 For more information on see [RFC 8252: Loopback Interface Redirection](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3).
 
-## External/Custom OAuth Configs on Desktop
-*\*Available starting in Tableau 2023.1*
+## Custom OAuth Configs on Desktop
+*Available starting in Tableau 2023.1*
 
-The end user or admin can specify custom OAuth configs for desktop applications, independent of the plugin connector. These should be installed in `My Tableau Repository/OAuthConfigs` or `My Tableau Prep Repository/OAuthConfigs`. They must define the new field `oauthConfigId`. The user will be prompted to select from available configs when creating the connection.
+The end user or admin can specify custom OAuth configs for desktop applications, independent of the plugin connector. These should be installed in the repository folder which corresponds to the application, such as `"My Tableau Repository/OAuthConfigs"` or `"My Tableau Prep Repository/OAuthConfigs"`. They must define the new field `oauthConfigId`. The user will be prompted to select from available configs when creating the connection.
 
 # OAuth on Tableau Server & Tableau Online
 
@@ -285,15 +199,15 @@ The value `dbclass` should match that configured in the plugin manifest and OAut
 
 
 ## Site Level OAuth Clients
-The preferred way to configure OAuth is using site level OAuth clients. These are configured by the server admin for Tableau Server, or site admin for Tableau Online. For an example of configuring an Azure AD OAuth client on a site: https://help.tableau.com/current/server/en-us/config_oauth_azure_ad.htm.
+The preferred way to configure OAuth on Tableau Cloud/Server is by using site level OAuth clients. These are configured by the server admin for Tableau Server, or site admin for Tableau Online. For an example of configuring an Azure AD OAuth client on a site: https://help.tableau.com/current/server/en-us/config_oauth_azure_ad.htm.
 
-The OAuth clients will only be effective for a particular site, and will not not require a restart. They will take take precedence over the server-level OAuth clients if any. For each site, there is only one OAuth client allowed for each OAuth config.
+The site OAuth clients will only be effective for a particular site, and will not not require a restart. They will take take precedence over the server-level OAuth clients if any. For each site, there is only one OAuth client allowed for each OAuth config.
 
 ### Create Site OAuth Client (Pre 2023.1)
 ![Image](../assets/create-oauth-client-embedded-legacy.png)
 
 ### Create Site OAuth Client (2023.1+)
-Starting in Tableau 2023.1, you can have multiple OAuth configs for a connector. These may be embedded or external/custom.
+Starting in Tableau 2023.1, you can have multiple OAuth configs for a connector. These may be embedded or custom.
 
 To create a client for an embedded config, select the config ID.
 
@@ -323,13 +237,13 @@ After successfully adding your credential you will notice an entry appear under 
 
 ![Image](../assets/saved-credentials.png)
 
-## Desktop Publish flow
+## Desktop Publish Flow
 
 When publishing an OAuth connection to Tableau Server, you will see multiple auth options:
 - **Prompt** means this resource will published without embedding credential, viewers would need to provide credential to access the resource.
 - **Embedding [username]** means you will embed the credential to this resource, so all the viewer can use the same credential to access the resource. Note in order for this to show up, you must already have added a saved OAuth credential according to previous section. You would see multiple entries if you have multiple records of saved credentials and you can pick which one you want to use for embedding.
 - **Embed Password** is not a supported auth mechanism for plugin OAuth connections and an error will show up if you choose that option.
 
-## Tableau Server Web Authoring flow
+## Tableau Server Web Authoring Flow
 
 For Web Authoring, the UI dialog will be same as Tableau Desktop. The difference will be that we are using the server OAuth clients. The server or site admin must configure the OAuth client information (client ID, client secret, etc) beforehand for this to succeed.


### PR DESCRIPTION
I split this up because I will have the general OAuth instructions linked to from the main Tableau docs for the admins to setup custom OAuth config. The admins shouldn’t need to know about plugin things like javascript and manifests, etc.

Also do some cleanup
- Remove references to "external" config to simplify things. We will just call that "custom."
- Other rewording.
- Changed the main example to use fixed IDP URLs since the custom domain is only for embedded, which is only available for devs.

I validated that all the links work. Some redirect to the section in the other page now.