### PR TITLE
Check for prohibited words in non-secure field

### DIFF
--- a/connector-packager/CHANGELOG.md
+++ b/connector-packager/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 8/29/2025
+- Add checks for secure field violations
+
 ## [2.1.0] - 5/8/2020
 - Add support for packaging connectors using connection dialogs v2
 

--- a/connector-packager/connector_packager/xsd_validator.py
+++ b/connector-packager/connector_packager/xsd_validator.py
@@ -200,6 +200,7 @@ def validate_file_specific_rules_connection_fields(file_to_test: ConnectorFile, 
 
         if 'name' in child.attrib:
             field_name = child.attrib['name']
+            display_name = child.attrib['label']
             properties.connection_fields.append(field_name)
 
             # Only password is allowed to be secure
@@ -240,6 +241,12 @@ def validate_file_specific_rules_connection_fields(file_to_test: ConnectorFile, 
                     if word in field_name.lower():
                         xml_violations_buffer.append(field_name + " is not marked as secure and contains prohibited word '" + word + "'. The values of non-secure fields will be logged in plain text.")
                         return False
+                    
+                if display_name is not None:
+                    for word in VENDOR_FIELD_PROHIBITED_WORDS:
+                        if word in display_name.lower():
+                            xml_violations_buffer.append(field_name + " is not marked as secure and contains prohibited word '" + word + "' in the display name: " + display_name + ". The values of non-secure fields will be logged in plain text.")
+                            return False
                 
 
             

--- a/connector-packager/tests/test_resources/field_name_validation/invalid/non_password_secure_field/connectionFields.xml
+++ b/connector-packager/tests/test_resources/field_name_validation/invalid/non_password_secure_field/connectionFields.xml
@@ -1,0 +1,10 @@
+<connection-fields>
+  <field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="auth-user-pass" />
+
+  <!-- -  is valid -->
+  <field label='SecureField' name='v-very-secure'
+          value-type='string' default-value='' optional='true'
+          secure='true' category='advanced'>
+  </field>
+  
+</connection-fields>

--- a/connector-packager/tests/test_resources/field_name_validation/invalid/prohibited_word/connectionFields.xml
+++ b/connector-packager/tests/test_resources/field_name_validation/invalid/prohibited_word/connectionFields.xml
@@ -1,0 +1,10 @@
+<connection-fields>
+  <field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="auth-user-pass" />
+
+  <!-- -  is valid -->
+  <field label='EpicPassword' name='v-epic-password'
+          value-type='string' default-value='' optional='true'
+          secure='false' category='advanced'>
+  </field>
+  
+</connection-fields>

--- a/connector-packager/tests/test_resources/field_name_validation/invalid/prohibited_word/connectionFields.xml
+++ b/connector-packager/tests/test_resources/field_name_validation/invalid/prohibited_word/connectionFields.xml
@@ -1,8 +1,8 @@
 <connection-fields>
   <field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="auth-user-pass" />
 
-  <!-- -  is valid -->
-  <field label='EpicPassword' name='v-epic-password'
+  <!-- -  has banned word in field name -->
+  <field label='Epic' name='v-epic-password'
           value-type='string' default-value='' optional='true'
           secure='false' category='advanced'>
   </field>

--- a/connector-packager/tests/test_resources/field_name_validation/invalid/prohibited_word_label/connectionFields.xml
+++ b/connector-packager/tests/test_resources/field_name_validation/invalid/prohibited_word_label/connectionFields.xml
@@ -1,10 +1,10 @@
 <connection-fields>
   <field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="auth-user-pass" />
 
-  <!-- -  Field marked as secure that is not pasword -->
-  <field label='SecureField' name='v-very-secure'
+  <!-- -  has banned word in field label -->
+  <field label='EpicPassword' name='v-epic'
           value-type='string' default-value='' optional='true'
-          secure='true' category='advanced'>
+          secure='false' category='advanced'>
   </field>
   
 </connection-fields>

--- a/connector-packager/tests/test_xsd_validator.py
+++ b/connector-packager/tests/test_xsd_validator.py
@@ -266,6 +266,16 @@ class TestXSDValidator(unittest.TestCase):
         self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
                          "XML Validation failed for connectionFields.xml")
 
+        print("Test connectionFields is invalidated by non-password field marked secure")
+        test_file = TEST_FOLDER / "field_name_validation/invalid/non_password_secure_field/connectionFields.xml"
+        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
+                         "XML Validation failed for connectionFields.xml")
+
+        print("Test connectionFields is invalidated by non-secure field containing prohibited word")
+        test_file = TEST_FOLDER / "field_name_validation/invalid/prohibited_word/connectionFields.xml"
+        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
+                         "XML Validation failed for connectionFields.xml")
+
         logging.debug("test_validate_connetion_field_name xml violations:")
         for violation in xml_violations_buffer:
             logging.debug(violation)

--- a/connector-packager/tests/test_xsd_validator.py
+++ b/connector-packager/tests/test_xsd_validator.py
@@ -275,6 +275,11 @@ class TestXSDValidator(unittest.TestCase):
         test_file = TEST_FOLDER / "field_name_validation/invalid/prohibited_word/connectionFields.xml"
         self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
                          "XML Validation failed for connectionFields.xml")
+        
+        print("Test connectionFields is invalidated by non-secure field containing prohibited word in label")
+        test_file = TEST_FOLDER / "field_name_validation/invalid/prohibited_word_label/connectionFields.xml"
+        self.assertFalse(validate_single_file(file_to_test, test_file, xml_violations_buffer, dummy_properties),
+                         "XML Validation failed for connectionFields.xml")
 
         logging.debug("test_validate_connetion_field_name xml violations:")
         for violation in xml_violations_buffer:


### PR DESCRIPTION
Makes two changes:
- If the field is marked secure, and the field name is not `password`, fail packager validation. These connectors will not work in Tableau.
- If the field has token, password, or secret in it, and is not marked secure, fail the validation, since that suggests that field would leak customer secrets. Open to making this a non-failing warning, but given we already have a warning I'd kind of rather err on the side of caution

Also adds two new test cases to cover these scenarios.

For work item W-19338086