### PR TITLE
@W-16327429: Enable a new language Dutch for all connectors

### DIFF
--- a/connector-packager/connector_packager/xml_parser.py
+++ b/connector-packager/connector_packager/xml_parser.py
@@ -20,7 +20,7 @@ TRANSLATABLE_STRING_PREFIX = "@string/"
 # find one for the correct language
 TABLEAU_FALLBACK_LANGUAGE = "en_US"
 TABLEAU_SUPPORTED_LANGUAGES = ["de_DE", "en_GB", "es_ES", "fr_CA", "fr_FR", "ga_IE", "it_IT", "ja_JP", "ko_KR",
-                               "pt_BR", "sv_SE", "th_TH", "zh_CN", "zh_TW"]
+                               "nl_NL", "pt_BR", "sv_SE", "th_TH", "zh_CN", "zh_TW"]
 
 
 class XMLParser:


### PR DESCRIPTION
Add dutch language to the package so that it is accepted for partner connectors. 
All the connectors already have updated dutch language support in https://sourcegraph.prod.tableautools.com/github.com/sf-analyticscloud/monolith/-/tree/modules/connectors/connector_plugins/plugins