### PR TITLE
Add support for null oauth config in packager

### DIFF
--- a/connector-packager/connector_packager/jar_jdk_packager.py
+++ b/connector-packager/connector_packager/jar_jdk_packager.py
@@ -87,6 +87,12 @@ def get_min_support_version(file_list: List[ConnectorFile], cur_min_version_tabl
             oauthConfigs = manifestRoot.findall('.//oauth-config')
             if (oauthConfigs is not None and len(oauthConfigs) > 1 and 2023.1 > float(min_version_tableau)):
                 min_version_tableau = "2023.1"
+                reasons.append("Support for multiple OAuth configs was added in the 2023.1 release")
+            elif (oauthConfigs is not None and len(oauthConfigs) == 1):
+                firstConfig = oauthConfigs[0]
+                if firstConfig.attrib['file'] == "null_config" and 2024.1 > float(min_version_tableau):
+                    min_version_tableau = "2024.1"
+                    reasons.append("Connector uses Null OAuth Config, which was added in the 2024.1 release")
 
     if version.parse(cur_min_version_tableau) > version.parse(min_version_tableau):
         reasons.append("min-tableau-version set to " + cur_min_version_tableau + ", since that is higher than calculated version of " + min_version_tableau)

--- a/connector-packager/tests/test_jar_packager.py
+++ b/connector-packager/tests/test_jar_packager.py
@@ -18,6 +18,7 @@ VERSION_2021_1 = "2021.1"
 VERSION_2021_4 = "2021.4"
 VERSION_2023_1 = "2023.1"
 VERSION_2023_2 = "2023.2"
+VERSION_2024_1 = "2024.1"
 VERSION_FUTURE = "2525.1"
 VERSION_THREE_PART = "2021.1.3"
 
@@ -390,6 +391,36 @@ class TestJarPackager(unittest.TestCase):
         manifest = ET.parse(path_to_extracted_manifest)
         self.assertEqual(manifest.getroot().get("min-version-tableau"),
                          VERSION_2023_2, "wrong min-version-tableau attr or doesn't exist")
+
+        if dest_dir.exists():
+            shutil.rmtree(dest_dir)
+
+    def test_jdk_create_jar_with_null_oauth_config(self):
+        files_list = [
+            ConnectorFile("manifest.xml", "manifest"),
+            ConnectorFile("connectionFields.xml", "connection-fields"),
+            ConnectorFile("connectionBuilder.js", "script"),
+            ConnectorFile("dialect.xml", "dialect"),
+            ConnectorFile("connectionResolver.xml", "connection-resolver")]
+        source_dir = TEST_FOLDER / Path("null_oauth_config")
+        dest_dir = TEST_FOLDER / Path("packaged-connector-by-jdk/")
+        package_name = "null_oauth_config.taco"
+
+        jdk_create_jar(source_dir, files_list, package_name, dest_dir)
+
+        path_to_test_file = dest_dir / Path(package_name)
+        self.assertTrue(os.path.isfile(path_to_test_file), "taco file doesn't exist")
+
+        # test min support tableau version is stamped
+        args = ["jar", "xf", package_name, MANIFEST_FILE_NAME]
+        p = subprocess.Popen(args, cwd=os.path.abspath(dest_dir))
+        self.assertEqual(p.wait(), 0, "can not extract manfifest file from taco")
+        path_to_extracted_manifest = dest_dir / MANIFEST_FILE_NAME
+        self.assertTrue(os.path.isfile(path_to_extracted_manifest), "extracted manifest file doesn't exist")
+
+        manifest = ET.parse(path_to_extracted_manifest)
+        self.assertEqual(manifest.getroot().get("min-version-tableau"),
+                         VERSION_2024_1, "wrong min-version-tableau attr or doesn't exist")
 
         if dest_dir.exists():
             shutil.rmtree(dest_dir)

--- a/connector-packager/tests/test_resources/null_oauth_config/connectionBuilder.js
+++ b/connector-packager/tests/test_resources/null_oauth_config/connectionBuilder.js
@@ -1,0 +1,28 @@
+(function dsbuilder(attr)
+{
+    var params = {};
+    var authAttrValue = attr[connectionHelper.attributeAuthentication];
+
+    params["SERVER"] = attr[connectionHelper.attributeServer];
+    params["UID"] = attr[connectionHelper.attributeUsername];
+    if(authAttrValue =="auth-user-pass")
+    {
+        params["PWD"] = attr[connectionHelper.attributePassword];
+    }
+    else if(authAttrValue == "oauth")
+    {
+        params["AUTHENTICATOR"] = "OAUTH";
+        params["TOKEN"] = attr["ACCESSTOKEN"];
+    }
+
+    var formattedParams = [];
+
+    formattedParams.push(connectionHelper.formatKeyValuePair(driverLocator.keywordDriver, driverLocator.locateDriver(attr)));
+
+    for (var key in params)
+    {
+        formattedParams.push(connectionHelper.formatKeyValuePair(key, params[key]));
+    }
+
+    return formattedParams;
+})

--- a/connector-packager/tests/test_resources/null_oauth_config/connectionFields.xml
+++ b/connector-packager/tests/test_resources/null_oauth_config/connectionFields.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<connection-fields>
+  <field name="server" label="Server" value-type="string" category="endpoint" >
+    <validation-rule reg-exp="^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$"/>
+  </field>
+
+  <field name="authentication" label="Authentication" category="authentication" value-type="selection" default-value="auth-user-pass" >
+    <selection-group>
+      <option value="auth-user-pass" label="Username and Password"/>
+      <option value="oauth" label="OAuth"/>
+    </selection-group>
+  </field>
+
+  <field name="username" label="Username" category="authentication" value-type="string">
+    <conditions>
+      <condition field="authentication" value="auth-user-pass"/>
+    </conditions>
+  </field>
+
+  <field name="password" label="Password" category="authentication" value-type="string" secure="true">
+    <conditions>
+      <condition field="authentication" value="auth-user-pass"/>
+    </conditions>
+  </field>
+
+    <field name="instanceurl" label="OAuth Instance Url" category="authentication" value-type="string">
+        <conditions>
+          <condition field="authentication" value="oauth" />
+        </conditions>
+        <validation-rule reg-exp="^https:\/\/(.+\.)?(snowflakecomputing\.(com|us|cn|de))(.*)"/>
+    </field>
+
+
+</connection-fields>

--- a/connector-packager/tests/test_resources/null_oauth_config/connectionResolver.xml
+++ b/connector-packager/tests/test_resources/null_oauth_config/connectionResolver.xml
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<tdr class='null_oauth_config'>
+	<connection-resolver>
+    <connection-builder>
+      <script file='connectionBuilder.js'/>
+    </connection-builder>
+    <connection-normalizer>
+      <required-attributes>
+        <attribute-list>
+          <attr>class</attr>
+          <attr>server</attr>
+          <attr>port</attr>
+          <attr>dbname</attr>
+          <attr>username</attr>
+          <attr>one-time-sql</attr>
+          <attr>service</attr>
+          <attr>authentication</attr>
+          <attr>password</attr>
+        </attribute-list>
+      </required-attributes>
+    </connection-normalizer>
+	</connection-resolver>
+	<driver-resolver>
+    <driver-match >
+      <driver-name type='regex'>SnowflakeDSIIDriver*</driver-name>
+    </driver-match>
+  </driver-resolver>
+</tdr>

--- a/connector-packager/tests/test_resources/null_oauth_config/dialect.xml
+++ b/connector-packager/tests/test_resources/null_oauth_config/dialect.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dialect name='SimpleSnowflake'
+         class='null_oauth_config'
+         base='SnowflakeDialect'
+         version='18.1'>
+ </dialect>
+

--- a/connector-packager/tests/test_resources/null_oauth_config/manifest.xml
+++ b/connector-packager/tests/test_resources/null_oauth_config/manifest.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='utf-8' ?>
+
+<connector-plugin class='null_oauth_config' superclass='odbc' plugin-version='0.0.0' name='Null OAuth Config' version='18.1'>
+  <vendor-information>
+      <company name="Sample Company"/>
+      <support-link url = "https://example.com"/>
+  </vendor-information>
+  <connection-customization class="null_oauth_config" enabled="true" version="10.0">
+    <vendor name="vendor"/>
+    <driver name="driver"/>
+     <customizations>
+      <customization name="CAP_QUERY_HAVING_REQUIRES_GROUP_BY" value="yes"/>
+      <customization name="CAP_QUERY_INITIAL_SQL_SPLIT_STATEMENTS" value="yes"/>
+    </customizations>
+  </connection-customization>
+  <connection-fields file='connectionFields.xml'/>
+  <connection-resolver file="connectionResolver.xml"/>
+  <dialect file='dialect.xml'/>
+  <oauth-config file='null_config'/>
+</connector-plugin>


### PR DESCRIPTION
- Tacos with null OAuth config are packaged
- min_tableau_version set to 2024.1 (can always update if we backport)
- Adds a new test, confirmed all other tests pass

Opening new pull request to try and get the cla bot to work. Sorry for the spam.

Old PR: https://github.com/tableau/connector-plugin-sdk/pull/1170
