### PR TITLE
Document CAP_ESCAPE_UNDERSCORE_IN_NAMES capability

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -287,6 +287,7 @@ CAP_SET_ISOLATION_LEVEL_VIA_SQL | Set to 'yes' to force Tableau to set the trans
 Capability | Description | Default | Recommended
 -|-|-|-
 CAP_CONNECT_NO_CUSTOM_SQL | Set to 'yes' to disable the custom sql option. | &ndash; | &ndash;
+CAP_ESCAPE_UNDERSCORE_IN_NAMES | Set to ‘yes’ to escape underscores for search-based enumerations of catalog/schema/table names. | &ndash; | &ndash;
 CAP_EQUALITY_JOINS_ONLY | Set to 'yes' to restrict connector to only allow equality joins. Available in Tableau 2022.1 and newer. | &ndash; | &ndash;
 CAP_EXTRACT_ONLY | Set to 'yes' to perform queries on extracted data only. | &ndash; | &ndash;
 CAP_EXTRACT_ONLY_REFRESH  | Set to 'yes' to enable extracted data to be refreshed. | &ndash; | &ndash;


### PR DESCRIPTION
Add `CAP_ESCAPE_UNDERSCORE_IN_NAMES` to the "Uncommon" section of the Capabilities documentation.