### PR TITLE
Fix null oauth version check

### DIFF
--- a/connector-packager/connector_packager/jar_jdk_packager.py
+++ b/connector-packager/connector_packager/jar_jdk_packager.py
@@ -96,9 +96,9 @@ def get_min_support_version(file_list: List[ConnectorFile], cur_min_version_tabl
                 reasons.append("Support for multiple OAuth configs was added in the 2023.1 release")
             elif (oauthConfigs is not None and len(oauthConfigs) == 1):
                 firstConfig = oauthConfigs[0]
-                if firstConfig.attrib['file'] == "null_config" and 2024.1 > float(min_version_tableau):
-                    min_version_tableau = "2024.1"
-                    reasons.append("Connector uses Null OAuth Config, which was added in the 2024.1 release")
+                if firstConfig.attrib['file'] == "null_config" and 2023.3 > float(min_version_tableau):
+                    min_version_tableau = "2022023.3"
+                    reasons.append("Connector uses Null OAuth Config, which was added in the 2023.3 release")
 
     if version.parse(cur_min_version_tableau) > version.parse(min_version_tableau):
         reasons.append("min-tableau-version set to " + cur_min_version_tableau + ", since that is higher than calculated version of " + min_version_tableau)

--- a/connector-packager/connector_packager/jar_jdk_packager.py
+++ b/connector-packager/connector_packager/jar_jdk_packager.py
@@ -97,7 +97,7 @@ def get_min_support_version(file_list: List[ConnectorFile], cur_min_version_tabl
             elif (oauthConfigs is not None and len(oauthConfigs) == 1):
                 firstConfig = oauthConfigs[0]
                 if firstConfig.attrib['file'] == "null_config" and 2023.3 > float(min_version_tableau):
-                    min_version_tableau = "2022023.3"
+                    min_version_tableau = "2023.3"
                     reasons.append("Connector uses Null OAuth Config, which was added in the 2023.3 release")
 
     if version.parse(cur_min_version_tableau) > version.parse(min_version_tableau):

--- a/connector-packager/tests/test_jar_packager.py
+++ b/connector-packager/tests/test_jar_packager.py
@@ -454,7 +454,7 @@ class TestJarPackager(unittest.TestCase):
 
         manifest = ET.parse(path_to_extracted_manifest)
         self.assertEqual(manifest.getroot().get("min-version-tableau"),
-                         VERSION_2024_1, "wrong min-version-tableau attr or doesn't exist")
+                         VERSION_2023_3, "wrong min-version-tableau attr or doesn't exist")
 
         if dest_dir.exists():
             shutil.rmtree(dest_dir)


### PR DESCRIPTION
I double checked, and turns out we backported this fix to 2023.3, but the packager stamps the minimum version as 2024.1. Corrected this mistake on the issue and now fixing the packager. 
