### PR TITLE
Document CAP_EXTRACT_ONLY_FEDERATED capability

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -293,6 +293,7 @@ CAP_CONNECT_NO_CUSTOM_SQL | Set to 'yes' to disable the custom sql option. | &nd
 CAP_EQUALITY_JOINS_ONLY | Set to 'yes' to restrict connector to only allow equality joins. Available in Tableau 2022.1 and newer. | &ndash; | &ndash;
 CAP_ESCAPE_UNDERSCORE_IN_NAMES | Set to ‘yes’ to escape underscores for search-based enumerations of catalog/schema/table names. | &ndash; | &ndash;
 CAP_EXTRACT_ONLY | Set to 'yes' to perform queries on extracted data only. | &ndash; | &ndash;
+CAP_EXTRACT_ONLY_FEDERATED | Set to 'yes' to enable extracted data to be joined with other data sources (i.e. cross-database joins). | &ndash; | &ndash;
 CAP_EXTRACT_ONLY_REFRESH  | Set to 'yes' to enable extracted data to be refreshed. | &ndash; | &ndash;
 CAP_FORCE_CONNECTION_VERIFICATION | Set to 'yes' to verify connection status during initial connection by running a probe query. Available in Tableau 2022.2 and newer. | &ndash; | &ndash;
 CAP_FORCE_COUNT_FOR_NUMBEROFRECORDS | Set to 'yes' to force these alternatives for calculating number of records: <br>1. COUNT(1) rather than SUM(1) <br>2. COUNT(const) * const rather than SUM(const) <br>Available in Tableau 2020.2 and newer. | &ndash; | &ndash;

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -293,7 +293,7 @@ CAP_CONNECT_NO_CUSTOM_SQL | Set to 'yes' to disable the custom sql option. | &nd
 CAP_EQUALITY_JOINS_ONLY | Set to 'yes' to restrict connector to only allow equality joins. Available in Tableau 2022.1 and newer. | &ndash; | &ndash;
 CAP_ESCAPE_UNDERSCORE_IN_NAMES | Set to ‘yes’ to escape underscores for search-based enumerations of catalog/schema/table names. | &ndash; | &ndash;
 CAP_EXTRACT_ONLY | Set to 'yes' to perform queries on extracted data only. | &ndash; | &ndash;
-CAP_EXTRACT_ONLY_FEDERATED | Set to 'yes' to enable extracted data to be joined with other data sources (i.e. cross-database joins). | &ndash; | &ndash;
+CAP_EXTRACT_ONLY_FEDERATED | Set to 'yes' to enable extracted data to be joined with other data sources (i.e. cross-database joins). Available in Tableau 2023.2 and newer. | &ndash; | &ndash;
 CAP_EXTRACT_ONLY_REFRESH  | Set to 'yes' to enable extracted data to be refreshed. | &ndash; | &ndash;
 CAP_FORCE_CONNECTION_VERIFICATION | Set to 'yes' to verify connection status during initial connection by running a probe query. Available in Tableau 2022.2 and newer. | &ndash; | &ndash;
 CAP_FORCE_COUNT_FOR_NUMBEROFRECORDS | Set to 'yes' to force these alternatives for calculating number of records: <br>1. COUNT(1) rather than SUM(1) <br>2. COUNT(const) * const rather than SUM(const) <br>Available in Tableau 2020.2 and newer. | &ndash; | &ndash;


### PR DESCRIPTION
## Summary
- Add documentation for CAP_EXTRACT_ONLY_FEDERATED capability in the Uncommon section
- This capability enables extracted data to be joined with other data sources (cross-database joins)

## Test plan
- [x] Verify the capability is documented in the correct section
- [x] Confirm formatting matches existing entries
- [x] Check that no default or recommended values are specified

🤖 Generated with [Claude Code](https://claude.com/claude-code)