### PR TITLE
@W-21970029: Migrate off "setup.py test"

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -19,7 +19,12 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: ${{matrix.java}}
+    - name: Install connector-packager and dependencies
+      run: |
+        cd connector-packager
+        pip install -e .
+        pip install pytest
     - name: Run Connector Packager unit tests with JDK ${{ matrix.java }}
       run: |
         cd connector-packager
-        python setup.py test
+        pytest tests/ -v

--- a/connector-packager/README.md
+++ b/connector-packager/README.md
@@ -94,7 +94,12 @@ The [Pyright](https://marketplace.visualstudio.com/items?itemName=ms-pyright.pyr
 ### Test `connector-packager` Module
 
 ```
-(.venv) PS connector-plugin-sdk\connector-packager> python setup.py test
+(.venv) PS connector-plugin-sdk\connector-packager> pytest tests/
+```
+
+Or with verbose output:
+```
+(.venv) PS connector-plugin-sdk\connector-packager> pytest tests/ -v
 ```
 
 ### Run the `connector-packager` Module

--- a/connector-packager/connector_packager/jar_jdk_packager.py
+++ b/connector-packager/connector_packager/jar_jdk_packager.py
@@ -84,7 +84,7 @@ def get_min_support_version(file_list: List[ConnectorFile], cur_min_version_tabl
             tdr_root = ET.parse(input_dir / connector_file.file_name).getroot()
             attribute_list = tdr_root.find('.//connection-normalizer/required-attributes/attribute-list')
 
-            if not attribute_list:
+            if attribute_list is None:
                 if 2021.1 > float(min_version_tableau):
                     min_version_tableau = "2021.1"
                 reasons.append("Connector uses inferred connection resolver, which was added in the 2021.1 release")

--- a/connector-packager/connector_packager/xsd_validator.py
+++ b/connector-packager/connector_packager/xsd_validator.py
@@ -294,14 +294,14 @@ def validate_file_specific_rules_tdr(file_to_test: ConnectorFile, path_to_file: 
 
     # The connection resolver appears after the dialog elements in the manifest's xml, so we know
     # USES_TCD is accurate here
-    if not attribute_list and properties.uses_tcd:
+    if attribute_list is None and properties.uses_tcd:
         xml_violations_buffer.append("Connectors using a .tcd file cannot use inferred connection resolver,"
                                      "must manually populate required-attributes/attributes-list in "
                                      + str(path_to_file) + ".")
         return False
 
     # Check that all the connection-fields attributes are in the required attributes
-    if properties.connection_fields and attribute_list:
+    if properties.connection_fields and attribute_list is not None:
         attributes = []
         for attr in attribute_list.iter():
             attributes.append(attr.text)
@@ -323,7 +323,7 @@ def validate_file_specific_rules_tdr(file_to_test: ConnectorFile, path_to_file: 
 
     properties_builder = root.find('.//connection-properties')
 
-    if not properties_builder and properties.is_jdbc:
+    if properties_builder is None and properties.is_jdbc:
         xml_violations_buffer.append("Connectors using a 'jdbc' superclass must declare a <connection-properties> element in " +
                                      str(path_to_file) + ".")
         return False
@@ -373,7 +373,7 @@ def warn_file_specific_rules_tdr(path_to_file: Path):
     root = xml_tree.getroot()
     attribute_list = root.find('.//connection-normalizer/required-attributes/attribute-list')
 
-    if not attribute_list:
+    if attribute_list is None:
         return
 
     authentication_attr_exists = False

--- a/connector-packager/pytest.ini
+++ b/connector-packager/pytest.ini
@@ -1,0 +1,14 @@
+[pytest]
+# Pytest configuration for connector-packager tests
+
+# Test discovery
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+
+# Output options
+addopts =
+    -v
+    --tb=short
+    --strict-markers

--- a/connector-packager/setup.py
+++ b/connector-packager/setup.py
@@ -14,9 +14,10 @@ setup(
     packages=['connector_packager'],
     license='MIT',
     description='A Python module for packaging a Tableau connector.',
-    test_suite='tests',
     python_requires='>3.7',
     install_requires=['xmlschema', 'defusedxml', 'packaging'],
-    tests_require=['six'],
+    extras_require={
+        'dev': ['pytest>=7.0.0'],
+    },
     include_package_data=True
 )

--- a/connector-packager/tests/manifest.py
+++ b/connector-packager/tests/manifest.py
@@ -5,7 +5,7 @@ Module for JAR manifest.
 import os
 
 from collections import OrderedDict
-from six import BytesIO
+from io import BytesIO
 from connector_packager.version import __version__
 
 


### PR DESCRIPTION
Running unittests via "setup.py test" has been deprecated for a while and finally stopped working, breaking our automated tests. Using pytest instead, updating the workflows to match. Confirmed that the tests pass using pytest, and confirmed that if the assertion is reversed the test fails, so the tests are being run and not simply all returning true.

Also fixed one other deprecation warning, about using "not" to check if an ElementTree object does not exist. Those tests still pass.