### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,31 +4,7 @@
 
 This project consists of documentation, example files, the Tableau Datasource Verification Tool (TDVT) test harness, and a packaging tool that you can use to build and customize a Tableau Connector that uses an ODBC or JDBC driver.
 
-The latest version of the SDK is always targeted towards the latest, non-beta version of Tableau. Right now, this is **Tableau Desktop/Server 2024.2**. This means that the samples may not work on older versions of Tableau, and connectors packaged with newer versions of the SDK may not work in older versions of Tableau. You can download past releases of the SDK to work with older versions of Tableau if necessary.
-
-| Tool                                             | Latest Version      |
-|--------------------------------------------------|---------------------|
-| Connector SDK for Tableau 2024.1                 | 07-03-2024          |
-| Connector SDK for Tableau 2023.3                 | 03-26-2024          |
-| Connector SDK for Tableau 2023.2                 | 11-06-2023          |
-| Connector SDK for Tableau 2023.1                 | 06-15-2023          |
-| Connector SDK for Tableau 2022.4                 | 03-15-2023          |
-| Connector SDK for Tableau 2022.3                 | 12-14-2022          |
-| Connector SDK for Tableau 2022.2                 | 10-18-2022          |
-| Connector SDK for Tableau 2022.1                 | 06-29-2022          |
-| Connector SDK for Tableau 2021.4                 | 03-31-2022          |
-| Connector SDK for Tableau 2021.3                 | 12-15-2021          |
-| Connector SDK for Tableau 2021.2                 | 09-09-2021          |
-| Connector SDK for Tableau 2021.1                 | 07-14-2021          |
-| Connector SDK for Tableau 2020.4                 | 03-29-2021          |
-| Connector SDK for Tableau 2020.3                 | 12-07-2020          |
-| Connector SDK for Tableau 2020.2                 | 8-12-2020           |
-| Connector SDK for Tableau 2020.1                 | 5-08-2020           |
-| Connector SDK for Tableau 2019.4                 | 3-13-2020           |
-| Connector Packager SDK (Beta) for Tableau 2019.3 | 12-11-2019          |
-| TDVT                                             | 2.7.0 (10-28-2022)  |
-|                                                  | 1.5.24 (04-13-2020) |
-| Connector Packager                               | 2.1.0 (05-08-2020)  |
+The latest version of the SDK is always targeted towards the latest, non-beta version of Tableau. 
 
 * [Why Connectors?](#why-connectors)
 * [Get started](#get-started)


### PR DESCRIPTION
When the SDK was first released in beta, we tagged SDK releases to correspond to Tableau mainline releases as the SDK was still in flux. We no longer tag individual releases of the SDK to coincide with mainline releases of Tableau, because the SDK is stable enough that backwards compatibility is rarely a worry. The packager will flag if your connector is using a new feature not available in certain older versions of Tableau, so rolling back to an older version of the SDK should not be an issue.